### PR TITLE
feat(ecosystem): add morphir-scala submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "ecosystem/morphir-python"]
 	path = ecosystem/morphir-python
 	url = https://github.com/finos/morphir-python.git
+[submodule "ecosystem/morphir-scala"]
+	path = ecosystem/morphir-scala
+	url = https://github.com/finos/morphir-scala.git

--- a/ecosystem/AGENTS.md
+++ b/ecosystem/AGENTS.md
@@ -9,6 +9,7 @@ This directory holds **git submodules** for Morphir ecosystem repositories. Use 
 - **morphir-examples** – Example Morphir projects.
 - **morphir-moonbit** – MoonBit implementation of Morphir tooling.
 - **morphir-python** – Python implementation of Morphir tooling.
+- **morphir-scala** – Scala implementation of Morphir tooling. Mill build, cross-compiled to JVM, JS, and Scala Native.
 
 Do not edit submodule content in-place for long-term changes. Prefer contributing in the submodule's own repo and then updating the submodule ref in finos/morphir when intentional.
 
@@ -54,12 +55,6 @@ mise run test:morphir-moonbit -- morphir-sdk
 
 Valid package names: `morphir-sdk`, `morphir-core`, `morphir-moonbit-bindings`
 
-Changes inside submodules are committed in the submodule repo. The morphir repo only commits the submodule ref when intentionally updating to a new revision.
-
-## Future submodules
-
-When morphir-go, morphir-python, or others are added, they will live under `ecosystem/` with the same pattern. Document any language- or repo-specific usage in this file.
-
 ### morphir-python
 
 Python implementation of Morphir tooling. Uses `uv` for package management and `behave` for BDD tests.
@@ -67,3 +62,25 @@ Python implementation of Morphir tooling. Uses `uv` for package management and `
 ```bash
 cd ecosystem/morphir-python && uv sync && uv run behave
 ```
+
+### morphir-scala
+
+Scala implementation of Morphir tooling. Built with [Mill](https://mill-build.org) through the repo's own `./mill` launcher; the Mill version is pinned in `.mill-version`. finos/morphir defines **no** top-level mise tasks for it — run its tasks from inside the submodule:
+
+```bash
+cd ecosystem/morphir-scala
+
+mise run lint          # Formatting check (./mill --ticker false -i ci.lint)
+mise run test:jvm      # JVM tests
+mise run test:js       # JS tests
+mise run test:native   # Scala Native tests
+mise run ci:local      # Full local CI
+```
+
+Mill can also be driven directly, e.g. `./mill morphir.jvm.compile` or `./mill morphir.tests.jvm.test`. See the submodule's own [AGENTS.md](morphir-scala/AGENTS.md) for the full task list and its Scala coding conventions.
+
+Changes inside submodules are committed in the submodule repo. The morphir repo only commits the submodule ref when intentionally updating to a new revision.
+
+## Future submodules
+
+When morphir-go, morphir-dotnet, or others are added, they will live under `ecosystem/` with the same pattern. Document any language- or repo-specific usage in this file.

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -11,6 +11,7 @@ This directory contains [git submodules](https://git-scm.com/book/en/v2/Git-Tool
 | **morphir-examples** | [finos/morphir-examples](https://github.com/finos/morphir-examples) | main | Example Morphir projects; used for docs, tests, and reference |
 | **morphir-moonbit** | [finos/morphir-moonbit](https://github.com/finos/morphir-moonbit) | main | MoonBit implementation of Morphir tooling |
 | **morphir-python** | [finos/morphir-python](https://github.com/finos/morphir-python) | main | Python implementation of Morphir tooling |
+| **morphir-scala** | [finos/morphir-scala](https://github.com/finos/morphir-scala) | main | Scala implementation of Morphir tooling; Mill build cross-compiled to JVM, JS, and Scala Native |
 
 ## First-time clone
 
@@ -65,6 +66,7 @@ mise run submodules:status
 - **morphir-examples**: Used for examples, documentation, and tests. See each submodule's own README for build and usage.
 - **morphir-moonbit**: MoonBit implementation with packages for SDK, core types, and WASM bindings. See below for build commands.
 - **morphir-python**: Python implementation of Morphir tooling. See the submodule's own README for build and usage.
+- **morphir-scala**: Scala implementation of Morphir tooling, built with Mill. See below for build commands.
 
 ## Building and testing morphir-moonbit
 
@@ -86,6 +88,22 @@ mise run test:morphir-moonbit -- morphir-core
 ```
 
 Valid package names: `morphir-sdk`, `morphir-core`, `morphir-moonbit-bindings`
+
+## Building and testing morphir-scala
+
+morphir-scala is built with [Mill](https://mill-build.org) using the launcher checked into its own repo. There are no top-level `mise` tasks for it in finos/morphir — run its tasks from inside the submodule:
+
+```bash
+cd ecosystem/morphir-scala
+
+mise run lint          # Check formatting
+mise run test:jvm      # Run JVM tests
+mise run test:js       # Run JS tests
+mise run test:native   # Run Scala Native tests
+mise run ci:local      # Run full local CI
+```
+
+Mill can also be invoked directly, e.g. `./mill morphir.jvm.compile`. See the submodule's own [README](morphir-scala/README.md) and [CONTRIBUTING](morphir-scala/CONTRIBUTING.md) for details.
 
 ## Adding a new submodule
 


### PR DESCRIPTION
## Summary

Adds [finos/morphir-scala](https://github.com/finos/morphir-scala) to the `ecosystem/` submodule set, alongside morphir-elm, morphir-rust, morphir-examples, morphir-moonbit, and morphir-python.

Scope is deliberately **submodule registration + documentation only** — no build wiring and no CI changes. morphir-scala is built with Mill from within its own repo, and this PR adds no top-level `mise` tasks for it.

## Changes

- **`.gitmodules`** — new `ecosystem/morphir-scala` entry pointing at `https://github.com/finos/morphir-scala.git`. No `branch =` key, since it tracks `main` (only morphir-elm needs one, for `remixed`).
- **`ecosystem/morphir-scala`** — gitlink pinned at `c9d08e64` (`v0.5.0-M04-96-gc9d08e64`), the current `main` HEAD.
- **`ecosystem/README.md`** — submodules table row, a "How morphir uses them" bullet, and a "Building and testing morphir-scala" section.
- **`ecosystem/AGENTS.md`** — "What lives here" bullet and a `### morphir-scala` build/test section.

### Drive-by fix

`ecosystem/AGENTS.md` had the `### morphir-python` build instructions nested under a **"Future submodules"** heading, even though morphir-python was already added — and that heading's text still listed morphir-python as not-yet-added. This PR moves the morphir-python block up into "Building and Testing" where it belongs, and updates the "Future submodules" note to name repos that genuinely have not been added yet (morphir-go, morphir-dotnet).

## Not changed

- Root `README.md` and `AGENTS.md` already list morphir-scala in their project catalogs (`README.md:73`, `AGENTS.md:18`). Those are project catalogs, not submodule lists, so no edit was needed.
- `_config.yml` already excludes `ecosystem/` wholesale from Jekyll, so no exclusion change was needed.

## Verification

- `git submodule status` — all six submodules registered; `ecosystem/morphir-scala` clean at `c9d08e64`.
- `python3 .config/mise/tasks/ci/validate_docs.py` → `518 markdown files / All checked files are valid / Documentation validation passed!`
- Confirmed every submodule-relative link added (`morphir-scala/AGENTS.md`, `README.md`, `CONTRIBUTING.md`) resolves to a real file.

## Notes for reviewers

- The documented build commands are transcribed from morphir-scala's own `AGENTS.md`; they were **not** executed as part of this PR (no JVM/Mill run), consistent with the docs-only scope.
- Unrelated pre-existing issue found along the way: `mise run submodules:add` fails on arm64 Linux with `aqua:WebAssembly/binaryen@125: unsupported env: linux/arm64 (supported: ["darwin", "amd64"])` — mise provisions the full toolchain before running any task. The task script itself is fine (`python3 .config/mise/tasks/submodules/add.py morphir-scala` worked). Worth its own issue if arm64 Linux is meant to be supported.
