### PR TITLE
fix: resolve goreleaser hook permission issues

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
   hooks:
     # Safeguard: Remove any replace directives that may have been accidentally committed
     # This ensures go install compatibility
-    - ./scripts/remove-replace-directives.sh
+    - bash ./scripts/remove-replace-directives.sh
     # Ensure all modules have their dependencies in order
     - go mod tidy -C cmd/morphir
     - go mod tidy -C pkg/models


### PR DESCRIPTION
## Summary
Fix GoReleaser hook execution by adding bash prefix

The `remove-replace-directives.sh` script was failing in GitHub Actions with permission denied errors during the v0.3.0 release. Using `bash` prefix explicitly resolves this issue.

## Changes
- Modified [.goreleaser.yaml](.goreleaser.yaml) to use `bash ./scripts/remove-replace-directives.sh` instead of `./scripts/remove-replace-directives.sh`

## Test Plan
- [x] Verified fix resolves permission issue in GoReleaser hooks
- [ ] Will trigger v0.3.0 release after merge

## Related
- Fixes failed release workflow for v0.3.0