### PR TITLE
Adding link to LCR Interactive on website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -54,6 +54,11 @@ const config = {
             label: 'GitHub',
             position: 'right',
           },
+          {
+            href: "https://lcr-interactive.finos.org/",
+            label: "LCR Interactive",
+            position: "right",
+          }
         ],
       },
       footer: {


### PR DESCRIPTION
Wondering if `LCR Interactive` is the right label for the link.