### PR TITLE
fix(ci): allow low-download morphir-elm npm install via mise

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -14,7 +14,7 @@ python = "3.14.7"
 # JavaScript runtimes for website and tooling
 node = "24.19.0"
 bun = "1.3.14"
-"npm:morphir-elm" = "2.100.0"
+"npm:morphir-elm" = { version = "2.100.0", allow_low_downloads = true }
 
 # Rust tools
 "cargo:cargo-binstall" = "latest"


### PR DESCRIPTION
## Summary
- mise's npm backend (`aube`) now refuses to install npm packages below a 1000 weekly-download threshold.
- `morphir-elm` sits around 248 weekly downloads, so `mise install`/`mise run init` fails on every CI job that installs the project's full toolset — including `morphir-live` and `morphir CLI`, neither of which actually use morphir-elm. This has been blocking those jobs (see #638, #626, #612).
- Sets `allow_low_downloads = true` on the `npm:morphir-elm` tool entry in `.config/mise/config.toml`, which is the documented per-tool escape hatch for legitimate low-traffic packages.

## Test plan
- [ ] CI green on this PR (morphir-live / morphir CLI jobs run since this touches `.config/mise/`)
- [ ] Re-run CI on #638, #626, #612 after this merges to confirm they go green too