### PR TITLE
docs: add complete V4 document tree file format specifications

### DIFF
--- a/docs/spec/ir/schemas/v4/document-tree-files.md
+++ b/docs/spec/ir/schemas/v4/document-tree-files.md
@@ -1,0 +1,1185 @@
+---
+title: "Document Tree File Formats"
+description: "Complete specification for VFS document tree file formats in Morphir IR V4"
+---
+
+# Document Tree File Formats
+
+This document provides complete specifications for all file formats used in VFS (Virtual File System) mode, where Morphir IR distributions are stored as a directory tree with individual files for each definition.
+
+## Overview
+
+In VFS mode, a Morphir IR distribution is organized as:
+
+```
+.morphir-dist/
+├── manifest.json                  # Distribution metadata
+└── pkg/
+    └── package-name/
+        └── module-path/
+            ├── module.json        # Module manifest
+            ├── type-name.type.json    # Type definitions
+            └── value-name.value.json  # Value definitions
+```
+
+## File Types
+
+### 1. Distribution Manifest (`manifest.json`)
+
+**Location**: `.morphir-dist/manifest.json`  
+**Purpose**: Distribution-level metadata and configuration
+
+**Required Fields**:
+- `formatVersion`: IR format version (`"4.0.0"` or `4`)
+- `distribution`: Distribution type (`"Library"`, `"Specs"`, or `"Application"`)
+- `package`: Package name (canonical path format, e.g., `"my-org/my-project"`)
+
+**Optional Fields**:
+- `version`: Package version (semantic version string)
+- `created`: Creation timestamp (ISO 8601 format)
+- `layout`: Distribution layout (`"VfsMode"` or `"Classic"`, defaults to `"VfsMode"`)
+- `entryPoints`: Entry points map (required for Application distributions)
+
+**Schema**: See [morphir-ir-v4-document-tree-files.yaml](/schemas/morphir-ir-v4-document-tree-files.yaml) → `DistributionManifestFile`
+
+**Example (Library)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "distribution": "Library",
+  "package": "my-org/my-project",
+  "version": "1.2.0",
+  "created": "2026-01-15T12:00:00Z",
+  "layout": "VfsMode"
+}
+```
+
+**Example (Specs)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "distribution": "Specs",
+  "package": "morphir/sdk",
+  "version": "3.0.0",
+  "created": "2026-01-15T12:00:00Z",
+  "layout": "VfsMode"
+}
+```
+
+**Example (Application)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "distribution": "Application",
+  "package": "my-org/my-cli",
+  "version": "2.0.0",
+  "created": "2026-01-15T12:00:00Z",
+  "layout": "VfsMode",
+  "entryPoints": {
+    "startup": {
+      "target": "my-org/my-cli:main#run",
+      "kind": "main",
+      "doc": "Primary application entry point"
+    },
+    "build": {
+      "target": "my-org/my-cli:commands#build",
+      "kind": "command",
+      "doc": "Build the project"
+    }
+  }
+}
+```
+
+### 2. Module Manifest (`module.json`)
+
+**Location**: `.morphir-dist/pkg/package-name/module-path/module.json`  
+**Purpose**: Module metadata and optional inline definitions
+
+**Required Fields**:
+- `formatVersion`: IR format version (`"4.0.0"` or `4`)
+- `path` or `module`: Module path (canonical format, e.g., `"my-org/domain"`)
+
+> **Note on `path` vs `module` fields:**
+>
+> Both `path` and `module` fields are equivalent and accepted for backwards compatibility. The `path` field is preferred for new files. When reading `module.json` files, tools should accept either field name.
+
+**Optional Fields**:
+- `doc`: Module-level documentation (string or array of strings)
+- `types`: Either array of type names (manifest style) or object with inline definitions (inline style)
+- `values`: Either array of value names (manifest style) or object with inline definitions (inline style)
+
+**Encoding Styles**:
+
+#### Manifest Style (Granular)
+Lists type/value names; definitions in separate files:
+
+```json
+{
+  "formatVersion": "4.0.0",
+  "path": "my-org/domain",
+  "doc": "Domain model for main application",
+  "types": ["user", "user-(id)", "order"],
+  "values": ["get-user-by-email", "create-order", "validate-user"]
+}
+```
+
+**Example with legacy `module` field** (equivalent to `path`):
+```json
+{
+  "formatVersion": "4.0.0",
+  "module": "my-org/domain",
+  "doc": "Domain model for main application",
+  "types": ["user", "order"],
+  "values": ["create-order"]
+}
+```
+
+#### Inline Style (Hybrid)
+Contains definitions directly:
+
+```json
+{
+  "formatVersion": "4.0.0",
+  "path": "my-org/domain",
+  "doc": "Domain model for main application",
+  "types": {
+    "user": {
+      "access": "Public",
+      "doc": "Represents a user",
+      "TypeAliasDefinition": {
+        "typeParams": [],
+        "typeExp": {
+          "Record": {
+            "fields": {
+              "email": "morphir/sdk:string#string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "values": {
+    "create-user": {
+      "access": "Public",
+      "ExpressionBody": {
+        "inputTypes": {},
+        "outputType": "my-org/domain:types#user",
+        "body": { "Literal": { "attributes": {}, "literal": { "StringLiteral": "..." } } }
+      }
+    }
+  }
+}
+```
+
+**Schema**: See [morphir-ir-v4-document-tree-files.yaml](/schemas/morphir-ir-v4-document-tree-files.yaml) → `ModuleManifestFile`
+
+### 3. Type Definition File (`*.type.json`)
+
+**Location**: `.morphir-dist/pkg/package-name/module-path/type-name.type.json`  
+**Purpose**: Individual type definition or specification
+
+**Required Fields**:
+- `formatVersion`: IR format version (`"4.0.0"` or `4`)
+- `name`: Type name (canonical format, must match filename without `.type.json` suffix)
+- Exactly one of:
+  - `def`: Type definition (implementation) - contains `TypeAliasDefinition`, `CustomTypeDefinition`, or `IncompleteTypeDefinition`
+  - `spec`: Type specification (interface) - contains `TypeAliasSpecification`, `OpaqueTypeSpecification`, `CustomTypeSpecification`, or `DerivedTypeSpecification`
+
+**Optional Fields**:
+- `doc`: Documentation (string or array of strings) - can be at top level or nested in `def`/`spec`
+
+**File Naming**:
+- Use canonical name format (kebab-case)
+- Suffix: `.type.json`
+- Example: `user.type.json`, `user-(id).type.json`, `order-line-item.type.json`
+
+**Schema**: See [morphir-ir-v4-document-tree-files.yaml](/schemas/morphir-ir-v4-document-tree-files.yaml) → `TypeDefinitionFile`
+
+**Example (Definition)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "user",
+  "doc": "Represents a user in the system",
+  "def": {
+    "access": "Public",
+    "TypeAliasDefinition": {
+      "typeParams": [],
+      "typeExp": {
+        "Record": {
+          "fields": {
+            "user-id": "my-org/domain:types#user-(id)",
+            "email": "morphir/sdk:string#string",
+            "created-at": "my-org/sdk:local-date-time#local-date-time"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+> **Note on Design Document Examples:**
+>
+> Some examples in the design documents (`docs/design/draft/ir/distributions.md`) may be simplified and omit the `access` field for brevity. In actual VFS files that are part of a PackageDefinition, the `access` field is **required** in `def` objects. The examples in this specification document show the complete, valid format.
+
+**Example (Specification)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "int",
+  "spec": {
+    "doc": "Arbitrary precision integer",
+    "OpaqueTypeSpecification": {}
+  }
+}
+```
+
+**Example (Custom Type Definition)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "order-status",
+  "def": {
+    "access": "Public",
+    "CustomTypeDefinition": {
+      "typeParams": [],
+      "access": "Public",
+      "value": {
+        "constructors": {
+          "pending": [],
+          "processing": [],
+          "shipped": [],
+          "delivered": [],
+          "cancelled": []
+        }
+      }
+    }
+  }
+}
+```
+
+### 4. Value Definition File (`*.value.json`)
+
+**Location**: `.morphir-dist/pkg/package-name/module-path/value-name.value.json`  
+**Purpose**: Individual value definition or specification
+
+**Required Fields**:
+- `formatVersion`: IR format version (`"4.0.0"` or `4`)
+- `name`: Value name (canonical format, must match filename without `.value.json` suffix)
+- Exactly one of:
+  - `def`: Value definition (implementation) - contains wrapper object with `ExpressionBody`, `NativeBody`, `ExternalBody`, or `IncompleteBody`
+  - `spec`: Value specification (interface) - contains `inputs` (object) and `output` (type)
+
+**Optional Fields**:
+- `doc`: Documentation (string or array of strings) - can be at top level or nested in `def`/`spec`
+
+**File Naming**:
+- Use canonical name format (kebab-case)
+- Suffix: `.value.json`
+- Example: `get-user-by-email.value.json`, `create-order.value.json`, `validate-email.value.json`
+
+**Schema**: See [morphir-ir-v4-document-tree-files.yaml](/schemas/morphir-ir-v4-document-tree-files.yaml) → `ValueDefinitionFile`
+
+**Example (Definition with ExpressionBody)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "get-user-by-email",
+  "doc": "Retrieve a user by email address",
+  "def": {
+    "access": "Public",
+    "ExpressionBody": {
+      "inputTypes": {
+        "email": "morphir/sdk:string#string",
+        "users": ["morphir/sdk:list#list", "my-org/domain:types#user"]
+      },
+      "outputType": ["morphir/sdk:maybe#maybe", "my-org/domain:types#user"],
+      "body": {
+        "Apply": {
+          "attributes": {},
+          "function": {
+            "Reference": {
+              "attributes": {},
+              "fqname": "morphir/sdk:list#find",
+              "args": []
+            }
+          },
+          "argument": {
+            "Variable": {
+              "attributes": {},
+              "name": "email"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+> **Note on Type Reference Formats:**
+>
+> Type references in `inputTypes`, `outputType`, and `typeExp` fields can use either:
+> - **Canonical string format**: `"morphir/sdk:string#string"` (preferred, more compact)
+> - **Array format**: `["morphir/sdk:list#list", "my-org/domain:types#user"]` (for parameterized types)
+>
+> Both formats are valid. The canonical string format is preferred for simple types, while array format is used for parameterized types where the first element is the type constructor and subsequent elements are type arguments.
+
+**Example (Definition with NativeBody)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "add",
+  "def": {
+    "access": "Public",
+    "NativeBody": {
+      "inputTypes": {
+        "a": "morphir/sdk:basics#int",
+        "b": "morphir/sdk:basics#int"
+      },
+      "outputType": "morphir/sdk:basics#int",
+      "nativeInfo": {
+        "hint": { "Arithmetic": {} }
+      }
+    }
+  }
+}
+```
+
+**Example (Specification)**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "validate-email",
+  "spec": {
+    "doc": [
+      "Validate an email address format.",
+      "Returns true if the email is valid, false otherwise."
+    ],
+    "inputs": {
+      "email": "morphir/sdk:string#string"
+    },
+    "output": "morphir/sdk:basics#bool"
+  }
+}
+```
+
+## Directory Structure
+
+### Standard Layout
+
+```
+.morphir-dist/
+├── manifest.json                         # Distribution metadata
+└── pkg/
+    └── my-org/
+        └── my-project/                   # Package directory
+            ├── domain/                   # Module directory
+            │   ├── module.json          # Module manifest
+            │   ├── user.type.json       # Type definition
+            │   ├── user-(id).type.json  # Type definition
+            │   ├── order.type.json      # Type definition
+            │   ├── get-user.value.json  # Value definition
+            │   └── create-order.value.json
+            └── api/                     # Another module
+                ├── module.json
+                ├── request.type.json
+                └── handle-request.value.json
+```
+
+### Nested Modules
+
+Modules can be nested by creating subdirectories:
+
+```
+.morphir-dist/
+└── pkg/
+    └── my-org/
+        └── my-project/
+            └── domain/
+                ├── module.json          # domain module
+                ├── user.type.json
+                └── orders/              # domain/orders submodule
+                    ├── module.json      # domain/orders module
+                    ├── order.type.json
+                    └── shipping/        # domain/orders/shipping submodule
+                        ├── module.json  # domain/orders/shipping module
+                        └── address.type.json
+```
+
+## Field Details
+
+### formatVersion
+
+**Type**: String (semver) or Integer  
+**Required**: Yes  
+**Description**: IR format version
+
+**Formats**:
+- Semantic version: `"4.0.0"`, `"4.0.0-alpha.1"`, `"4.0.0+20240123"`
+- Legacy integer: `4`
+
+**Examples**:
+```json
+"formatVersion": "4.0.0"
+"formatVersion": 4
+```
+
+### name
+
+**Type**: Name (canonical string format)  
+**Required**: Yes (in `*.type.json` and `*.value.json` files)  
+**Description**: The canonical name of the type or value
+
+**Format**: Kebab-case with optional parenthesized abbreviations
+- `"user"`
+- `"get-user-by-email"`
+- `"value-in-(usd)"`
+- `"user-(id)"`
+
+**Constraint**: Must match the filename (without suffix)
+
+### path / module
+
+**Type**: ModuleName (canonical path format)  
+**Required**: Yes (in `module.json`, either field)  
+**Description**: Module path
+
+**Format**: Forward-slash separated segments
+- `"domain"`
+- `"my-org/domain"`
+- `"domain/orders/shipping"`
+
+**Note**: `path` and `module` are equivalent; `path` is preferred for new files, while `module` is accepted for backwards compatibility with legacy files.
+
+### doc
+
+**Type**: String or Array of Strings  
+**Required**: No  
+**Description**: Documentation
+
+**Formats**:
+- Single-line: `"doc": "Brief description"`
+- Multi-line: `"doc": ["Line 1", "Line 2", "Line 3"]`
+
+**Location**: Can appear at:
+- Top level of file
+- Nested in `def` or `spec` object
+- Both (top-level takes precedence for display)
+
+### def
+
+**Type**: Object  
+**Required**: Yes (if this is a definition file)  
+**Description**: Type or value definition (implementation)
+
+**For Type Definitions**:
+- Must contain exactly one of: `TypeAliasDefinition`, `CustomTypeDefinition`, `IncompleteTypeDefinition`
+- Must include `access` field (`"Public"` or `"Private"`) when part of PackageDefinition
+- May include `doc` field
+
+**For Value Definitions**:
+- Must contain wrapper object with exactly one of: `ExpressionBody`, `NativeBody`, `ExternalBody`, `IncompleteBody`
+- Must include `access` field (`"Public"` or `"Private"`) when part of PackageDefinition
+- May include `doc` field
+
+**Example (Type)**:
+```json
+{
+  "def": {
+    "access": "Public",
+    "doc": "User type",
+    "TypeAliasDefinition": {
+      "typeParams": [],
+      "typeExp": "morphir/sdk:string#string"
+    }
+  }
+}
+```
+
+**Example (Value)**:
+```json
+{
+  "def": {
+    "access": "Public",
+    "doc": "Create a user",
+    "ExpressionBody": {
+      "inputTypes": {},
+      "outputType": "my-org/domain:types#user",
+      "body": { "Literal": { "attributes": {}, "literal": { "StringLiteral": "..." } } }
+    }
+  }
+}
+```
+
+### spec
+
+**Type**: Object  
+**Required**: Yes (if this is a specification file)  
+**Description**: Type or value specification (interface)
+
+**For Type Specifications**:
+- Must contain exactly one of: `TypeAliasSpecification`, `OpaqueTypeSpecification`, `CustomTypeSpecification`, `DerivedTypeSpecification`
+- May include `doc` field
+
+**For Value Specifications**:
+- Must contain:
+  - `inputs`: Object mapping parameter names to types
+  - `output`: Type
+- May include `doc` field
+
+**Example (Type)**:
+```json
+{
+  "spec": {
+    "doc": "Integer type",
+    "OpaqueTypeSpecification": {}
+  }
+}
+```
+
+**Example (Value)**:
+```json
+{
+  "spec": {
+    "doc": "Add two integers",
+    "inputs": {
+      "a": "morphir/sdk:basics#int",
+      "b": "morphir/sdk:basics#int"
+    },
+    "output": "morphir/sdk:basics#int"
+  }
+}
+```
+
+## Access Control
+
+### In PackageDefinition Context
+
+When type/value files are part of a PackageDefinition:
+- `def` objects **must** include `access` field
+- Values: `"Public"` or `"Private"`
+- Determines visibility within the package
+
+### In PackageSpecification Context
+
+When type/value files are part of a PackageSpecification:
+- Only public items are included
+- `spec` objects do **not** include `access` field (specs are always public)
+
+## Advanced Examples
+
+### Incomplete Type Definition
+
+**user.type.json** (with incomplete definition):
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "user",
+  "def": {
+    "access": "Public",
+    "IncompleteTypeDefinition": {
+      "typeParams": [],
+      "reason": {
+        "UnresolvedReference": {
+          "target": "my-org/domain:types#missing-type"
+        }
+      }
+    }
+  }
+}
+```
+
+### External Value Definition
+
+**external-api.value.json**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "call-external-api",
+  "def": {
+    "access": "Public",
+    "ExternalBody": {
+      "inputTypes": {
+        "url": "morphir/sdk:string#string",
+        "payload": "morphir/sdk:json#json"
+      },
+      "outputType": ["morphir/sdk:result#result", "morphir/sdk:json#json", "morphir/sdk:string#string"],
+      "externalInfo": {
+        "provider": "http",
+        "endpoint": "/api/v1/data",
+        "method": "POST"
+      }
+    }
+  }
+}
+```
+
+### Value with Complex Expression Body
+
+**calculate-total.value.json**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "calculate-total",
+  "doc": [
+    "Calculate the total price of an order including tax.",
+    "Applies discounts and regional tax rates."
+  ],
+  "def": {
+    "access": "Public",
+    "ExpressionBody": {
+      "inputTypes": {
+        "order": "my-org/domain:orders#order",
+        "tax-rate": "morphir/sdk:basics#float"
+      },
+      "outputType": "morphir/sdk:basics#float",
+      "body": {
+        "LetDefinition": {
+          "attributes": {},
+          "valueName": "subtotal",
+          "valueDefinition": {
+            "ExpressionBody": {
+              "inputTypes": {},
+              "outputType": "morphir/sdk:basics#float",
+              "body": {
+                "Apply": {
+                  "attributes": {},
+                  "function": {
+                    "Reference": {
+                      "attributes": {},
+                      "fqname": "morphir/sdk:list#sum",
+                      "args": []
+                    }
+                  },
+                  "argument": {
+                    "Field": {
+                      "attributes": {},
+                      "subject": {
+                        "Variable": {
+                          "attributes": {},
+                          "name": "order"
+                        }
+                      },
+                      "fieldName": "line-items"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "inValue": {
+            "Apply": {
+              "attributes": {},
+              "function": {
+                "Reference": {
+                  "attributes": {},
+                  "fqname": "morphir/sdk:basics#multiply",
+                  "args": []
+                }
+              },
+              "argument": {
+                "Tuple": {
+                  "attributes": {},
+                  "elements": [
+                    {
+                      "Variable": {
+                        "attributes": {},
+                        "name": "subtotal"
+                      }
+                    },
+                    {
+                      "Apply": {
+                        "attributes": {},
+                        "function": {
+                          "Reference": {
+                            "attributes": {},
+                            "fqname": "morphir/sdk:basics#add",
+                            "args": []
+                          }
+                        },
+                        "argument": {
+                          "Tuple": {
+                            "attributes": {},
+                            "elements": [
+                              {
+                                "Literal": {
+                                  "attributes": {},
+                                  "literal": { "FloatLiteral": 1.0 }
+                                }
+                              },
+                              {
+                                "Variable": {
+                                  "attributes": {},
+                                  "name": "tax-rate"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Type with Type Parameters
+
+**result.type.json**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "result",
+  "spec": {
+    "doc": "Result type representing success or error",
+    "CustomTypeSpecification": {
+      "typeParams": ["ok", "err"],
+      "value": {
+        "constructors": {
+          "ok": [["value", "ok"]],
+          "err": [["error", "err"]]
+        }
+      }
+    }
+  }
+}
+```
+
+### Module with Mixed Styles
+
+**module.json** (manifest style with some inline definitions):
+```json
+{
+  "formatVersion": "4.0.0",
+  "path": "my-org/domain",
+  "doc": "Domain model",
+  "types": ["user", "order"],
+  "values": {
+    "create-user": {
+      "access": "Public",
+      "ExpressionBody": {
+        "inputTypes": {
+          "email": "morphir/sdk:string#string"
+        },
+        "outputType": "my-org/domain:types#user",
+        "body": {
+          "Constructor": {
+            "attributes": {},
+            "fqname": "my-org/domain:types#user",
+            "args": [
+              {
+                "Variable": {
+                  "attributes": {},
+                  "name": "email"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Note**: While mixing styles is technically possible, it's recommended to use consistent style per module for clarity.
+
+## Complete Examples
+
+### Complete Module Structure
+
+**Directory**: `.morphir-dist/pkg/my-org/my-project/domain/`
+
+**module.json**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "path": "my-org/domain",
+  "doc": "Domain model for the application",
+  "types": ["user", "user-(id)", "order"],
+  "values": ["get-user-by-email", "create-order", "validate-user"]
+}
+```
+
+**user.type.json**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "user",
+  "doc": "Represents a user in the system",
+  "def": {
+    "access": "Public",
+    "TypeAliasDefinition": {
+      "typeParams": [],
+      "typeExp": {
+        "Record": {
+          "fields": {
+            "user-id": "my-org/domain:types#user-(id)",
+            "email": "morphir/sdk:string#string",
+            "created-at": "my-org/sdk:local-date-time#local-date-time"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**user-(id).type.json**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "user-(id)",
+  "def": {
+    "access": "Public",
+    "CustomTypeDefinition": {
+      "typeParams": [],
+      "access": "Public",
+      "value": {
+        "constructors": {
+          "user-(id)": [
+            ["id", "morphir/sdk:string#string"]
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+**get-user-by-email.value.json**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "name": "get-user-by-email",
+  "doc": "Retrieve a user by their email address",
+  "def": {
+    "access": "Public",
+    "ExpressionBody": {
+      "inputTypes": {
+        "email": "morphir/sdk:string#string",
+        "users": ["morphir/sdk:list#list", "my-org/domain:types#user"]
+      },
+      "outputType": ["morphir/sdk:maybe#maybe", "my-org/domain:types#user"],
+      "body": {
+        "Apply": {
+          "attributes": {},
+          "function": {
+            "Reference": {
+              "attributes": {},
+              "fqname": "morphir/sdk:list#find",
+              "args": []
+            }
+          },
+          "argument": {
+            "Variable": {
+              "attributes": {},
+              "name": "email"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Validation Rules
+
+### File Naming
+- ✅ Must use canonical name format (kebab-case)
+- ✅ Type files: `*.type.json`
+- ✅ Value files: `*.value.json`
+- ✅ Module files: `module.json` (exact name)
+- ✅ Manifest file: `manifest.json` (exact name, at root)
+- ❌ No spaces or special characters (except hyphens and parentheses)
+- ❌ No uppercase letters
+
+**Valid Examples**:
+- `user.type.json` ✅
+- `user-(id).type.json` ✅
+- `get-user-by-email.value.json` ✅
+- `value-in-(usd).value.json` ✅
+
+**Invalid Examples**:
+- `User.type.json` ❌ (uppercase)
+- `user id.type.json` ❌ (space)
+- `user.id.type.json` ❌ (period, use hyphen)
+- `user_id.type.json` ❌ (underscore, use hyphen)
+
+### Required Fields
+- All files: `formatVersion`
+- Definition files: `name`, exactly one of `def` or `spec`
+- Module files: `path` or `module`
+- Manifest files: `distribution`, `package`
+
+### Field Consistency
+- `name` field must match filename (without suffix)
+- `path`/`module` field must match directory structure
+- `def` and `spec` are mutually exclusive (exactly one required)
+
+**Example**: If file is `user.type.json`, then `name` must be `"user"`.
+
+**Example**: If file is in `.morphir-dist/pkg/my-org/my-project/domain/`, then `path` should be `"my-org/domain"` or `"my-org/my-project/domain"` depending on package structure.
+
+### Type and Value Definition Validation
+
+**Type Definitions** (`def` in `*.type.json`):
+- Must contain exactly one of: `TypeAliasDefinition`, `CustomTypeDefinition`, `IncompleteTypeDefinition`
+- Must include `access` field when part of PackageDefinition
+- `TypeAliasDefinition` must have `typeParams` (array) and `typeExp` (type)
+- `CustomTypeDefinition` must have `typeParams`, `access`, and `value.constructors` (object)
+- `IncompleteTypeDefinition` must have `typeParams` and `reason` (HoleReason)
+
+**Type Specifications** (`spec` in `*.type.json`):
+- Must contain exactly one of: `TypeAliasSpecification`, `OpaqueTypeSpecification`, `CustomTypeSpecification`, `DerivedTypeSpecification`
+- `OpaqueTypeSpecification` must be empty object `{}`
+- `TypeAliasSpecification` must have `typeParams` and `typeExp`
+- `CustomTypeSpecification` must have `typeParams` and `value.constructors`
+
+**Value Definitions** (`def` in `*.value.json`):
+- Must contain wrapper object with exactly one of: `ExpressionBody`, `NativeBody`, `ExternalBody`, `IncompleteBody`
+- Must include `access` field when part of PackageDefinition
+- `ExpressionBody` must have `inputTypes` (object), `outputType` (type), and `body` (expression)
+- `NativeBody` must have `inputTypes`, `outputType`, and `nativeInfo`
+- `ExternalBody` must have `inputTypes`, `outputType`, and `externalInfo`
+- `IncompleteBody` must have `inputTypes`, `outputType`, and `reason`
+
+**Value Specifications** (`spec` in `*.value.json`):
+- Must have `inputs` (object mapping parameter names to types)
+- Must have `output` (type)
+- May have `doc` (string or array of strings)
+
+### Module Manifest Validation
+
+**Manifest Style**:
+- `types` must be array of Name strings
+- `values` must be array of Name strings
+- Referenced type/value files must exist in same directory
+
+**Inline Style**:
+- `types` must be object mapping names to AccessControlled TypeDefinition
+- `values` must be object mapping names to AccessControlled ValueDefinition
+- Each definition must include `access` field
+
+**Hybrid Style** (not recommended but allowed):
+- One of `types`/`values` can be array, other can be object
+- Consistency is preferred
+
+### Distribution Manifest Validation
+
+**Required for all distributions**:
+- `formatVersion`: Must be `"4.0.0"` or `4`
+- `distribution`: Must be `"Library"`, `"Specs"`, or `"Application"`
+- `package`: Must be valid PackageName (canonical format)
+
+**Required for Application distributions**:
+- `entryPoints`: Must be present and non-empty object
+- Each entry point must have `target` (FQName) and `kind` (EntryPointKind)
+
+**Optional but recommended**:
+- `version`: Semantic version string
+- `created`: ISO 8601 timestamp
+- `layout`: Should be `"VfsMode"` for document tree distributions
+
+### Directory Structure Validation
+
+**Package Directory**:
+- Must match `package` field in `manifest.json`
+- Path: `.morphir-dist/pkg/{package-path}/`
+
+**Module Directory**:
+- Must match `path`/`module` field in `module.json`
+- Path: `.morphir-dist/pkg/{package-path}/{module-path}/`
+- Must contain `module.json` file
+
+**Definition Files**:
+- Must be in module directory
+- Filename must match `name` field in file
+- Type files: `{name}.type.json`
+- Value files: `{name}.value.json`
+
+## Error Handling
+
+### Common Validation Errors
+
+**Missing Required Field**:
+```json
+// ❌ Missing 'name' field
+{
+  "formatVersion": "4.0.0",
+  "def": { ... }
+}
+```
+
+**Name Mismatch**:
+```json
+// ❌ File is 'user.type.json' but name is 'order'
+{
+  "formatVersion": "4.0.0",
+  "name": "order",
+  "def": { ... }
+}
+```
+
+**Both def and spec Present**:
+```json
+// ❌ Cannot have both def and spec
+{
+  "formatVersion": "4.0.0",
+  "name": "user",
+  "def": { ... },
+  "spec": { ... }
+}
+```
+
+**Missing Access Field**:
+```json
+// ❌ Missing 'access' in def (required for PackageDefinition)
+{
+  "formatVersion": "4.0.0",
+  "name": "user",
+  "def": {
+    "TypeAliasDefinition": { ... }
+  }
+}
+```
+
+**Invalid Entry Points**:
+```json
+// ❌ Application distribution missing entryPoints
+{
+  "formatVersion": "4.0.0",
+  "distribution": "Application",
+  "package": "my-org/my-cli"
+  // Missing entryPoints!
+}
+```
+
+### Recommended Error Messages
+
+When validation fails, provide clear error messages:
+
+- **File naming**: `"Filename 'User.type.json' does not match canonical name format. Expected 'user.type.json'"`
+- **Name mismatch**: `"Name field 'order' does not match filename 'user.type.json'"`
+- **Missing field**: `"Required field 'name' is missing in type definition file"`
+- **Both def/spec**: `"Cannot have both 'def' and 'spec' fields. Use exactly one."`
+- **Missing access**: `"Definition in PackageDefinition context must include 'access' field"`
+- **Invalid entry points**: `"Application distribution must include 'entryPoints' field"`
+
+## Schema Reference
+
+Formal JSON schemas are available in:
+- [morphir-ir-v4-document-tree-files.yaml](/schemas/morphir-ir-v4-document-tree-files.yaml) - Complete schemas for all file formats
+- [morphir-ir-v4.yaml](/schemas/morphir-ir-v4.yaml) - Core IR schema (referenced by document tree files)
+
+## Metadata Files
+
+### Package Metadata
+
+Package-level metadata can be stored in additional files:
+
+**Location**: `.morphir-dist/pkg/package-name/package.json` (optional)
+
+**Purpose**: Package-level metadata, dependencies, configuration
+
+**Example**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "package": "my-org/my-project",
+  "version": "1.2.0",
+  "description": "My project description",
+  "dependencies": {
+    "morphir/sdk": "3.0.0"
+  },
+  "metadata": {
+    "author": "My Org",
+    "license": "Apache-2.0",
+    "repository": "https://github.com/my-org/my-project"
+  }
+}
+```
+
+**Note**: Package metadata files (`package.json`) are **optional** and **not part of the core V4 IR schema**. They are documented here for reference, but implementations are not required to support them. The `manifest.json` file contains all essential distribution metadata required by the V4 specification. Package metadata files may be used by tooling for additional metadata, but are not validated by the core IR schema.
+
+### Module Metadata
+
+Module-level metadata is stored in `module.json`. Additional metadata can be included:
+
+**Example with extended metadata**:
+```json
+{
+  "formatVersion": "4.0.0",
+  "path": "my-org/domain",
+  "doc": "Domain model",
+  "types": ["user", "order"],
+  "values": ["create-order"],
+  "metadata": {
+    "tags": ["domain", "core"],
+    "deprecated": false,
+    "since": "1.0.0"
+  }
+}
+```
+
+**Metadata Fields** (all optional):
+- `tags`: Array of string tags for categorization
+- `deprecated`: Boolean indicating if module is deprecated
+- `since`: Version when module was introduced
+- `extensions`: Object for tool-specific metadata
+
+## File Format Comparison
+
+### Classic Mode vs VFS Mode
+
+| Aspect | Classic Mode | VFS Mode |
+|--------|--------------|----------|
+| **Structure** | Single `morphir-ir.json` file | Directory tree with individual files |
+| **Manifest File** | Not separate (embedded in root) | `.morphir-dist/manifest.json` |
+| **Module Structure** | Nested in distribution JSON | `module.json` file per module |
+| **Type Definitions** | Nested in module JSON | `*.type.json` files |
+| **Value Definitions** | Nested in module JSON | `*.value.json` files |
+| **Use Case** | Simple projects, backwards compat | Large projects, incremental updates |
+
+## Complete Directory Tree Example
+
+```
+.morphir-dist/
+├── manifest.json
+└── pkg/
+    └── my-org/
+        └── my-project/
+            ├── domain/
+            │   ├── module.json
+            │   ├── user.type.json
+            │   ├── user-(id).type.json
+            │   ├── order.type.json
+            │   ├── get-user-by-email.value.json
+            │   └── create-order.value.json
+            ├── api/
+            │   ├── module.json
+            │   ├── request.type.json
+            │   ├── response.type.json
+            │   └── handle-request.value.json
+            └── utils/
+                ├── module.json
+                ├── validation.type.json
+                └── validate-email.value.json
+```
+
+## Related Documentation
+
+- [Module Structure](../modules.md) - Module concepts and structure
+- [Distribution Structure](../../design/draft/ir/distributions.md) - Distribution modes and VFS examples
+- [V4 Schema](../schemas/v4/) - Complete V4 schema documentation
+- [V4 Schema YAML](../schemas/v4/morphir-ir-v4.yaml) - Formal JSON schema

--- a/docs/spec/ir/schemas/v4/index.md
+++ b/docs/spec/ir/schemas/v4/index.md
@@ -268,6 +268,27 @@ distribution:
 
 > **Note on Entry Points:** The `entryPoints` object uses keys (e.g., `"startup"`, `"build"`, `"api-handler"`) as arbitrary identifiers chosen by developers. Each entry point has a `kind` field (e.g., `"main"`, `"command"`, `"handler"`) that categorizes it semantically. The name and kind can differ - for example, an entry point named `"startup"` can have `kind: "main"`, or `"api-handler"` can have `kind: "handler"`. The name is for identification, while the kind is for semantic categorization used by tooling and runtime.
 
+## Document Tree File Formats
+
+V4 supports VFS (Virtual File System) mode where distributions are stored as directory trees with individual files for each definition.
+
+**File Formats**:
+- `manifest.json` - Distribution metadata
+- `module.json` - Module manifest (with optional inline definitions)
+- `*.type.json` - Type definition/specification files
+- `*.value.json` - Value definition/specification files
+
+**Complete Documentation**: See [Document Tree File Formats](document-tree-files.md) for:
+- Complete file format specifications with detailed examples
+- Required and optional fields for each file type
+- Encoding styles (manifest vs inline)
+- Directory structure examples
+- Field details and validation rules
+- Error handling and common validation errors
+- Advanced examples (incomplete types, external values, complex expressions)
+
+**Formal Schemas**: See [morphir-ir-v4-document-tree-files.yaml](/schemas/morphir-ir-v4-document-tree-files.yaml) for JSON schemas validating all document tree file formats.
+
 ## Complete Example
 
 A complete Library distribution example showing the full structure:

--- a/website/static/schemas/morphir-ir-v4-document-tree-files.yaml
+++ b/website/static/schemas/morphir-ir-v4-document-tree-files.yaml
@@ -1,0 +1,411 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://morphir.finos.org/schemas/morphir-ir-v4-document-tree-files.yaml"
+title: "Morphir IR V4 Document Tree File Formats"
+description: |
+  JSON schemas for document tree file formats used in VFS (Virtual File System) mode.
+  
+  In VFS mode, Morphir IR distributions are stored as a directory tree with individual
+  files for each type and value definition. This enables incremental updates, better
+  tooling support, and easier navigation of large codebases.
+  
+  File types:
+  - manifest.json: Distribution-level metadata
+  - module.json: Module manifest (with optional inline definitions)
+  - *.type.json: Individual type definition/specification files
+  - *.value.json: Individual value definition/specification files
+  
+  Note: This schema references definitions from morphir-ir-v4.yaml for core types
+  (Name, ModuleName, PackageName, TypeDefinition, ValueDefinition, etc.).
+
+definitions:
+  # Import core types from main schema (these would be $ref in practice)
+  Name:
+    oneOf:
+      - type: string
+        pattern: "^[a-z0-9]+(-[a-z0-9]+|-(\\([a-z]+\\)))*$"
+        description: "Canonical string representation"
+        examples: ["my-name", "user-id", "value-in-(usd)"]
+      - type: array
+        items:
+          type: string
+          pattern: "^[a-z][a-z0-9]*$"
+        minItems: 1
+        description: "Legacy array representation"
+  
+  ModuleName:
+    oneOf:
+      - type: string
+        pattern: "^[a-z0-9-()]+(/[a-z0-9-()]+)*$"
+        description: "Canonical string representation"
+        examples: ["basics", "domain/users", "u-s/f-r-2052-a/data-tables"]
+      - type: array
+        items: { $ref: "#/definitions/Name" }
+        minItems: 1
+        description: "Legacy array representation"
+  
+  PackageName:
+    $ref: "#/definitions/ModuleName"
+    description: "Package identifier (same format as ModuleName)"
+  
+  AccessControlled:
+    type: object
+    required: ["access", "value"]
+    properties:
+      access:
+        enum: ["Public", "Private"]
+        description: "Visibility level"
+      value: {}
+  
+  TypeDefinition:
+    type: object
+    description: "Type definition variant (TypeAliasDefinition, CustomTypeDefinition, or IncompleteTypeDefinition)"
+    additionalProperties: true
+  
+  TypeSpecification:
+    type: object
+    description: "Type specification variant (TypeAliasSpecification, OpaqueTypeSpecification, etc.)"
+    additionalProperties: true
+  
+  ValueDefinition:
+    type: object
+    description: "Value definition variant (wrapper object with ExpressionBody, NativeBody, etc.)"
+    additionalProperties: true
+  
+  ValueSpecification:
+    type: object
+    required: ["inputs", "output"]
+    properties:
+      inputs:
+        type: object
+        additionalProperties: true
+        description: "Input parameter types"
+      output: {}
+      description: "Output type"
+    additionalProperties: true
+  
+  EntryPoint:
+    type: object
+    required: ["target", "kind"]
+    properties:
+      target:
+        oneOf:
+          - type: string
+            pattern: "^[a-z0-9-()/]+:[a-z0-9-()/]+#[a-z0-9-()]+$"
+          - type: array
+            minItems: 3
+            maxItems: 3
+        description: "Fully-qualified name"
+      kind:
+        enum: ["main", "command", "handler", "job", "policy"]
+        description: "Entry point kind"
+      doc:
+        oneOf:
+          - type: string
+          - type: array
+            items: { type: string }
+        description: "Optional documentation"
+
+  # Common header fields for all VFS node files
+  VfsNodeHeader:
+    type: object
+    required: ["formatVersion", "name"]
+    properties:
+      formatVersion:
+        oneOf:
+          - type: string
+            pattern: "^4\\.0\\.0(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$"
+            description: "Semantic version string (e.g., '4.0.0', '4.0.0-alpha.1')"
+            examples: ["4.0.0", "4.0.0-alpha.1"]
+          - type: integer
+            const: 4
+            description: "Legacy integer format for backwards compatibility"
+            examples: [4]
+      name:
+        $ref: "#/definitions/Name"
+        description: "The canonical name of the type or value (matches filename without suffix)"
+    description: |
+      Common header fields present in all granular definition files (*.type.json, *.value.json).
+      The name field matches the filename (without the .type.json or .value.json suffix).
+    examples:
+      - { "formatVersion": "4.0.0", "name": "user" }
+      - { "formatVersion": 4, "name": "get-user-by-email" }
+
+  # Type Definition File (*.type.json)
+  TypeDefinitionFile:
+    allOf:
+      - $ref: "#/definitions/VfsNodeHeader"
+      - type: object
+        required: []
+        properties:
+          doc:
+            oneOf:
+              - type: string
+                description: "Single-line documentation (will be split on newlines)"
+              - type: array
+                items: { type: string }
+                description: "Multi-line documentation (one string per line)"
+            description: "Optional documentation for this type"
+          def:
+            type: object
+            required: []
+            properties:
+              access:
+                enum: ["Public", "Private"]
+                description: "Access level (required for definitions in PackageDefinition)"
+              doc:
+                oneOf:
+                  - type: string
+                  - type: array
+                    items: { type: string }
+                description: "Optional documentation (can be at def level or top level)"
+            additionalProperties: true
+            description: |
+              Type definition (implementation). Used in PackageDefinition.
+              Must contain one of: TypeAliasDefinition, CustomTypeDefinition, IncompleteTypeDefinition.
+              The access field is required when this file is part of a PackageDefinition.
+          spec:
+            type: object
+            required: []
+            properties:
+              doc:
+                oneOf:
+                  - type: string
+                  - type: array
+                    items: { type: string }
+                description: "Optional documentation"
+            additionalProperties: true
+            description: |
+              Type specification (interface). Used in PackageSpecification.
+              Must contain one of: TypeAliasSpecification, OpaqueTypeSpecification, 
+              CustomTypeSpecification, DerivedTypeSpecification.
+    description: |
+      Type definition or specification file (*.type.json).
+      
+      Structure:
+      - formatVersion: Required, semver string or integer 4
+      - name: Required, canonical name matching filename
+      - doc: Optional, documentation (can be at top level or nested in def/spec)
+      - def: Required if this is a definition (implementation), contains TypeDefinition variant
+      - spec: Required if this is a specification (interface), contains TypeSpecification variant
+      
+      Exactly one of 'def' or 'spec' must be present.
+    examples:
+      - { "formatVersion": "4.0.0", "name": "user", "doc": "Represents a user", "def": { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": { "Record": { "fields": { "email": "morphir/sdk:string#string" } } } } } }
+      - { "formatVersion": "4.0.0", "name": "int", "spec": { "doc": "Arbitrary precision integer", "OpaqueTypeSpecification": {} } }
+
+  # Value Definition File (*.value.json)
+  ValueDefinitionFile:
+    allOf:
+      - $ref: "#/definitions/VfsNodeHeader"
+      - type: object
+        required: []
+        properties:
+          doc:
+            oneOf:
+              - type: string
+                description: "Single-line documentation"
+              - type: array
+                items: { type: string }
+                description: "Multi-line documentation"
+            description: "Optional documentation for this value"
+          def:
+            type: object
+            required: []
+            properties:
+              access:
+                enum: ["Public", "Private"]
+                description: "Access level (required for definitions in PackageDefinition)"
+              doc:
+                oneOf:
+                  - type: string
+                  - type: array
+                    items: { type: string }
+                description: "Optional documentation"
+            additionalProperties: true
+            description: |
+              Value definition (implementation). Used in PackageDefinition.
+              Must contain one of: ExpressionBody, NativeBody, ExternalBody, IncompleteBody
+              wrapped in their wrapper object format (e.g., { "ExpressionBody": { ... } }).
+              The access field is required when this file is part of a PackageDefinition.
+          spec:
+            type: object
+            required: []
+            properties:
+              doc:
+                oneOf:
+                  - type: string
+                  - type: array
+                    items: { type: string }
+                description: "Optional documentation"
+            additionalProperties: true
+            description: |
+              Value specification (interface). Used in PackageSpecification.
+              Must contain: inputs (object mapping parameter names to types) and output (type).
+    description: |
+      Value definition or specification file (*.value.json).
+      
+      Structure:
+      - formatVersion: Required, semver string or integer 4
+      - name: Required, canonical name matching filename
+      - doc: Optional, documentation (can be at top level or nested in def/spec)
+      - def: Required if this is a definition (implementation), contains ValueDefinition variant
+      - spec: Required if this is a specification (interface), contains ValueSpecification
+      
+      Exactly one of 'def' or 'spec' must be present.
+    examples:
+      - { "formatVersion": "4.0.0", "name": "get-user-by-email", "def": { "access": "Public", "ExpressionBody": { "inputTypes": { "email": "morphir/sdk:string#string" }, "outputType": "morphir/sdk:maybe#maybe", "body": { "Variable": { "attributes": {}, "name": "email" } } } } }
+      - { "formatVersion": "4.0.0", "name": "add", "spec": { "doc": "Add two integers", "inputs": { "a": "morphir/sdk:basics#int", "b": "morphir/sdk:basics#int" }, "output": "morphir/sdk:basics#int" } }
+
+  # Module Manifest File (module.json)
+  ModuleManifestFile:
+    type: object
+    required: ["formatVersion"]
+    properties:
+      formatVersion:
+        oneOf:
+          - type: string
+            pattern: "^4\\.0\\.0(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$"
+            description: "Semantic version string"
+            examples: ["4.0.0"]
+          - type: integer
+            const: 4
+            description: "Legacy integer format"
+            examples: [4]
+      path:
+        $ref: "#/definitions/ModuleName"
+        description: "Module path (canonical format, e.g., 'my-org/domain')"
+      module:
+        $ref: "#/definitions/ModuleName"
+        description: "Alternative field name for module path (legacy compatibility)"
+      doc:
+        oneOf:
+          - type: string
+            description: "Single-line module documentation"
+          - type: array
+            items: { type: string }
+            description: "Multi-line module documentation"
+        description: "Optional module-level documentation"
+      types:
+        oneOf:
+          - type: array
+            items: { $ref: "#/definitions/Name" }
+            description: "List of type names in this module (manifest style)"
+          - type: object
+            additionalProperties:
+              allOf:
+                - $ref: "#/definitions/AccessControlled"
+                - properties:
+                    value:
+                      oneOf:
+                        - type: object
+                          required: ["doc", "value"]
+                          properties:
+                            doc: { type: string }
+                            value: { $ref: "#/definitions/TypeDefinition" }
+                        - $ref: "#/definitions/TypeDefinition"
+            description: "Inline type definitions (inline style)"
+      values:
+        oneOf:
+          - type: array
+            items: { $ref: "#/definitions/Name" }
+            description: "List of value names in this module (manifest style)"
+          - type: object
+            additionalProperties:
+              allOf:
+                - $ref: "#/definitions/AccessControlled"
+                - properties:
+                    value:
+                      oneOf:
+                        - type: object
+                          required: ["doc", "value"]
+                          properties:
+                            doc: { type: string }
+                            value: { $ref: "#/definitions/ValueDefinition" }
+                        - $ref: "#/definitions/ValueDefinition"
+            description: "Inline value definitions (inline style)"
+    description: |
+      Module manifest file (module.json).
+      
+      Supports two encoding styles:
+      
+      1. **Manifest Style (Granular)**: Lists type/value names, definitions in separate files
+         - formatVersion: Required
+         - path or module: Required, module path
+         - doc: Optional, module documentation
+         - types: Optional, array of type names
+         - values: Optional, array of value names
+      
+      2. **Inline Style (Hybrid)**: Contains definitions directly
+         - formatVersion: Required
+         - path or module: Required, module path
+         - doc: Optional, module documentation
+         - types: Optional, object mapping type names to definitions
+         - values: Optional, object mapping value names to definitions
+      
+      Either 'path' or 'module' field must be present (they are equivalent).
+      The 'path' field is preferred; 'module' is accepted for backwards compatibility.
+      Types and values can be arrays (manifest) or objects (inline), but not mixed.
+    examples:
+      - { "formatVersion": "4.0.0", "path": "my-org/domain", "types": ["user", "order"], "values": ["create-order"] }
+      - { "formatVersion": "4.0.0", "module": "main/domain", "doc": "Domain model", "types": { "user": { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/sdk:string#string" } } }, "values": {} }
+      - { "formatVersion": "4.0.0", "path": "my-org/domain", "doc": "Domain model", "types": ["user", "order"], "values": ["create-order"] }
+      - { "formatVersion": "4.0.0", "module": "my-org/domain", "doc": "Domain model (legacy field)", "types": ["user"], "values": [] }
+
+  # Distribution Manifest File (manifest.json)
+  DistributionManifestFile:
+    type: object
+    required: ["formatVersion", "distribution", "package"]
+    properties:
+      formatVersion:
+        oneOf:
+          - type: string
+            pattern: "^4\\.0\\.0(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$"
+            description: "Semantic version string"
+            examples: ["4.0.0"]
+          - type: integer
+            const: 4
+            description: "Legacy integer format"
+            examples: [4]
+      distribution:
+        enum: ["Library", "Specs", "Application"]
+        description: "Distribution type"
+      package:
+        $ref: "#/definitions/PackageName"
+        description: "Package name (canonical path format)"
+      version:
+        type: string
+        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.-]+)?(\\+[a-zA-Z0-9.-]+)?$"
+        description: "Package version (semantic version)"
+        examples: ["1.2.0", "2.0.0-alpha.1"]
+      created:
+        type: string
+        format: "date-time"
+        description: "ISO 8601 timestamp when distribution was created"
+        examples: ["2026-01-15T12:00:00Z", "2026-01-15T12:00:00+00:00"]
+      layout:
+        enum: ["Classic", "VfsMode"]
+        description: "Distribution layout mode (VfsMode for document tree)"
+        default: "VfsMode"
+      entryPoints:
+        type: object
+        additionalProperties: { $ref: "#/definitions/EntryPoint" }
+        description: |
+          Entry points (required for Application distributions, optional otherwise).
+          Map of entry point names to EntryPoint definitions.
+    description: |
+      Distribution manifest/metadata file (manifest.json).
+      
+      Located at: `.morphir-dist/manifest.json`
+      
+      Contains distribution-level metadata:
+      - formatVersion: Required, IR format version
+      - distribution: Required, distribution type (Library, Specs, Application)
+      - package: Required, package name
+      - version: Optional, package version
+      - created: Optional, creation timestamp (ISO 8601)
+      - layout: Optional, distribution layout (defaults to VfsMode for document tree)
+      - entryPoints: Optional, entry points (required for Application distributions)
+    examples:
+      - { "formatVersion": "4.0.0", "distribution": "Library", "package": "my-org/my-project", "version": "1.2.0", "created": "2026-01-15T12:00:00Z", "layout": "VfsMode" }
+      - { "formatVersion": "4.0.0", "distribution": "Specs", "package": "morphir/sdk", "version": "3.0.0", "created": "2026-01-15T12:00:00Z", "layout": "VfsMode" }
+      - { "formatVersion": "4.0.0", "distribution": "Application", "package": "my-org/my-cli", "version": "2.0.0", "created": "2026-01-15T12:00:00Z", "entryPoints": { "startup": { "target": "my-org/my-cli:main#run", "kind": "main" } } }


### PR DESCRIPTION
This PR adds comprehensive documentation and schemas for VFS (Virtual File System) document tree file formats in Morphir IR V4.

## Changes

- **New Documentation**: `docs/spec/ir/schemas/v4/document-tree-files.md` (1,185 lines)
  - Complete specifications for all VFS file formats
  - Extensive examples (basic, advanced, complete modules)
  - Validation rules and error handling guidance
  - Field details and access control documentation

- **New Schema**: `website/static/schemas/morphir-ir-v4-document-tree-files.yaml` (411 lines)
  - JSON schemas for all document tree file formats
  - Located in website/static/schemas for downloadability
  - Includes examples and descriptions

- **Updated**: `docs/spec/ir/schemas/v4/index.md`
  - Restored "Document Tree File Formats" section with links

## File Formats Documented

1. **Distribution Manifest** (`manifest.json`) - Distribution-level metadata
2. **Module Manifest** (`module.json`) - Module metadata with optional inline definitions
3. **Type Definition Files** (`*.type.json`) - Individual type definitions/specifications
4. **Value Definition Files** (`*.value.json`) - Individual value definitions/specifications

## Features

- ✅ Complete file format specifications
- ✅ JSON schemas for validation
- ✅ Extensive examples (Library, Specs, Application distributions)
- ✅ Validation rules and error handling
- ✅ Advanced examples (incomplete types, external values, complex expressions)
- ✅ Access control documentation
- ✅ Directory structure examples

This fills an important gap in V4 documentation and provides the detailed specifications referenced in design documents.