### PR TITLE
feat(pipeline): add validation step and refactor validate command

### DIFF
--- a/pkg/pipeline/validate.go
+++ b/pkg/pipeline/validate.go
@@ -1,0 +1,205 @@
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/finos/morphir/pkg/vfs"
+)
+
+// ValidateInput provides the input for the validation step.
+type ValidateInput struct {
+	// IRPath is the path to the Morphir IR file to validate.
+	IRPath vfs.VPath
+	// Version specifies which schema version to validate against.
+	// If 0, the version is auto-detected from the formatVersion field.
+	Version int
+}
+
+// ValidateOutput contains the result of the validation step.
+type ValidateOutput struct {
+	Valid   bool
+	Version int
+	Path    string
+	Errors  []string
+	RawData any
+}
+
+// NewValidateStep creates a pipeline step that validates Morphir IR.
+// The step reads the IR file from VFS, validates it against the JSON schema,
+// and emits diagnostics for any validation errors.
+func NewValidateStep() Step[ValidateInput, ValidateOutput] {
+	return NewStep[ValidateInput, ValidateOutput](
+		"validate",
+		"Validates Morphir IR against JSON schema",
+		func(ctx Context, in ValidateInput) (ValidateOutput, StepResult) {
+			var result StepResult
+			var output ValidateOutput
+
+			// Resolve the IR file from VFS
+			entry, _, err := ctx.VFS.Resolve(in.IRPath)
+			if err != nil {
+				result.Err = fmt.Errorf("failed to resolve IR path %s: %w", in.IRPath, err)
+				result.Diagnostics = []Diagnostic{{
+					Severity: SeverityError,
+					Code:     "VALIDATE_RESOLVE_ERROR",
+					Message:  result.Err.Error(),
+					StepName: "validate",
+				}}
+				return output, result
+			}
+
+			// Ensure it's a file
+			file, ok := entry.(vfs.File)
+			if !ok {
+				result.Err = fmt.Errorf("path %s is not a file", in.IRPath)
+				result.Diagnostics = []Diagnostic{{
+					Severity: SeverityError,
+					Code:     "VALIDATE_NOT_FILE",
+					Message:  result.Err.Error(),
+					StepName: "validate",
+				}}
+				return output, result
+			}
+
+			// Read file contents
+			data, err := file.Bytes()
+			if err != nil {
+				result.Err = fmt.Errorf("failed to read IR file: %w", err)
+				result.Diagnostics = []Diagnostic{{
+					Severity: SeverityError,
+					Code:     "VALIDATE_READ_ERROR",
+					Message:  result.Err.Error(),
+					StepName: "validate",
+				}}
+				return output, result
+			}
+
+			// Validate the IR using the internal validation logic
+			valResult, err := validateIRBytes(data, in.IRPath.String(), in.Version)
+			if err != nil {
+				result.Err = err
+				result.Diagnostics = []Diagnostic{{
+					Severity: SeverityError,
+					Code:     "VALIDATE_INTERNAL_ERROR",
+					Message:  err.Error(),
+					StepName: "validate",
+				}}
+				return output, result
+			}
+
+			output = ValidateOutput{
+				Valid:   valResult.Valid,
+				Version: valResult.Version,
+				Path:    valResult.Path,
+				Errors:  valResult.Errors,
+				RawData: valResult.RawData,
+			}
+
+			// Convert validation errors to diagnostics
+			if !valResult.Valid {
+				for _, errMsg := range valResult.Errors {
+					result.Diagnostics = append(result.Diagnostics, Diagnostic{
+						Severity: SeverityError,
+						Code:     "VALIDATE_SCHEMA_ERROR",
+						Message:  errMsg,
+						Location: &Location{Path: in.IRPath},
+						StepName: "validate",
+					})
+				}
+			}
+
+			// Generate report artifact
+			reportData, _ := json.MarshalIndent(map[string]any{
+				"valid":   output.Valid,
+				"version": output.Version,
+				"path":    output.Path,
+				"errors":  output.Errors,
+			}, "", "  ")
+
+			result.Artifacts = []Artifact{{
+				Kind:        ArtifactReport,
+				Path:        vfs.MustVPath("/.morphir/validation-report.json"),
+				ContentType: "application/json",
+				Content:     reportData,
+			}}
+
+			return output, result
+		},
+	)
+}
+
+// InternalValidationResult mirrors the validation.Result for internal use
+// to avoid circular dependencies. It is exported to allow injection of
+// custom validation functions from cmd/morphir.
+type InternalValidationResult struct {
+	Valid   bool
+	Version int
+	Path    string
+	Errors  []string
+	RawData any
+}
+
+// Alias for internal use (backwards compatibility)
+type internalValidationResult = InternalValidationResult
+
+// validateIRBytes is a placeholder that will call the actual validation logic.
+// This is implemented separately to allow for dependency injection in tests
+// and to break circular dependencies with pkg/tooling/validation.
+var validateIRBytes = defaultValidateIRBytes
+
+// defaultValidateIRBytes provides basic IR validation.
+// The actual implementation calls pkg/tooling/validation.ValidateBytes.
+func defaultValidateIRBytes(data []byte, sourcePath string, version int) (*internalValidationResult, error) {
+	// Detect version from IR if not specified
+	detectedVersion := version
+	if detectedVersion == 0 {
+		var partial struct {
+			FormatVersion int `json:"formatVersion"`
+		}
+		if err := json.Unmarshal(data, &partial); err != nil {
+			return &internalValidationResult{
+				Valid:  false,
+				Path:   sourcePath,
+				Errors: []string{fmt.Sprintf("failed to parse JSON: %v", err)},
+			}, nil
+		}
+		detectedVersion = partial.FormatVersion
+		if detectedVersion < 1 || detectedVersion > 3 {
+			return &internalValidationResult{
+				Valid:   false,
+				Version: detectedVersion,
+				Path:    sourcePath,
+				Errors:  []string{fmt.Sprintf("invalid formatVersion: %d (expected 1, 2, or 3)", detectedVersion)},
+			}, nil
+		}
+	}
+
+	// Parse the IR JSON
+	var irData any
+	if err := json.Unmarshal(data, &irData); err != nil {
+		return &internalValidationResult{
+			Valid:   false,
+			Version: detectedVersion,
+			Path:    sourcePath,
+			Errors:  []string{fmt.Sprintf("invalid JSON: %v", err)},
+		}, nil
+	}
+
+	// For now, return valid if JSON parses successfully
+	// The full schema validation is handled by cmd/morphir which has access to
+	// pkg/tooling/validation. This step provides the pipeline interface.
+	return &internalValidationResult{
+		Valid:   true,
+		Version: detectedVersion,
+		Path:    sourcePath,
+		RawData: irData,
+	}, nil
+}
+
+// SetValidateIRBytes allows setting a custom validation function.
+// This is useful for testing or for injecting the full validation logic
+// from pkg/tooling/validation.
+func SetValidateIRBytes(fn func(data []byte, sourcePath string, version int) (*internalValidationResult, error)) {
+	validateIRBytes = fn
+}

--- a/pkg/pipeline/validate_test.go
+++ b/pkg/pipeline/validate_test.go
@@ -1,0 +1,201 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/finos/morphir/pkg/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestVFS creates an in-memory VFS with the given file content at the given path.
+func createTestVFS(t *testing.T, filePath string, content []byte) vfs.VFS {
+	t.Helper()
+
+	// Create an empty root folder
+	root := vfs.NewMemFolder(vfs.MustVPath("/"), vfs.Meta{}, vfs.Origin{MountName: "workspace"}, nil)
+
+	// Create a mount with the root
+	mount := vfs.Mount{
+		Name: "workspace",
+		Mode: vfs.MountRW,
+		Root: root,
+	}
+
+	// Create overlay VFS
+	overlay := vfs.NewOverlayVFS([]vfs.Mount{mount})
+
+	// Get writer and create the file
+	writer, err := overlay.Writer()
+	require.NoError(t, err)
+
+	_, err = writer.CreateFile(vfs.MustVPath(filePath), content, vfs.WriteOptions{MkdirParents: true})
+	require.NoError(t, err)
+
+	return overlay
+}
+
+// createEmptyTestVFS creates an empty in-memory VFS.
+func createEmptyTestVFS() vfs.VFS {
+	root := vfs.NewMemFolder(vfs.MustVPath("/"), vfs.Meta{}, vfs.Origin{MountName: "workspace"}, nil)
+	mount := vfs.Mount{
+		Name: "workspace",
+		Mode: vfs.MountRW,
+		Root: root,
+	}
+	return vfs.NewOverlayVFS([]vfs.Mount{mount})
+}
+
+func TestValidateStepSuccess(t *testing.T) {
+	// Create in-memory VFS with valid IR
+	validIR := []byte(`{"formatVersion": 3, "distribution": []}`)
+	overlay := createTestVFS(t, "/morphir.ir.json", validIR)
+	ctx := NewContext("/workspace", 3, ModeDefault, overlay)
+
+	step := NewValidateStep()
+	input := ValidateInput{
+		IRPath:  vfs.MustVPath("/morphir.ir.json"),
+		Version: 0, // Auto-detect
+	}
+
+	output, result := step.Execute(ctx, input)
+
+	require.NoError(t, result.Err)
+	require.True(t, output.Valid)
+	require.Equal(t, 3, output.Version)
+	require.Empty(t, output.Errors)
+	require.Len(t, result.Artifacts, 1)
+	require.Equal(t, ArtifactReport, result.Artifacts[0].Kind)
+}
+
+func TestValidateStepInvalidJSON(t *testing.T) {
+	// Create in-memory VFS with invalid JSON
+	invalidJSON := []byte(`{invalid json`)
+	overlay := createTestVFS(t, "/morphir.ir.json", invalidJSON)
+	ctx := NewContext("/workspace", 3, ModeDefault, overlay)
+
+	step := NewValidateStep()
+	input := ValidateInput{
+		IRPath:  vfs.MustVPath("/morphir.ir.json"),
+		Version: 0,
+	}
+
+	output, result := step.Execute(ctx, input)
+
+	require.NoError(t, result.Err) // No error returned, but validation fails
+	require.False(t, output.Valid)
+	require.NotEmpty(t, output.Errors)
+	require.Len(t, result.Diagnostics, 1)
+	require.Equal(t, SeverityError, result.Diagnostics[0].Severity)
+}
+
+func TestValidateStepInvalidVersion(t *testing.T) {
+	// Create in-memory VFS with invalid format version
+	invalidVersion := []byte(`{"formatVersion": 99}`)
+	overlay := createTestVFS(t, "/morphir.ir.json", invalidVersion)
+	ctx := NewContext("/workspace", 3, ModeDefault, overlay)
+
+	step := NewValidateStep()
+	input := ValidateInput{
+		IRPath:  vfs.MustVPath("/morphir.ir.json"),
+		Version: 0,
+	}
+
+	output, result := step.Execute(ctx, input)
+
+	require.NoError(t, result.Err)
+	require.False(t, output.Valid)
+	require.Contains(t, output.Errors[0], "invalid formatVersion")
+}
+
+func TestValidateStepFileNotFound(t *testing.T) {
+	overlay := createEmptyTestVFS()
+	ctx := NewContext("/workspace", 3, ModeDefault, overlay)
+
+	step := NewValidateStep()
+	input := ValidateInput{
+		IRPath:  vfs.MustVPath("/nonexistent.json"),
+		Version: 0,
+	}
+
+	_, result := step.Execute(ctx, input)
+
+	require.Error(t, result.Err)
+	require.Contains(t, result.Err.Error(), "failed to resolve")
+	require.Len(t, result.Diagnostics, 1)
+	require.Equal(t, "VALIDATE_RESOLVE_ERROR", result.Diagnostics[0].Code)
+}
+
+func TestValidateStepWithPipeline(t *testing.T) {
+	// Test the validation step works correctly in a pipeline
+	validIR := []byte(`{"formatVersion": 3, "distribution": []}`)
+	overlay := createTestVFS(t, "/morphir.ir.json", validIR)
+	ctx := NewContext("/workspace", 3, ModeDefault, overlay)
+
+	validateStep := NewValidateStep()
+	pipeline := NewPipeline("validate-ir", "Validates Morphir IR", validateStep)
+
+	input := ValidateInput{
+		IRPath:  vfs.MustVPath("/morphir.ir.json"),
+		Version: 0,
+	}
+
+	output, pipelineResult, err := pipeline.Run(ctx, input)
+
+	require.NoError(t, err)
+	require.True(t, output.Valid)
+	require.Len(t, pipelineResult.Steps, 1)
+	require.Equal(t, "validate", pipelineResult.Steps[0].Name)
+	require.Len(t, pipelineResult.Artifacts, 1)
+}
+
+func TestValidateStepExplicitVersion(t *testing.T) {
+	// Test with explicit version specified
+	validIR := []byte(`{"formatVersion": 3, "distribution": []}`)
+	overlay := createTestVFS(t, "/morphir.ir.json", validIR)
+	ctx := NewContext("/workspace", 3, ModeDefault, overlay)
+
+	step := NewValidateStep()
+	input := ValidateInput{
+		IRPath:  vfs.MustVPath("/morphir.ir.json"),
+		Version: 3, // Explicit version
+	}
+
+	output, result := step.Execute(ctx, input)
+
+	require.NoError(t, result.Err)
+	require.True(t, output.Valid)
+	require.Equal(t, 3, output.Version)
+}
+
+func TestValidateStepCustomValidator(t *testing.T) {
+	// Test with custom validation function
+	originalFn := validateIRBytes
+	defer func() { validateIRBytes = originalFn }()
+
+	// Set custom validator that always fails
+	SetValidateIRBytes(func(data []byte, sourcePath string, version int) (*internalValidationResult, error) {
+		return &internalValidationResult{
+			Valid:   false,
+			Version: 3,
+			Path:    sourcePath,
+			Errors:  []string{"custom validation error"},
+		}, nil
+	})
+
+	validIR := []byte(`{"formatVersion": 3}`)
+	overlay := createTestVFS(t, "/morphir.ir.json", validIR)
+	ctx := NewContext("/workspace", 3, ModeDefault, overlay)
+
+	step := NewValidateStep()
+	input := ValidateInput{
+		IRPath:  vfs.MustVPath("/morphir.ir.json"),
+		Version: 0,
+	}
+
+	output, result := step.Execute(ctx, input)
+
+	require.NoError(t, result.Err)
+	require.False(t, output.Valid)
+	require.Contains(t, output.Errors[0], "custom validation error")
+	require.Len(t, result.Diagnostics, 1)
+}


### PR DESCRIPTION
## Summary

- Add `NewValidateStep()` validation pipeline step in `pkg/pipeline/validate.go`
- Add comprehensive tests for the validation step in `pkg/pipeline/validate_test.go`
- Refactor `morphir validate` command to use the pipeline runner

## Changes

### New Validation Pipeline Step
- `ValidateInput` and `ValidateOutput` types for pipeline I/O
- `NewValidateStep()` creates a step that validates Morphir IR against JSON schema
- Supports auto-detection of format version from IR files
- Supports explicit version specification via input
- Dependency injection via `SetValidateIRBytes()` for custom validation logic
- Generates diagnostics for validation errors
- Produces validation report artifact

### Refactored Validate Command
- Uses VFS-based file access with OS mount
- Creates and runs validation pipeline
- Injects real validation logic from `pkg/tooling/validation`
- Maintains backward compatibility with all output formats (text, JSON, markdown, TUI)

## Test plan

- [x] All existing pipeline tests pass
- [x] New validation step tests pass (7 test cases)
- [x] Manual testing with valid IR file
- [x] Manual testing with invalid IR file
- [x] JSON output mode works correctly
- [x] Full test suite passes

Fixes #395, #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)