### PR TITLE
chore: upgrade lipgloss to v2.0.0-beta.3

### DIFF
--- a/cmd/morphir/cmd/golang.go
+++ b/cmd/morphir/cmd/golang.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/v2"
 	golangpipeline "github.com/finos/morphir/pkg/bindings/golang/pipeline"
 	"github.com/finos/morphir/pkg/models/ir"
 	"github.com/finos/morphir/pkg/pipeline"

--- a/cmd/morphir/cmd/project.go
+++ b/cmd/morphir/cmd/project.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/table"
 	"github.com/finos/morphir/pkg/tooling/workspace"
 	"github.com/spf13/cobra"
 )

--- a/cmd/morphir/cmd/task.go
+++ b/cmd/morphir/cmd/task.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
-	"github.com/charmbracelet/lipgloss/table"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/table"
 	"github.com/finos/morphir/pkg/config"
 	"github.com/finos/morphir/pkg/tooling/workspace"
 	"github.com/spf13/cobra"

--- a/cmd/morphir/cmd/validate.go
+++ b/cmd/morphir/cmd/validate.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/finos/morphir/cmd/morphir/internal/tui"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/components"
 	"github.com/finos/morphir/pkg/pipeline"

--- a/cmd/morphir/cmd/wit.go
+++ b/cmd/morphir/cmd/wit.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/v2"
 	witpipeline "github.com/finos/morphir/pkg/bindings/wit/pipeline"
 	"github.com/finos/morphir/pkg/pipeline"
 	"github.com/finos/morphir/pkg/vfs"

--- a/cmd/morphir/go.mod
+++ b/cmd/morphir/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
-	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3
 	github.com/finos/morphir/pkg/bindings/golang v0.4.0-alpha.3
 	github.com/finos/morphir/pkg/bindings/morphir-elm v0.4.0-alpha.3
 	github.com/finos/morphir/pkg/bindings/wit v0.4.0-alpha.3
@@ -28,6 +28,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.2 // indirect
 	github.com/charmbracelet/colorprofile v0.3.1 // indirect
+	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect

--- a/cmd/morphir/go.sum
+++ b/cmd/morphir/go.sum
@@ -26,6 +26,8 @@ github.com/charmbracelet/glamour v0.10.0 h1:MtZvfwsYCx8jEPFJm3rIBFIMZUfUJ765oX8V
 github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
+github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3 h1:W6DpZX6zSkZr0iFq6JVh1vItLoxfYtNlaxOJtWp8Kis=
+github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3/go.mod h1:65HTtKURcv/ict9ZQhr6zT84JqIjMcJbyrZYHHKNfKA=
 github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7D2jVDQ=
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13 h1:/KBBKHuVRbq1lYx5BzEHBAFBP8VcQzJejZ/IA3iR28k=

--- a/cmd/morphir/internal/tui/components/sidebar.go
+++ b/cmd/morphir/internal/tui/components/sidebar.go
@@ -6,7 +6,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/keymap"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/styles"
 )

--- a/cmd/morphir/internal/tui/components/statusbar.go
+++ b/cmd/morphir/internal/tui/components/statusbar.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/keymap"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/styles"
 )

--- a/cmd/morphir/internal/tui/components/viewer.go
+++ b/cmd/morphir/internal/tui/components/viewer.go
@@ -9,7 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
-	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/keymap"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/styles"
 )

--- a/cmd/morphir/internal/tui/layout.go
+++ b/cmd/morphir/internal/tui/layout.go
@@ -1,7 +1,7 @@
 package tui
 
 import (
-	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/components"
 	"github.com/finos/morphir/cmd/morphir/internal/tui/styles"
 )

--- a/cmd/morphir/internal/tui/styles/theme.go
+++ b/cmd/morphir/internal/tui/styles/theme.go
@@ -1,39 +1,42 @@
 package styles
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/lipgloss/v2/compat"
+)
 
 // Theme defines the color palette and styles for the TUI
 type Theme struct {
-	Primary    lipgloss.AdaptiveColor
-	Secondary  lipgloss.AdaptiveColor
-	Accent     lipgloss.AdaptiveColor
-	Muted      lipgloss.AdaptiveColor
-	Background lipgloss.AdaptiveColor
-	Foreground lipgloss.AdaptiveColor
-	Border     lipgloss.AdaptiveColor
-	SelectedBg lipgloss.AdaptiveColor
-	SelectedFg lipgloss.AdaptiveColor
-	ErrorFg    lipgloss.AdaptiveColor
-	WarningFg  lipgloss.AdaptiveColor
-	SuccessFg  lipgloss.AdaptiveColor
-	InfoFg     lipgloss.AdaptiveColor
+	Primary    compat.AdaptiveColor
+	Secondary  compat.AdaptiveColor
+	Accent     compat.AdaptiveColor
+	Muted      compat.AdaptiveColor
+	Background compat.AdaptiveColor
+	Foreground compat.AdaptiveColor
+	Border     compat.AdaptiveColor
+	SelectedBg compat.AdaptiveColor
+	SelectedFg compat.AdaptiveColor
+	ErrorFg    compat.AdaptiveColor
+	WarningFg  compat.AdaptiveColor
+	SuccessFg  compat.AdaptiveColor
+	InfoFg     compat.AdaptiveColor
 }
 
 // DefaultTheme provides a professional, terminal-friendly color scheme
 var DefaultTheme = Theme{
-	Primary:    lipgloss.AdaptiveColor{Light: "#7D56F4", Dark: "#7D56F4"},
-	Secondary:  lipgloss.AdaptiveColor{Light: "#3C3C3C", Dark: "#DDDDDD"},
-	Accent:     lipgloss.AdaptiveColor{Light: "#F25D94", Dark: "#F25D94"},
-	Muted:      lipgloss.AdaptiveColor{Light: "#888888", Dark: "#666666"},
-	Background: lipgloss.AdaptiveColor{Light: "#FFFFFF", Dark: "#1A1A1A"},
-	Foreground: lipgloss.AdaptiveColor{Light: "#1A1A1A", Dark: "#DDDDDD"},
-	Border:     lipgloss.AdaptiveColor{Light: "#CCCCCC", Dark: "#444444"},
-	SelectedBg: lipgloss.AdaptiveColor{Light: "#E0E0E0", Dark: "#2A2A2A"},
-	SelectedFg: lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"},
-	ErrorFg:    lipgloss.AdaptiveColor{Light: "#D70000", Dark: "#FF5555"},
-	WarningFg:  lipgloss.AdaptiveColor{Light: "#FF8700", Dark: "#FFAA00"},
-	SuccessFg:  lipgloss.AdaptiveColor{Light: "#008700", Dark: "#50FA7B"},
-	InfoFg:     lipgloss.AdaptiveColor{Light: "#0087D7", Dark: "#8BE9FD"},
+	Primary:    compat.AdaptiveColor{Light: lipgloss.Color("#7D56F4"), Dark: lipgloss.Color("#7D56F4")},
+	Secondary:  compat.AdaptiveColor{Light: lipgloss.Color("#3C3C3C"), Dark: lipgloss.Color("#DDDDDD")},
+	Accent:     compat.AdaptiveColor{Light: lipgloss.Color("#F25D94"), Dark: lipgloss.Color("#F25D94")},
+	Muted:      compat.AdaptiveColor{Light: lipgloss.Color("#888888"), Dark: lipgloss.Color("#666666")},
+	Background: compat.AdaptiveColor{Light: lipgloss.Color("#FFFFFF"), Dark: lipgloss.Color("#1A1A1A")},
+	Foreground: compat.AdaptiveColor{Light: lipgloss.Color("#1A1A1A"), Dark: lipgloss.Color("#DDDDDD")},
+	Border:     compat.AdaptiveColor{Light: lipgloss.Color("#CCCCCC"), Dark: lipgloss.Color("#444444")},
+	SelectedBg: compat.AdaptiveColor{Light: lipgloss.Color("#E0E0E0"), Dark: lipgloss.Color("#2A2A2A")},
+	SelectedFg: compat.AdaptiveColor{Light: lipgloss.Color("#000000"), Dark: lipgloss.Color("#FFFFFF")},
+	ErrorFg:    compat.AdaptiveColor{Light: lipgloss.Color("#D70000"), Dark: lipgloss.Color("#FF5555")},
+	WarningFg:  compat.AdaptiveColor{Light: lipgloss.Color("#FF8700"), Dark: lipgloss.Color("#FFAA00")},
+	SuccessFg:  compat.AdaptiveColor{Light: lipgloss.Color("#008700"), Dark: lipgloss.Color("#50FA7B")},
+	InfoFg:     compat.AdaptiveColor{Light: lipgloss.Color("#0087D7"), Dark: lipgloss.Color("#8BE9FD")},
 }
 
 // Common style definitions


### PR DESCRIPTION
## Summary
- Upgrade charmbracelet/lipgloss from v1 to v2.0.0-beta.3
- Update all imports from `github.com/charmbracelet/lipgloss` to `github.com/charmbracelet/lipgloss/v2`
- Use `compat.AdaptiveColor` from `lipgloss/v2/compat` package for backward-compatible adaptive color support
- Update Theme struct to use `lipgloss.Color()` for color values (v2 uses `color.Color` interface)

## Breaking Changes in lipgloss v2
lipgloss v2 uses the standard library `color.Color` interface instead of string-based color values. The `compat` package provides `AdaptiveColor` for easy migration.

## Files Changed
- `cmd/morphir/internal/tui/styles/theme.go` - Updated to use compat.AdaptiveColor with lipgloss.Color()
- Various command files - Updated imports to v2
- `cmd/morphir/go.mod` - Updated dependency

## Test plan
- [x] Build succeeds
- [ ] TUI renders correctly with updated colors
- [ ] CI passes