### PR TITLE
fix: update new module versions for v0.4.0-alpha.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,9 @@ jobs:
           git tag -f ${{ github.event.inputs.tag }}
           echo "GORELEASER_CURRENT_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
 
+      - name: Set up Go workspace
+        run: mise run setup-workspace
+
       - name: Run GoReleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,8 @@ before:
     # Ensure all modules have their dependencies in order
     # NOTE: Keep this list in sync with scripts/release-tags.sh MODULES array
     - go mod tidy -C cmd/morphir
+    - go mod tidy -C pkg/bindings/golang
+    - go mod tidy -C pkg/bindings/morphir-elm
     - go mod tidy -C pkg/bindings/typemap
     - go mod tidy -C pkg/bindings/wit
     - go mod tidy -C pkg/config
@@ -27,6 +29,7 @@ before:
     - go mod tidy -C pkg/pipeline
     - go mod tidy -C pkg/sdk
     - go mod tidy -C pkg/task
+    - go mod tidy -C pkg/toolchain
     - go mod tidy -C pkg/tooling
     - go mod tidy -C pkg/vfs
 


### PR DESCRIPTION
## Summary

Fix release workflow failure by updating go.mod to reference v0.4.0-alpha.2 for new modules.

### Problem
The release workflow failed because cmd/morphir/go.mod referenced `v0.4.0-alpha.1` for:
- `pkg/bindings/golang`  
- `pkg/toolchain`

These modules are **new** and have no prior published versions, so `v0.4.0-alpha.1` doesn't exist for them.

### Fix
Update go.mod to reference `v0.4.0-alpha.2` (the version being released). Since GoReleaser runs after tags are pushed, the tags will exist when Go tries to fetch them.

### After Merge
Need to:
1. Delete existing v0.4.0-alpha.2 tags
2. Recreate tags on the merged commit
3. Re-trigger release workflow