### PR TITLE
Fix Morphir README LCR Example Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Morphir is a collection of tools. Each tool is in its own repo with its own inst
 
 Morphir tools can be used to optimize a wide range of development tasks. For example, Morphir can be used to define and automated development of an entire service. The [Morphir Dapr](https://github.com/finos/morphir-dapr) project is example of this.
 
-Another good use of Morphir is to define shared rules than can be used across heterogeneous systems. This can be useful for initiatives like open-source Reg Tech models that are shared across firms. [Morphir LCR](https://github.com/finos/morphir-examples/tree/master/src/Morphir/Sample/LCR) presents a good example of this.
+Another good use of Morphir is to define shared rules than can be used across heterogeneous systems. This can be useful for initiatives like open-source Reg Tech models that are shared across firms. [Morphir LCR](https://github.com/finos/morphir-examples/tree/main/tests/Morphir/Sample/Reg/LCR) presents a good example of this.
 
 More Morphir examples can be found at [Morphir Examples](https://github.com/finos/morphir-examples/).
 


### PR DESCRIPTION
## Description

This pull request fixes the Morphir `LCR` example link on the Morphir project `README.md`

Please note, this is related to GitHub Issue #64

## From
```
[Morphir LCR](https://github.com/finos/morphir-examples/tree/master/src/Morphir/Sample/LCR)
```

## To
```
[Morphir LCR](https://github.com/finos/morphir-examples/tree/main/tests/Morphir/Sample/Reg/LCR)
```