### PR TITLE
fix: handle existing tags in manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set tag for manual dispatch
         if: github.event_name == 'workflow_dispatch'
         run: |
-          git tag ${{ github.event.inputs.tag }}
+          git tag -f ${{ github.event.inputs.tag }}
           echo "GORELEASER_CURRENT_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
 
       - name: Run GoReleaser


### PR DESCRIPTION
## Problem

When manually triggering the release workflow for an existing tag (e.g., after retrying a failed release), the workflow fails with:

```
fatal: tag 'v0.3.0' already exists
##[error]Process completed with exit code 128.
```

This happens because the workflow tries to create the tag but it already exists.

## Solution

Use `git tag -f` instead of `git tag` to force-create the tag, allowing it to work with both new and existing tags.

## Testing

After this fix, manually triggering the release workflow with an existing tag should:
1. Re-create the tag locally (pointing to current checkout)
2. Set GORELEASER_CURRENT_TAG environment variable
3. Proceed with GoReleaser build

This enables retrying failed releases without manual tag cleanup.