### PR TITLE
chore: release v0.4.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-alpha.3] - 2026-01-13
+
+### Added
+- **Structured Logging**: New `pkg/logging` module with zerolog wrapper (#549)
+  - Logger type with functional options pattern (`WithLevel`, `WithFormat`, `WithFile`)
+  - Multi-writer support for simultaneous stderr and file logging
+  - Configurable log levels (trace, debug, info, warn, error, fatal, disabled)
+  - Text format (colored, human-readable) and JSON format for log aggregation
+  - Log files written to `.morphir/logs/` directory
+  - `Noop()` logger for testing and disabled logging scenarios
+
+### Changed
+- Removed `-v` short flag from `--version` command (reserved for future `--verbose` flag)
+- Use `morphir --version` or `morphir version` for version information
+
+### Infrastructure
+- Migrated mise tasks to TypeScript/Python with pinned tool versions (#548)
+  - Tasks now use Bun for TypeScript execution
+  - Improved cross-platform compatibility
+  - Better error handling and output formatting
+
+### Fixed
+- Updated charmbracelet/lipgloss dependency to v2 (#546, #547)
+
 ## [0.4.0-alpha.2] - 2026-01-13
 
 ### Added
@@ -277,7 +301,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Duplicate help command registration in CLI
 
-[Unreleased]: https://github.com/finos/morphir/compare/v0.4.0-alpha.2...HEAD
+[Unreleased]: https://github.com/finos/morphir/compare/v0.4.0-alpha.3...HEAD
+[0.4.0-alpha.3]: https://github.com/finos/morphir/compare/v0.4.0-alpha.2...v0.4.0-alpha.3
 [0.4.0-alpha.2]: https://github.com/finos/morphir/compare/v0.4.0-alpha.1...v0.4.0-alpha.2
 [0.4.0-alpha.1]: https://github.com/finos/morphir/compare/v0.3.3...v0.4.0-alpha.1
 [0.3.3]: https://github.com/finos/morphir/compare/v0.3.2...v0.3.3

--- a/cmd/morphir/cmd/CHANGELOG.md
+++ b/cmd/morphir/cmd/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-alpha.3] - 2026-01-13
+
+### Added
+- **Structured Logging**: New `pkg/logging` module with zerolog wrapper (#549)
+  - Logger type with functional options pattern (`WithLevel`, `WithFormat`, `WithFile`)
+  - Multi-writer support for simultaneous stderr and file logging
+  - Configurable log levels (trace, debug, info, warn, error, fatal, disabled)
+  - Text format (colored, human-readable) and JSON format for log aggregation
+  - Log files written to `.morphir/logs/` directory
+  - `Noop()` logger for testing and disabled logging scenarios
+
+### Changed
+- Removed `-v` short flag from `--version` command (reserved for future `--verbose` flag)
+- Use `morphir --version` or `morphir version` for version information
+
+### Infrastructure
+- Migrated mise tasks to TypeScript/Python with pinned tool versions (#548)
+  - Tasks now use Bun for TypeScript execution
+  - Improved cross-platform compatibility
+  - Better error handling and output formatting
+
+### Fixed
+- Updated charmbracelet/lipgloss dependency to v2 (#546, #547)
+
 ## [0.4.0-alpha.2] - 2026-01-13
 
 ### Added
@@ -277,7 +301,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Duplicate help command registration in CLI
 
-[Unreleased]: https://github.com/finos/morphir/compare/v0.4.0-alpha.2...HEAD
+[Unreleased]: https://github.com/finos/morphir/compare/v0.4.0-alpha.3...HEAD
+[0.4.0-alpha.3]: https://github.com/finos/morphir/compare/v0.4.0-alpha.2...v0.4.0-alpha.3
 [0.4.0-alpha.2]: https://github.com/finos/morphir/compare/v0.4.0-alpha.1...v0.4.0-alpha.2
 [0.4.0-alpha.1]: https://github.com/finos/morphir/compare/v0.3.3...v0.4.0-alpha.1
 [0.3.3]: https://github.com/finos/morphir/compare/v0.3.2...v0.3.3

--- a/cmd/morphir/go.mod
+++ b/cmd/morphir/go.mod
@@ -7,8 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
-	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3
-	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3
+	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/finos/morphir/pkg/bindings/golang v0.4.0-alpha.2
 	github.com/finos/morphir/pkg/bindings/morphir-elm v0.4.0-alpha.2
 	github.com/finos/morphir/pkg/bindings/wit v0.4.0-alpha.2

--- a/cmd/morphir/go.sum
+++ b/cmd/morphir/go.sum
@@ -26,7 +26,6 @@ github.com/charmbracelet/glamour v0.10.0 h1:MtZvfwsYCx8jEPFJm3rIBFIMZUfUJ765oX8V
 github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
-github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3/go.mod h1:65HTtKURcv/ict9ZQhr6zT84JqIjMcJbyrZYHHKNfKA=
 github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7D2jVDQ=
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13 h1:/KBBKHuVRbq1lYx5BzEHBAFBP8VcQzJejZ/IA3iR28k=


### PR DESCRIPTION
## Summary

Prepare release v0.4.0-alpha.3 with the following changes:

### Added
- **Structured Logging**: New `pkg/logging` module with zerolog wrapper (#549)
  - Logger type with functional options pattern
  - Multi-writer support for simultaneous stderr and file logging
  - Configurable log levels and formats (text/JSON)
  - Log files written to `.morphir/logs/` directory

### Changed
- Removed `-v` short flag from `--version` command (reserved for future `--verbose` flag)

### Infrastructure
- Migrated mise tasks to TypeScript/Python with pinned tool versions (#548)

### Fixed
- Updated charmbracelet/lipgloss dependency to v2 (#546, #547)

## Release Checklist

- [x] CHANGELOG.md updated
- [x] Version section created
- [x] Comparison links updated
- [x] `cmd/morphir/cmd/CHANGELOG.md` synced
- [x] `mise run release:validate` passed

## Post-Merge Instructions

After this PR is merged, create and push tags:

```bash
git checkout main && git pull origin main
VERSION=v0.4.0-alpha.3 mise run release:tags:create
VERSION=v0.4.0-alpha.3 mise run release:tags:push
```