### PR TITLE
add google analytics docusaurus plugin

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -28,6 +28,10 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: "G-C433HZ0SMC",
+          anonymizeIP: true,
+        }
       }),
     ],
   ],

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
 		"@cmfcmf/docusaurus-search-local": "^0.10.0",
 		"@docusaurus/core": "2.0.0-beta.15",
 		"@docusaurus/preset-classic": "2.0.0-beta.15",
+		"@docusaurus/plugin-google-gtag": "^2.0.0",
 		"@mdx-js/react": "^1.6.21",
 		"clsx": "^1.1.1",
 		"prism-react-renderer": "^1.2.1",


### PR DESCRIPTION
FINOS marketing team would like to add Google Analytics to morphir.finos.org