### PR TITLE
feat(vfs): add VPath helper methods for path manipulation

### DIFF
--- a/pkg/vfs/path.go
+++ b/pkg/vfs/path.go
@@ -87,3 +87,204 @@ func (p VPath) Join(parts ...string) (VPath, error) {
 
 	return ParseVPath(raw)
 }
+
+// IsAbs returns true if the path is absolute (starts with /).
+func (p VPath) IsAbs() bool {
+	return strings.HasPrefix(p.value, "/")
+}
+
+// Base returns the last element of the path.
+// For "/a/b/c", it returns "c".
+// For "/a", it returns "a".
+// For "/", it returns "/".
+// For "a/b", it returns "b".
+func (p VPath) Base() string {
+	if p.value == "/" {
+		return "/"
+	}
+	idx := strings.LastIndex(p.value, "/")
+	if idx == -1 {
+		return p.value
+	}
+	return p.value[idx+1:]
+}
+
+// Dir returns the directory portion of the path.
+// For "/a/b/c", it returns "/a/b".
+// For "/a", it returns "/".
+// For "/", it returns "/".
+// For "a/b", it returns "a".
+// For "a", it returns ".".
+func (p VPath) Dir() VPath {
+	if p.value == "/" {
+		return p
+	}
+	idx := strings.LastIndex(p.value, "/")
+	if idx == -1 {
+		// Relative path with single component
+		return VPath{value: "."}
+	}
+	if idx == 0 {
+		// Absolute path with single component like "/a"
+		return VPath{value: "/"}
+	}
+	return VPath{value: p.value[:idx]}
+}
+
+// Ext returns the file extension including the dot.
+// For "/a/b/file.txt", it returns ".txt".
+// For "/a/b/file.tar.gz", it returns ".gz".
+// For "/a/b/file", it returns "".
+// For "/a/b/.dotfile", it returns "".
+func (p VPath) Ext() string {
+	base := p.Base()
+	if base == "/" || base == "." {
+		return ""
+	}
+	// Don't treat leading dot as extension (e.g., .dotfile)
+	if strings.HasPrefix(base, ".") {
+		base = base[1:]
+	}
+	idx := strings.LastIndex(base, ".")
+	if idx == -1 {
+		return ""
+	}
+	return "." + base[idx+1:]
+}
+
+// Stem returns the base name without the extension.
+// For "/a/b/file.txt", it returns "file".
+// For "/a/b/file.tar.gz", it returns "file.tar".
+// For "/a/b/file", it returns "file".
+// For "/a/b/.dotfile", it returns ".dotfile".
+func (p VPath) Stem() string {
+	base := p.Base()
+	if base == "/" || base == "." {
+		return base
+	}
+	ext := p.Ext()
+	if ext == "" {
+		return base
+	}
+	return base[:len(base)-len(ext)]
+}
+
+// Rel computes a relative path from this path to the target.
+// Both paths must be either both absolute or both relative.
+// Returns an error if the paths have different roots or if computation is not possible.
+func (p VPath) Rel(target VPath) (VPath, error) {
+	if p.IsAbs() != target.IsAbs() {
+		return VPath{}, errors.New("vfs: cannot compute relative path between absolute and relative paths")
+	}
+
+	if p.value == target.value {
+		return VPath{value: "."}, nil
+	}
+
+	pSegments := splitPathString(p.value)
+	tSegments := splitPathString(target.value)
+
+	// Find common prefix
+	commonLen := 0
+	for i := 0; i < len(pSegments) && i < len(tSegments); i++ {
+		if pSegments[i] != tSegments[i] {
+			break
+		}
+		commonLen++
+	}
+
+	// Build relative path
+	var parts []string
+
+	// Add ".." for each remaining segment in source path
+	for i := commonLen; i < len(pSegments); i++ {
+		parts = append(parts, "..")
+	}
+
+	// Add remaining segments from target path
+	parts = append(parts, tSegments[commonLen:]...)
+
+	if len(parts) == 0 {
+		return VPath{value: "."}, nil
+	}
+
+	return VPath{value: strings.Join(parts, "/")}, nil
+}
+
+// CommonRoot finds the common parent path of a set of paths.
+// All paths must be either all absolute or all relative.
+// Returns an error if paths are mixed absolute/relative or if the slice is empty.
+// If there is no common root, returns the root path for absolute paths ("/")
+// or an error for relative paths.
+func CommonRoot(paths []VPath) (VPath, error) {
+	if len(paths) == 0 {
+		return VPath{}, errors.New("vfs: cannot find common root of empty path list")
+	}
+
+	if len(paths) == 1 {
+		return paths[0], nil
+	}
+
+	// Check that all paths have the same absolute/relative nature
+	isAbs := paths[0].IsAbs()
+	for i := 1; i < len(paths); i++ {
+		if paths[i].IsAbs() != isAbs {
+			return VPath{}, errors.New("vfs: cannot find common root of mixed absolute and relative paths")
+		}
+	}
+
+	// Split all paths into segments
+	allSegments := make([][]string, len(paths))
+	minLen := -1
+	for i, p := range paths {
+		allSegments[i] = splitPathString(p.value)
+		if minLen == -1 || len(allSegments[i]) < minLen {
+			minLen = len(allSegments[i])
+		}
+	}
+
+	// Find common prefix length
+	commonLen := 0
+	for i := 0; i < minLen; i++ {
+		segment := allSegments[0][i]
+		allMatch := true
+		for j := 1; j < len(allSegments); j++ {
+			if allSegments[j][i] != segment {
+				allMatch = false
+				break
+			}
+		}
+		if !allMatch {
+			break
+		}
+		commonLen++
+	}
+
+	// Build common root path
+	if commonLen == 0 {
+		if isAbs {
+			return VPath{value: "/"}, nil
+		}
+		return VPath{}, errors.New("vfs: no common root found for relative paths")
+	}
+
+	commonSegments := allSegments[0][:commonLen]
+	commonPath := strings.Join(commonSegments, "/")
+	if isAbs {
+		commonPath = "/" + commonPath
+	}
+
+	return VPath{value: commonPath}, nil
+}
+
+// splitPathString splits a path string into segments, handling absolute paths correctly.
+func splitPathString(path string) []string {
+	if path == "/" {
+		return []string{}
+	}
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return []string{}
+	}
+	return strings.Split(path, "/")
+}

--- a/pkg/vfs/path_bdd_test.go
+++ b/pkg/vfs/path_bdd_test.go
@@ -1,0 +1,531 @@
+package vfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// BDD-style tests for VPath helpers using scenario outlines
+
+func TestVPathBDD_PathParsing(t *testing.T) {
+	scenarios := []struct {
+		scenario string
+		given    string
+		when     string
+		then     string
+	}{
+		{
+			scenario: "Parsing absolute path with redundant separators",
+			given:    "/a//b///c",
+			when:     "parsed as VPath",
+			then:     "/a/b/c",
+		},
+		{
+			scenario: "Parsing path with current directory markers",
+			given:    "/a/./b/./c",
+			when:     "parsed as VPath",
+			then:     "/a/b/c",
+		},
+		{
+			scenario: "Parsing path with parent directory markers",
+			given:    "/a/b/../c",
+			when:     "parsed as VPath",
+			then:     "/a/c",
+		},
+		{
+			scenario: "Parsing relative path",
+			given:    "a/b/c",
+			when:     "parsed as VPath",
+			then:     "a/b/c",
+		},
+		{
+			scenario: "Parsing root path",
+			given:    "/",
+			when:     "parsed as VPath",
+			then:     "/",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.scenario, func(t *testing.T) {
+			// Given: a raw path string
+			raw := s.given
+
+			// When: parsed as VPath
+			path, err := ParseVPath(raw)
+			require.NoError(t, err)
+
+			// Then: should be normalized correctly
+			require.Equal(t, s.then, path.String())
+		})
+	}
+}
+
+func TestVPathBDD_PathManipulation(t *testing.T) {
+	scenarios := []struct {
+		scenario  string
+		givenPath string
+		operation string
+		args      []string
+		expected  string
+	}{
+		{
+			scenario:  "Joining paths",
+			givenPath: "/a/b",
+			operation: "join",
+			args:      []string{"c", "d"},
+			expected:  "/a/b/c/d",
+		},
+		{
+			scenario:  "Joining with parent directory",
+			givenPath: "/a/b/c",
+			operation: "join",
+			args:      []string{"..", "d"},
+			expected:  "/a/b/d",
+		},
+		{
+			scenario:  "Joining relative paths",
+			givenPath: "a/b",
+			operation: "join",
+			args:      []string{"c"},
+			expected:  "a/b/c",
+		},
+		{
+			scenario:  "Getting base of file path",
+			givenPath: "/workspace/src/main.go",
+			operation: "base",
+			expected:  "main.go",
+		},
+		{
+			scenario:  "Getting directory of file path",
+			givenPath: "/workspace/src/main.go",
+			operation: "dir",
+			expected:  "/workspace/src",
+		},
+		{
+			scenario:  "Getting extension",
+			givenPath: "/workspace/src/main.go",
+			operation: "ext",
+			expected:  ".go",
+		},
+		{
+			scenario:  "Getting stem",
+			givenPath: "/workspace/src/main.go",
+			operation: "stem",
+			expected:  "main",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.scenario, func(t *testing.T) {
+			// Given: a VPath
+			path := MustVPath(s.givenPath)
+
+			// When: performing operation
+			var result string
+			switch s.operation {
+			case "join":
+				joined, err := path.Join(s.args...)
+				require.NoError(t, err)
+				result = joined.String()
+			case "base":
+				result = path.Base()
+			case "dir":
+				result = path.Dir().String()
+			case "ext":
+				result = path.Ext()
+			case "stem":
+				result = path.Stem()
+			}
+
+			// Then: should produce expected result
+			require.Equal(t, s.expected, result)
+		})
+	}
+}
+
+func TestVPathBDD_FileExtensions(t *testing.T) {
+	scenarios := []struct {
+		scenario string
+		path     string
+		ext      string
+		stem     string
+	}{
+		{
+			scenario: "Simple file extension",
+			path:     "file.txt",
+			ext:      ".txt",
+			stem:     "file",
+		},
+		{
+			scenario: "Multiple extensions",
+			path:     "archive.tar.gz",
+			ext:      ".gz",
+			stem:     "archive.tar",
+		},
+		{
+			scenario: "No extension",
+			path:     "README",
+			ext:      "",
+			stem:     "README",
+		},
+		{
+			scenario: "Dotfile without extension",
+			path:     ".gitignore",
+			ext:      "",
+			stem:     ".gitignore",
+		},
+		{
+			scenario: "Dotfile with extension",
+			path:     ".config.json",
+			ext:      ".json",
+			stem:     ".config",
+		},
+		{
+			scenario: "Path with directory and file",
+			path:     "/workspace/src/main.go",
+			ext:      ".go",
+			stem:     "main",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.scenario, func(t *testing.T) {
+			// Given: a file path
+			path := MustVPath(s.path)
+
+			// When: extracting extension and stem
+			ext := path.Ext()
+			stem := path.Stem()
+
+			// Then: should match expected values
+			require.Equal(t, s.ext, ext, "extension should match")
+			require.Equal(t, s.stem, stem, "stem should match")
+		})
+	}
+}
+
+func TestVPathBDD_RelativePaths(t *testing.T) {
+	scenarios := []struct {
+		scenario string
+		from     string
+		to       string
+		expected string
+	}{
+		{
+			scenario: "Same path",
+			from:     "/workspace/src",
+			to:       "/workspace/src",
+			expected: ".",
+		},
+		{
+			scenario: "Navigating to sibling",
+			from:     "/workspace/src",
+			to:       "/workspace/test",
+			expected: "../test",
+		},
+		{
+			scenario: "Navigating to child",
+			from:     "/workspace",
+			to:       "/workspace/src/utils",
+			expected: "src/utils",
+		},
+		{
+			scenario: "Navigating to parent",
+			from:     "/workspace/src/utils",
+			to:       "/workspace/src",
+			expected: "..",
+		},
+		{
+			scenario: "Navigating to cousin",
+			from:     "/workspace/src/utils",
+			to:       "/workspace/test/helpers",
+			expected: "../../test/helpers",
+		},
+		{
+			scenario: "Complex navigation",
+			from:     "/a/b/c/d",
+			to:       "/a/e/f",
+			expected: "../../../e/f",
+		},
+		{
+			scenario: "Relative paths",
+			from:     "src/main",
+			to:       "src/utils",
+			expected: "../utils",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.scenario, func(t *testing.T) {
+			// Given: two paths
+			from := MustVPath(s.from)
+			to := MustVPath(s.to)
+
+			// When: computing relative path
+			rel, err := from.Rel(to)
+			require.NoError(t, err)
+
+			// Then: should produce expected relative path
+			require.Equal(t, s.expected, rel.String())
+		})
+	}
+}
+
+func TestVPathBDD_CommonRoots(t *testing.T) {
+	scenarios := []struct {
+		scenario string
+		paths    []string
+		expected string
+	}{
+		{
+			scenario: "Siblings share parent",
+			paths:    []string{"/workspace/src", "/workspace/test"},
+			expected: "/workspace",
+		},
+		{
+			scenario: "Deep hierarchy with common ancestor",
+			paths: []string{
+				"/workspace/src/main.go",
+				"/workspace/src/utils/helper.go",
+				"/workspace/test/main_test.go",
+			},
+			expected: "/workspace",
+		},
+		{
+			scenario: "Nested children share root",
+			paths: []string{
+				"/workspace/a/b/c",
+				"/workspace/a/d/e",
+				"/workspace/f",
+			},
+			expected: "/workspace",
+		},
+		{
+			scenario: "No common root except filesystem root",
+			paths:    []string{"/usr/bin", "/var/log", "/home/user"},
+			expected: "/",
+		},
+		{
+			scenario: "Identical paths",
+			paths:    []string{"/workspace/src", "/workspace/src"},
+			expected: "/workspace/src",
+		},
+		{
+			scenario: "Single path",
+			paths:    []string{"/workspace/src/main.go"},
+			expected: "/workspace/src/main.go",
+		},
+		{
+			scenario: "Relative paths with common prefix",
+			paths:    []string{"src/main.go", "src/utils/helper.go", "src/test/main_test.go"},
+			expected: "src",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.scenario, func(t *testing.T) {
+			// Given: multiple paths
+			paths := make([]VPath, len(s.paths))
+			for i, p := range s.paths {
+				paths[i] = MustVPath(p)
+			}
+
+			// When: finding common root
+			root, err := CommonRoot(paths)
+			require.NoError(t, err)
+
+			// Then: should find expected common root
+			require.Equal(t, s.expected, root.String())
+		})
+	}
+}
+
+func TestVPathBDD_EdgeCases(t *testing.T) {
+	scenarios := []struct {
+		scenario    string
+		description string
+		operation   func() error
+		shouldError bool
+		errorMsg    string
+	}{
+		{
+			scenario:    "Empty path rejected",
+			description: "Parsing empty string should fail",
+			operation: func() error {
+				_, err := ParseVPath("")
+				return err
+			},
+			shouldError: true,
+			errorMsg:    "empty path",
+		},
+		{
+			scenario:    "Backslashes rejected",
+			description: "Backslashes are not allowed in VPath",
+			operation: func() error {
+				_, err := ParseVPath("a\\b")
+				return err
+			},
+			shouldError: true,
+			errorMsg:    "backslashes",
+		},
+		{
+			scenario:    "Path escaping root rejected",
+			description: "Cannot navigate above root",
+			operation: func() error {
+				_, err := ParseVPath("/../a")
+				return err
+			},
+			shouldError: true,
+			errorMsg:    "escapes root",
+		},
+		{
+			scenario:    "Mixed absolute and relative in Rel",
+			description: "Cannot compute relative path between absolute and relative",
+			operation: func() error {
+				from := MustVPath("/a/b")
+				to := MustVPath("c/d")
+				_, err := from.Rel(to)
+				return err
+			},
+			shouldError: true,
+			errorMsg:    "cannot compute relative path",
+		},
+		{
+			scenario:    "Empty path list in CommonRoot",
+			description: "Cannot find common root of empty list",
+			operation: func() error {
+				_, err := CommonRoot([]VPath{})
+				return err
+			},
+			shouldError: true,
+			errorMsg:    "empty path list",
+		},
+		{
+			scenario:    "Mixed paths in CommonRoot",
+			description: "Cannot find common root of mixed absolute/relative",
+			operation: func() error {
+				_, err := CommonRoot([]VPath{
+					MustVPath("/a/b"),
+					MustVPath("c/d"),
+				})
+				return err
+			},
+			shouldError: true,
+			errorMsg:    "mixed absolute and relative",
+		},
+		{
+			scenario:    "No common root for relative paths",
+			description: "Relative paths with no common prefix should error",
+			operation: func() error {
+				_, err := CommonRoot([]VPath{
+					MustVPath("a/b"),
+					MustVPath("c/d"),
+				})
+				return err
+			},
+			shouldError: true,
+			errorMsg:    "no common root found",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.scenario, func(t *testing.T) {
+			// When: performing operation
+			err := s.operation()
+
+			// Then: should match expected error behavior
+			if s.shouldError {
+				require.Error(t, err, s.description)
+				require.Contains(t, err.Error(), s.errorMsg)
+			} else {
+				require.NoError(t, err, s.description)
+			}
+		})
+	}
+}
+
+func TestVPathBDD_RealWorldScenarios(t *testing.T) {
+	scenarios := []struct {
+		scenario    string
+		description string
+		test        func(t *testing.T)
+	}{
+		{
+			scenario:    "Workspace navigation",
+			description: "Navigate between source and test directories",
+			test: func(t *testing.T) {
+				// Given: I am in the source directory
+				srcPath := MustVPath("/workspace/src")
+
+				// When: I navigate to a test file
+				testPath, err := srcPath.Join("..", "test", "main_test.go")
+				require.NoError(t, err)
+
+				// Then: I should be in the test directory
+				require.Equal(t, "/workspace/test/main_test.go", testPath.String())
+				require.Equal(t, "/workspace/test", testPath.Dir().String())
+			},
+		},
+		{
+			scenario:    "Build artifact path resolution",
+			description: "Resolve build artifacts with extensions",
+			test: func(t *testing.T) {
+				// Given: a source file path
+				srcFile := MustVPath("/workspace/src/main.go")
+
+				// When: determining output artifact
+				dir := srcFile.Dir()
+				stem := srcFile.Stem()
+				artifactPath, err := dir.Join("..", "bin", stem)
+				require.NoError(t, err)
+
+				// Then: artifact should be in bin directory without extension
+				require.Equal(t, "/workspace/bin/main", artifactPath.String())
+			},
+		},
+		{
+			scenario:    "Finding common project root",
+			description: "Find project root from multiple file paths",
+			test: func(t *testing.T) {
+				// Given: multiple files in a project
+				files := []VPath{
+					MustVPath("/project/src/app/main.go"),
+					MustVPath("/project/src/utils/helper.go"),
+					MustVPath("/project/test/integration/api_test.go"),
+					MustVPath("/project/README.md"),
+				}
+
+				// When: finding common root
+				root, err := CommonRoot(files)
+				require.NoError(t, err)
+
+				// Then: should identify project directory
+				require.Equal(t, "/project", root.String())
+			},
+		},
+		{
+			scenario:    "Relative import resolution",
+			description: "Resolve relative imports in source code",
+			test: func(t *testing.T) {
+				// Given: I am in a source file
+				currentFile := MustVPath("/workspace/src/app/handlers/user.go")
+
+				// When: I need to import from utils
+				utilsPath := MustVPath("/workspace/src/utils/validate.go")
+				rel, err := currentFile.Dir().Rel(utilsPath.Dir())
+				require.NoError(t, err)
+
+				// Then: relative path should be calculated correctly
+				require.Equal(t, "../../utils", rel.String())
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.scenario, func(t *testing.T) {
+			s.test(t)
+		})
+	}
+}

--- a/pkg/vfs/path_test.go
+++ b/pkg/vfs/path_test.go
@@ -65,3 +65,204 @@ func TestMustVPath(t *testing.T) {
 		_ = MustVPath("")
 	})
 }
+
+func TestVPathIsAbs(t *testing.T) {
+	require.True(t, MustVPath("/a/b").IsAbs())
+	require.True(t, MustVPath("/").IsAbs())
+	require.False(t, MustVPath("a/b").IsAbs())
+}
+
+func TestVPathBase(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/a/b/c", "c"},
+		{"/a", "a"},
+		{"/", "/"},
+		{"a/b", "b"},
+		{"a", "a"},
+		{"/file.txt", "file.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := MustVPath(tt.path).Base()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVPathDir(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/a/b/c", "/a/b"},
+		{"/a", "/"},
+		{"/", "/"},
+		{"a/b", "a"},
+		{"a", "."},
+		{"/workspace/src/main.go", "/workspace/src"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := MustVPath(tt.path).Dir()
+			require.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestVPathExt(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/a/b/file.txt", ".txt"},
+		{"/a/b/file.tar.gz", ".gz"},
+		{"/a/b/file", ""},
+		{"/a/b/.dotfile", ""},
+		{"/a/b/.dotfile.txt", ".txt"},
+		{"file.go", ".go"},
+		{"README", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := MustVPath(tt.path).Ext()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVPathStem(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/a/b/file.txt", "file"},
+		{"/a/b/file.tar.gz", "file.tar"},
+		{"/a/b/file", "file"},
+		{"/a/b/.dotfile", ".dotfile"},
+		{"/a/b/.dotfile.txt", ".dotfile"},
+		{"main.go", "main"},
+		{"README", "README"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := MustVPath(tt.path).Stem()
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestVPathRel(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   string
+		to     string
+		want   string
+		errMsg string
+	}{
+		{"same path", "/a/b", "/a/b", ".", ""},
+		{"sibling", "/a/b", "/a/c", "../c", ""},
+		{"child", "/a/b", "/a/b/c", "c", ""},
+		{"parent", "/a/b/c", "/a/b", "..", ""},
+		{"cousin", "/a/b/c", "/a/d/e", "../../d/e", ""},
+		{"deep nesting", "/a/b/c/d", "/a/e/f/g", "../../../e/f/g", ""},
+		{"relative paths", "a/b", "a/c", "../c", ""},
+		{"mixed abs/rel", "/a/b", "c/d", "", "cannot compute relative path"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from := MustVPath(tt.from)
+			to := MustVPath(tt.to)
+			got, err := from.Rel(to)
+
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got.String())
+			}
+		})
+	}
+}
+
+func TestCommonRoot(t *testing.T) {
+	tests := []struct {
+		name   string
+		paths  []string
+		want   string
+		errMsg string
+	}{
+		{
+			name:  "single path",
+			paths: []string{"/a/b/c"},
+			want:  "/a/b/c",
+		},
+		{
+			name:  "siblings",
+			paths: []string{"/a/b/c", "/a/b/d"},
+			want:  "/a/b",
+		},
+		{
+			name:  "deep common root",
+			paths: []string{"/workspace/src/main.go", "/workspace/src/utils/helper.go", "/workspace/test/main_test.go"},
+			want:  "/workspace",
+		},
+		{
+			name:  "no common root except /",
+			paths: []string{"/a/b", "/c/d"},
+			want:  "/",
+		},
+		{
+			name:  "relative paths with common root",
+			paths: []string{"a/b/c", "a/b/d", "a/e"},
+			want:  "a",
+		},
+		{
+			name:   "empty list",
+			paths:  []string{},
+			errMsg: "empty path list",
+		},
+		{
+			name:   "mixed absolute and relative",
+			paths:  []string{"/a/b", "c/d"},
+			errMsg: "mixed absolute and relative",
+		},
+		{
+			name:   "relative paths no common root",
+			paths:  []string{"a/b", "c/d"},
+			errMsg: "no common root found",
+		},
+		{
+			name:  "identical paths",
+			paths: []string{"/a/b/c", "/a/b/c", "/a/b/c"},
+			want:  "/a/b/c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := make([]VPath, len(tt.paths))
+			for i, p := range tt.paths {
+				paths[i] = MustVPath(p)
+			}
+
+			got, err := CommonRoot(paths)
+
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add comprehensive VPath helper methods to simplify path manipulation and normalization operations.

This PR addresses **morphir-gdf: Add VPath helper methods**.

## New VPath Methods

- **IsAbs()**: Check if path is absolute
- **Base()**: Get last path component (e.g., `/a/b/c` → `c`)
- **Dir()**: Get directory portion (e.g., `/a/b/c` → `/a/b`)
- **Ext()**: Get file extension (e.g., `file.txt` → `.txt`)
- **Stem()**: Get base name without extension (e.g., `file.txt` → `file`)
- **Rel(target)**: Compute relative path to target

## New Module-Level Functions

- **CommonRoot(paths)**: Find common parent path of multiple paths

## Key Features

- Proper handling of absolute vs relative paths
- Edge case handling (dotfiles, root paths, multiple extensions)
- Extension extraction with proper dotfile handling
- Relative path computation with validation
- Common root finding with error handling for mixed path types

## Test Coverage

All 91 VFS tests pass, including:

### Unit Tests (51 tests)
- IsAbs validation
- Base/Dir extraction
- Extension and stem handling
- Relative path computation
- Common root finding

### BDD-Style Tests (40+ scenarios)
- Path parsing with normalization
- Path manipulation (join, navigate)
- File extension handling
- Relative path navigation
- Common root identification
- Edge cases and error conditions
- Real-world scenarios:
  - Workspace navigation
  - Build artifact resolution
  - Project root detection
  - Relative import resolution

## Implementation Details

- Renamed internal `splitPath` helper to `splitPathString` to avoid conflict with existing function in `write_ops.go`
- All helpers follow Go standard library path semantics (similar to `path.Base`, `path.Dir`, etc.)
- Comprehensive error handling for invalid operations
- BDD tests use Given/When/Then structure for clarity

## Example Usage

```go
// Path components
path := vfs.MustVPath("/workspace/src/main.go")
path.Base()  // "main.go"
path.Dir()   // "/workspace/src"
path.Ext()   // ".go"
path.Stem()  // "main"

// Relative paths
from := vfs.MustVPath("/workspace/src")
to := vfs.MustVPath("/workspace/test")
rel, _ := from.Rel(to)  // "../test"

// Common root
paths := []vfs.VPath{
    vfs.MustVPath("/workspace/src/main.go"),
    vfs.MustVPath("/workspace/test/main_test.go"),
}
root, _ := vfs.CommonRoot(paths)  // "/workspace"
```

## Closes

Closes morphir-gdf