### PR TITLE
chore(release): prepare v0.4.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-alpha.1] - 2026-01-08
+
+### Added
+- **WIT Pipeline** (CLI Preview): WebAssembly Interface Types support for Morphir
+  - `morphir wit make` command to compile WIT files to Morphir IR
+  - `morphir wit gen` command to generate WIT from Morphir IR
+  - `morphir wit build` command for full WIT→IR→WIT pipeline
+  - JSONL batch processing mode for streaming/CI workflows (`--jsonl` flag)
+  - Type mapping infrastructure with diagnostics for lossy transformations
+  - WIT parser adapter and emitter with round-trip support
+  - BDD tests with scenario outlines for comprehensive coverage
+- **Virtual File System (VFS)**: New `pkg/vfs` module for filesystem abstraction
+  - Core VFS implementation with virtual paths (`VPath`)
+  - Traversal helpers for entry tree manipulation
+  - Shadowing support for overlaying file systems
+  - Sandbox policy hooks for write operations
+  - Path manipulation helpers
+- **Task Execution Engine**: New `pkg/task` module for build orchestration
+  - Task/target execution with dependency tracking
+  - Pipeline integration for task configuration
+  - `morphir task list` command to display configured tasks
+- **Pipeline Enhancements**: Major improvements to `pkg/pipeline`
+  - Core pipeline types and composition framework
+  - Validation step with improved diagnostics
+  - Comprehensive unit tests for composition and error handling
+- **Document Processing**: New `pkg/docling-doc` module
+  - Functional document processing with efficient builder pattern
+  - BDD tests integrated into release process
+- **Jupyter Notebook Support**: New `pkg/nbformat` module
+  - Support for reading and processing `.ipynb` files
+- **IR Visitor Framework**: New visitor pattern for Morphir IR
+  - Type and Pattern traversal helpers
+  - Extensible visitor infrastructure
+- **Type Mapping Infrastructure**: New `pkg/bindings/typemap` module
+  - Registry for bidirectional type mappings
+  - Support for multiple binding targets (WIT, Protocol Buffers, etc.)
+
 ### Changed
 - Migrated task runner from Justfile to `mise` tasks across scripts, docs, and CI
+- Removed outdated morphir-elm subtree and related Elm code
+- Upgraded Docusaurus from 2.0.0-beta.15 to stable 2.4.3
+- Updated lipgloss dependency to v2
+
+### Documentation
+- Added CLI Preview documentation for v0.4.0-alpha.1
+- Improved code coverage documentation and module tracking
+- Added module and package documentation for `pkg/models`
+
+### Infrastructure
+- Comprehensive code coverage and test reporting in CI/CD
+- Node.js 24 configured for Docusaurus website builds
+- Updated GitHub Actions (checkout v6, artifact actions, create-issue-from-file v6)
+- Security dependency updates for website
 
 ## [0.3.3] - 2026-01-05
 
@@ -186,7 +237,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Duplicate help command registration in CLI
 
-[Unreleased]: https://github.com/finos/morphir/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/finos/morphir/compare/v0.4.0-alpha.1...HEAD
+[0.4.0-alpha.1]: https://github.com/finos/morphir/compare/v0.3.3...v0.4.0-alpha.1
+[0.3.3]: https://github.com/finos/morphir/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/finos/morphir/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/finos/morphir/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/finos/morphir/compare/v0.2.1...v0.3.0

--- a/scripts/release-prep.sh
+++ b/scripts/release-prep.sh
@@ -50,14 +50,19 @@ echo "Creating release tags for all modules..."
 echo ""
 
 # Tag all modules with subdirectory prefixes
+# NOTE: tests/bdd is excluded as it's not a publishable module
 MODULES=(
-    "pkg/bindings/wasm-componentmodel"
+    "pkg/bindings/typemap"
+    "pkg/bindings/wit"
     "pkg/config"
+    "pkg/docling-doc"
     "pkg/models"
     "pkg/nbformat"
     "pkg/pipeline"
     "pkg/sdk"
+    "pkg/task"
     "pkg/tooling"
+    "pkg/vfs"
     "cmd/morphir"
 )
 


### PR DESCRIPTION
## Summary

Prepare release v0.4.0-alpha.1 - the first alpha release featuring the WIT Pipeline and several new infrastructure modules.

### Changes
- Updated CHANGELOG.md with v0.4.0-alpha.1 release notes
- Updated scripts/release-prep.sh with new modules:
  - `pkg/bindings/typemap` - Type mapping registry
  - `pkg/bindings/wit` - WIT bindings module
  - `pkg/docling-doc` - Document processing
  - `pkg/task` - Task execution engine
  - `pkg/vfs` - Virtual file system
- Removed obsolete `pkg/bindings/wasm-componentmodel`

### Major Features in v0.4.0-alpha.1
- **WIT Pipeline** (CLI Preview): `morphir wit make|gen|build` commands with JSONL batch mode
- **Virtual File System**: Core VFS implementation with traversal helpers
- **Task Execution Engine**: Task/target execution with dependency tracking
- **Document Processing**: Functional document builder pattern
- **Jupyter Notebook Support**: `pkg/nbformat` module
- **IR Visitor Framework**: Type and Pattern traversal helpers
- **Type Mapping Infrastructure**: Bidirectional type mappings

### Release Process
After this PR is merged:
1. Remove replace directives from go.mod files
2. Run `scripts/release.sh v0.4.0-alpha.1`
3. Monitor release workflow

## Test plan
- [x] `mise run verify` - All modules build
- [x] CI checks pass
- [ ] Merge PR
- [ ] Execute release process