### PR TITLE
fix(mise): install binaryen via the github backend for linux/arm64

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -19,7 +19,7 @@ bun = "1.3.14"
 # Rust tools
 "cargo:cargo-binstall" = "latest"
 "cargo:dioxus-cli" = "latest"       # Provides dx command
-"aqua:WebAssembly/binaryen" = "125" # Provides wasm-opt
+"github:WebAssembly/binaryen" = "version_125" # Provides wasm-opt (aqua backend lacks linux/arm64)
 
 # JSON Schema CLI (https://github.com/sourcemeta/jsonschema)
 jsonschema = "latest"


### PR DESCRIPTION
## Problem

`wasm-opt` is pinned as `"aqua:WebAssembly/binaryen" = "125"`. The aqua registry lists only `darwin` and `amd64` for that package, so on **linux/arm64** mise fails:

```
Failed to install aqua:WebAssembly/binaryen@125:
unsupported env: linux/arm64 (supported: ["darwin", "amd64"])
```

Because mise provisions **every** tool before running **any** task, this single entry blocks all `mise run` invocations on arm64 Linux — including tasks with nothing to do with wasm. `mise run submodules:add`, `mise run ci:validate-docs`, and the rest all fail at provisioning.

## This is a registry gap, not an upstream limitation

binaryen publishes an arm64 Linux build. From the `version_125` release assets:

```
binaryen-version_125-aarch64-linux.tar.gz     ← exists
binaryen-version_125-x86_64-linux.tar.gz
binaryen-version_125-arm64-macos.tar.gz
binaryen-version_125-x86_64-macos.tar.gz
```

Only aqua's metadata is missing the platform. Switching to the `github` backend resolves the release asset directly and picks the right one per platform.

## Verification

On linux/arm64 (Ubuntu 26.04, `mise 2026.8.10 linux-arm64`):

```
$ mise x github:WebAssembly/binaryen@version_125 -- wasm-opt --version
mise github:WebAssembly/binaryen ... verify SLSA provenance
mise github:WebAssembly/binaryen ... extract binaryen-version_125-aarch64-linux.tar.gz
mise github:WebAssembly/binaryen ✓ installed
wasm-opt version 125 (version_125)
```

Correct asset selected, SLSA provenance verified, same pinned version (**125**) on every platform. No version change — only the backend.

The `github` backend is also the non-deprecated choice: mise warns that `ubi` is removed in 2027.1.0.

## Note on local verification

I could not verify a full `mise run` on this machine, and want to be explicit about why. My worktree lives at `.claude/worktrees/` *inside* the main checkout, so mise merges both configs:

```
.../finos/morphir/.config/mise/config.toml                    aqua:WebAssembly/binaryen   ← parent
.../worktrees/chore+dependency-refresh/.config/mise/...       github:WebAssembly/binaryen ← this change
```

The parent's `aqua:` entry still applies and still fails. That's an artifact of the nested worktree, not of this change — a normal checkout or CI sees only one config. Once this is on `main`, `mise run` should work on arm64 Linux.
