### PR TITLE
feat(templates): embed antitrust voiceover video in meeting agenda

### DIFF
--- a/.github/ISSUE_TEMPLATE/Meeting.md
+++ b/.github/ISSUE_TEMPLATE/Meeting.md
@@ -14,6 +14,8 @@ Thursday DD MMM yyyy - 11am ET / 3pm UK
 
 ## Meeting notices
 
+https://github.com/user-attachments/assets/1089fd7d-5a39-4fa4-84a2-abf852538923
+
 - FINOS **Project leads** are responsible for observing the FINOS guidelines for [running project meetings](https://community.finos.org/docs/governance/meeting-procedures/). Project maintainers can find additional resources in the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
 
 - **All participants** in FINOS project meetings are subject to the [LF Antitrust Policy](https://www.linuxfoundation.org/antitrust-policy/), the [FINOS Community Code of Conduct](https://community.finos.org/docs/governance/code-of-conduct) and all other [FINOS policies](https://community.finos.org/docs/governance/#policies).


### PR DESCRIPTION
## Summary
- Embeds a short inline video right after the "Meeting notices" header in the meeting agenda issue template: an AI voiceover reading the antitrust policy notice over the FINOS Antitrust Policy compliance slide, so attendees can watch/listen instead of reading it themselves each time.
- Uses a `github.com/user-attachments/assets/...` link, which GitHub's issue renderer displays as a native inline video player.

## Test plan
- [ ] Open a new agenda issue from this template (or preview the raw file) and confirm the video renders inline with working playback right below "Meeting notices" and before the existing notice bullets.