### PR TITLE
chore: update internal module versions to v0.4.0-alpha.4

### DIFF
--- a/cmd/morphir/go.mod
+++ b/cmd/morphir/go.mod
@@ -8,16 +8,16 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3
-	github.com/finos/morphir/pkg/bindings/golang v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/bindings/morphir-elm v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/bindings/wit v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/config v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/logging v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/models v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/tooling v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/bindings/golang v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/bindings/morphir-elm v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/bindings/wit v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/config v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/logging v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/models v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/tooling v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.4
 	github.com/spf13/cobra v1.10.2
 )
 
@@ -36,7 +36,7 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.3 // indirect
+	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.4 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect

--- a/pkg/bindings/golang/go.mod
+++ b/pkg/bindings/golang/go.mod
@@ -3,10 +3,10 @@ module github.com/finos/morphir/pkg/bindings/golang
 go 1.25.5
 
 require (
-	github.com/finos/morphir/pkg/models v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/models v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/pkg/bindings/morphir-elm/go.mod
+++ b/pkg/bindings/morphir-elm/go.mod
@@ -3,7 +3,7 @@ module github.com/finos/morphir/pkg/bindings/morphir-elm
 go 1.25.5
 
 require (
-	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.4
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -11,8 +11,8 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.9.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/finos/morphir/pkg/config v0.3.3 // indirect
-	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.3 // indirect
-	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.3 // indirect
+	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.4 // indirect
+	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.4 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/pkg/bindings/wit/go.mod
+++ b/pkg/bindings/wit/go.mod
@@ -4,11 +4,11 @@ go 1.25.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/models v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/models v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/toolchain v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.4
 	github.com/stretchr/testify v1.11.1
 	go.bytecodealliance.org v0.7.0
 )

--- a/pkg/config/go.mod
+++ b/pkg/config/go.mod
@@ -3,7 +3,7 @@ module github.com/finos/morphir/pkg/config
 go 1.25.5
 
 require (
-	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.4
 	github.com/joho/godotenv v1.5.1
 	github.com/pelletier/go-toml/v2 v2.2.4
 )

--- a/pkg/pipeline/go.mod
+++ b/pkg/pipeline/go.mod
@@ -3,7 +3,7 @@ module github.com/finos/morphir/pkg/pipeline
 go 1.25.5
 
 require (
-	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.4
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/pkg/sdk/go.mod
+++ b/pkg/sdk/go.mod
@@ -2,4 +2,4 @@ module github.com/finos/morphir/pkg/sdk
 
 go 1.25.5
 
-require github.com/finos/morphir/pkg/models v0.4.0-alpha.3
+require github.com/finos/morphir/pkg/models v0.4.0-alpha.4

--- a/pkg/task/go.mod
+++ b/pkg/task/go.mod
@@ -3,9 +3,9 @@ module github.com/finos/morphir/pkg/task
 go 1.25.5
 
 require (
-	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.4
 	github.com/finos/morphir/pkg/tooling v0.3.3
-	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/pkg/toolchain/go.mod
+++ b/pkg/toolchain/go.mod
@@ -4,8 +4,8 @@ go 1.25.5
 
 require (
 	github.com/finos/morphir/pkg/config v0.3.3
-	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/pipeline v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/vfs v0.4.0-alpha.4
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/pkg/tooling/go.mod
+++ b/pkg/tooling/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/bmatcuk/doublestar/v4 v4.9.2
 	github.com/charmbracelet/glamour v0.10.0
-	github.com/finos/morphir/pkg/config v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/models v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/config v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/models v0.4.0-alpha.4
 	github.com/mattn/go-isatty v0.0.20
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	sigs.k8s.io/yaml v1.6.0
@@ -25,7 +25,7 @@ require (
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
-	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.3 // indirect
+	github.com/finos/morphir/pkg/bindings/typemap v0.4.0-alpha.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect

--- a/tests/bdd/go.mod
+++ b/tests/bdd/go.mod
@@ -5,8 +5,8 @@ go 1.25.5
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.2
 	github.com/cucumber/godog v0.15.0
-	github.com/finos/morphir/pkg/docling-doc v0.4.0-alpha.3
-	github.com/finos/morphir/pkg/models v0.4.0-alpha.3
+	github.com/finos/morphir/pkg/docling-doc v0.4.0-alpha.4
+	github.com/finos/morphir/pkg/models v0.4.0-alpha.4
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Summary
Update go.mod files to reference v0.4.0-alpha.4 (now published) instead of v0.4.0-alpha.3.

This allows the release build to succeed since pkg/pipeline@v0.4.0-alpha.4 includes the `WithLogger` method used by cmd/morphir.

## Urgency
This is blocking the v0.4.0-alpha.4 release.