### PR TITLE
Fix broken markdown headers

### DIFF
--- a/docs/morphir-typescript-api.md
+++ b/docs/morphir-typescript-api.md
@@ -3,7 +3,7 @@ id: morphir-typescript
 title: TypeScript - Morphir API
 ---
 
-#Morphir API for Typescript 
+# Morphir API for Typescript 
 The purpose of this documentation is to give a user an understanding of how to use the Morphir API created for Typescript.
 
 This API basically enables adding morphir as a dependency in a Typescript project. This allows a user have access to morphir 
@@ -11,7 +11,7 @@ types and modules to build tools and/or to aid work on the morphir generated IR.
 where the API provides modules in Morphir, mapping them to those in Cadl, in order to generate a Morphir IR as the Cadl emitter runs through
 a Cadl project.
 
-###How the Morphir API for Typescript is used.
+### How the Morphir API for Typescript is used.
 To use the modules/Types from the morphir api, they'd need to be imported from `morphir-elm`, as shown below in an **example:**
 ```
 import {toDistribution, Morphir} from "morphir-elm"


### PR DESCRIPTION
## Description 

It's been noticed that the `H1` and `H3` markdown tags on https://morphir.finos.org/docs/morphir-typescript are broken.  

This pull request fixes the headers in the markdown that will also fix the microsite the next time it's built and released.

## Screenshot of Broken Headers
<img width="960" alt="Screenshot 2023-08-16 at 10 45 07" src="https://github.com/finos/morphir/assets/6029572/dcb1e00a-606c-46f2-87bb-a7ca0ca08b5f">
