### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-01-05
+
+### Fixed
+- Complete module version references for all internal dependencies
+  - Updated pkg/tooling/go.mod to reference v0.3.0 for pkg/config and pkg/models
+  - Updated tests/bdd/go.mod to reference v0.3.0 for pkg/models
+  - Fixed release workflow to handle existing tags with `-f` flag
+- Release workflow now supports manual re-triggering for failed releases
+
 ## [0.3.0] - 2026-01-04
 
 ### Added
@@ -105,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Duplicate help command registration in CLI
 
-[Unreleased]: https://github.com/finos/morphir/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/finos/morphir/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/finos/morphir/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/finos/morphir/compare/v0.2.1...v0.3.0
 [0.1.0]: https://github.com/finos/morphir/releases/tag/v0.1.0

--- a/cmd/morphir/go.mod
+++ b/cmd/morphir/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/finos/morphir/pkg/config v0.3.0
-	github.com/finos/morphir/pkg/tooling v0.3.0
+	github.com/finos/morphir/pkg/config v0.3.1
+	github.com/finos/morphir/pkg/tooling v0.3.1
 	github.com/spf13/cobra v1.10.2
 )
 
@@ -25,7 +25,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/finos/morphir/pkg/models v0.3.0 // indirect
+	github.com/finos/morphir/pkg/models v0.3.1 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect

--- a/pkg/tooling/go.mod
+++ b/pkg/tooling/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/charmbracelet/glamour v0.10.0
-	github.com/finos/morphir/pkg/config v0.0.0
-	github.com/finos/morphir/pkg/models v0.0.0
+	github.com/finos/morphir/pkg/config v0.3.1
+	github.com/finos/morphir/pkg/models v0.3.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	sigs.k8s.io/yaml v1.4.0

--- a/tests/bdd/go.mod
+++ b/tests/bdd/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1
 	github.com/cucumber/godog v0.15.0
-	github.com/finos/morphir/pkg/models v0.0.0
+	github.com/finos/morphir/pkg/models v0.3.1
 	github.com/pelletier/go-toml/v2 v2.2.4
 	gopkg.in/yaml.v3 v3.0.1
 )


### PR DESCRIPTION
## Summary

This PR prepares the v0.3.1 release, which completes the module version fixes that were partially addressed in v0.3.0.

## Changes

### Module Version Updates
- **pkg/tooling/go.mod**: Updated to reference v0.3.1 for pkg/config and pkg/models (was v0.0.0)
- **tests/bdd/go.mod**: Updated to reference v0.3.1 for pkg/models (was v0.0.0)
- **cmd/morphir/go.mod**: Updated to reference v0.3.1 for all internal modules

### CHANGELOG
- Added v0.3.1 section documenting these fixes
- Updated comparison links

## Why v0.3.1?

During the v0.3.0 release, we discovered that not all go.mod files had their internal module version references updated from v0.0.0 to v0.3.0. This caused GoReleaser to fail when it removed replace directives during the build process.

Rather than continuing to retag v0.3.0 (which has issues with workflow triggers on re-pushed tags), we're releasing this as v0.3.1 to cleanly resolve the issue.

## Testing

Pre-flight checks will be run before tagging:
- [ ] All modules build (`just verify`)
- [ ] All tests pass (`just test`)
- [ ] GoReleaser snapshot build succeeds (`just release-snapshot`)
- [ ] Replace directive removal works correctly

## Post-Merge Steps

After merging:
1. Update main locally
2. Create v0.3.1 tags with `./scripts/release-prep.sh v0.3.1`
3. Push tags to trigger release workflow
4. Monitor workflow execution
5. Verify module availability via `go install`