### PR TITLE
Fix broken markdown links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Check out [Stephen Goldbaum's Morphir Examples on GitHub](https://github.com/ste
 
 # Further reading
 
-| Introduction & Background                                                  | Using Morphir                                                                                                 | Applicability                                                                           |
-| :------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------- |
-| [Resource Centre](https://resources.finos.org/morphir/)                    | [What Makes a Good Model](./docs/what-makes-a-good-domain-model.md)                                           | [Sharing Business Logic Across Application Boundaries](./docs/shared_logic_modeling.md) |
-| [Background](./docs/background.md)                                         | [Development Automation (Dev Bots)](./docs/dev_bots.md)                                                       | [Regulatory Technology](./docs/regtech_modeling.md)                                     |
-| [Community](./docs/morphir_community.md)                                   | [Modeling an Application](./docs/application_modeling.md)                                                     |                                                                                         |
-| [What's it all about?](./docs/whats_it_about.md)                           | [Modeling Decision Tables](https://github.com/finos/morphir-examples/tree/master/src/Morphir/Sample/Rules.md) |                                                                                         |
-| [Why we use Functional Programming?](./docs/why_functional_programming.md) | [Modeling for database developers](./docs/modeling/modeling-for-database-developers.md)                       |
+| Introduction & Background                                                  | Using Morphir                                                                                              | Applicability                                                                           |
+| :------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
+| [Resource Centre](https://resources.finos.org/morphir/)                    | [What Makes a Good Model](./docs/what-makes-a-good-domain-model.md)                                        | [Sharing Business Logic Across Application Boundaries](./docs/shared_logic_modeling.md) |
+| [Background](./docs/background.md)                                         | [Development Automation (Dev Bots)](./docs/dev_bots.md)                                                    | [Regulatory Technology](./docs/regtech_modeling.md)                                     |
+| [Community](./docs/morphir_community.md)                                   | [Modeling an Application](./docs/application_modeling.md)                                                  |                                                                                         |
+| [What's it all about?](./docs/whats_it_about.md)                           | [Modeling Decision Tables](https://github.com/finos/morphir-examples/tree/master/src/Morphir/Sample/Rules) |                                                                                         |
+| [Why we use Functional Programming?](./docs/why_functional_programming.md) | [Modeling for database developers](./docs/modeling/modeling-for-database-developers.md)                    |
 
 # Development setup
 

--- a/README.md
+++ b/README.md
@@ -52,15 +52,14 @@ Supporting the development of your business' needs in an ever-developing ecosyst
 Check out [Stephen Goldbaum's Morphir Examples on GitHub](https://github.com/stephengoldbaum/morphir-examples/tree/master/tutorial)
 
 # Further reading
-| Introduction & Background                                                 | Using Morphir                                                                                              | Applicability                                                                        |
-| :------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------- |
-| [Resource Centre](https://resources.finos.org/morphir/)                             | [What Makes a Good Model](./docs/what-makes-a-good-domain-model)                                           | [Sharing Business Logic Across Application Boundaries](./docs/shared_logic_modeling) |
-| [Background](./docs/background)                                           | [Development Automation (Dev Bots)](./docs/dev_bots)                                                       | [Regulatory Technology](./docs/regtech_modeling)                                     |
-| [Community](./docs/morphir_community)                                     | [Modeling an Application](./docs/application_modeling)                                                     |                                                                                      |
-| [What's it all about?](./docs/whats_it_about)                             | [Modeling Decision Tables](https://github.com/finos/morphir-examples/tree/master/src/Morphir/Sample/Rules) |                                                                                      |
-| [Working Across Technologies](./docs/work_across_languages_and_platforms) | [Modeling for database developers](./docs/modeling/modeling-for-database-developers.md)                    |                                                                                      |
-| [Why we use Functional Programming?](./docs/why_functional_programming)   |                                                                                                            |                                                                                      |
 
+| Introduction & Background                                                  | Using Morphir                                                                                                 | Applicability                                                                           |
+| :------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------- |
+| [Resource Centre](https://resources.finos.org/morphir/)                    | [What Makes a Good Model](./docs/what-makes-a-good-domain-model.md)                                           | [Sharing Business Logic Across Application Boundaries](./docs/shared_logic_modeling.md) |
+| [Background](./docs/background.md)                                         | [Development Automation (Dev Bots)](./docs/dev_bots.md)                                                       | [Regulatory Technology](./docs/regtech_modeling.md)                                     |
+| [Community](./docs/morphir_community.md)                                   | [Modeling an Application](./docs/application_modeling.md)                                                     |                                                                                         |
+| [What's it all about?](./docs/whats_it_about.md)                           | [Modeling Decision Tables](https://github.com/finos/morphir-examples/tree/master/src/Morphir/Sample/Rules.md) |                                                                                         |
+| [Why we use Functional Programming?](./docs/why_functional_programming.md) | [Modeling for database developers](./docs/modeling/modeling-for-database-developers.md)                       |
 
 # Development setup
 


### PR DESCRIPTION
## Description

This pull request fixes the following `markdown` links in `README.md` that are currently resolving to `404`.

- `[What Makes a Good Model](./docs/what-makes-a-good-domain-model.md)`
- `[Sharing Business Logic Across Application Boundaries](./docs/shared_logic_modeling.md)`
- `[Background](./docs/background.md)`
- `[Development Automation (Dev Bots)](./docs/dev_bots.md)`
- `[Regulatory Technology](./docs/regtech_modeling.md)`
- `[Community](./docs/morphir_community.md)`
- `[Modeling an Application](./docs/application_modeling.md)`
- `[What's it all about?](./docs/whats_it_about.md)`
- `[Why we use Functional Programming?](./docs/why_functional_programming.md)`
- `[Modeling for database developers](./docs/modeling/modeling-for-database-developers.md)`        

## Removal of link    
The following link has been removed from `README.md` as the page does not exist in the Morphir `docs` folder.

```
[Working Across Technologies](./docs/work_across_languages_and_platforms)
```

GitHub Issue #86 has been raised to address the broken link across the Morphir repo.