### PR TITLE
chore(husky): block go.work commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,16 @@
 # This can happen when using git worktrees where .beads becomes a symlink
 # to the main worktree's .beads directory
 
+# Prevent committing go.work (local dev only)
+if git diff --cached --name-only | grep -q "^go.work$"; then
+    echo "ERROR: go.work should not be committed."
+    echo ""
+    echo "Remove it from the index with:"
+    echo "  git reset HEAD go.work"
+    echo ""
+    exit 1
+fi
+
 # Check if .beads is staged for commit
 if git diff --cached --name-only | grep -q "^\.beads$"; then
     # Check if the staged .beads is a symlink (mode 120000)


### PR DESCRIPTION
## Summary
- add Husky pre-commit check to prevent committing go.work

## Testing
- pre-push hook (format/lint/vet/tests)
