### PR TITLE
fix: exclude ecosystem submodules from Jekyll processing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@
 exclude:
   - docs/
   - website/
+  - ecosystem/
   - node_modules/
   - vendor/
   - Gemfile


### PR DESCRIPTION
## Summary
Fixes the `actions/jekyll-build-pages` build failure.

## Problem
Ecosystem submodules (like `morphir-python`) contain Python code snippets with `{{ }}` syntax that Jekyll's Liquid engine misinterprets as template variables, causing the build to crash.

## Fix
Added `ecosystem/` to the Jekyll exclude list in `_config.yml` as a safeguard to prevent any submodule content from breaking the build.