### PR TITLE
fix(ci): remove workspace setup from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,6 @@ jobs:
           git tag -f ${{ github.event.inputs.tag }}
           echo "GORELEASER_CURRENT_TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
 
-      - name: Set up Go workspace
-        run: mise run workspace:setup
-
       - name: Run GoReleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The release workflow failed because the workspace setup step runs `go work sync` which modifies go.mod files, causing GoReleaser to fail with a dirty git state.

## Changes
Remove the `mise run workspace:setup` step from the release workflow. GoReleaser doesn't need the workspace since it builds modules independently and runs `go mod tidy` as part of its before hooks.

## Urgency
This is blocking the v0.4.0-alpha.4 release.