### PR TITLE
ci: add missing path filters so changed inputs trigger their jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,19 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'crates/**'
+              # crates/morphir and crates/morphir-live path-depend on crates
+              # inside this submodule, so a ref bump changes compiled source
+              - 'ecosystem/morphir-rust'
+              - '.gitmodules'
+              # pins the Rust toolchain these jobs build with
+              - '.config/mise/**'
               - '.github/workflows/ci.yml'
             docs:
               - 'website/**'
               - 'docs/**'
               - '**/*.md'
+              # the script the Docs job runs
+              - '.config/mise/tasks/ci/validate_docs.py'
               - '.github/workflows/ci.yml'
 
   # morphir-live: web UI application (depends on dioxus)


### PR DESCRIPTION
## Problem

`Detect Changes` gates the Rust and Docs jobs on path filters, but several inputs those jobs actually depend on weren't listed. Changing them ran **no jobs**, so CI reported green without building anything.

Three cases hit this in the last day:

| PR | Change | Rust jobs |
|---|---|---|
| #675 | rustc **1.97.1 → 1.98.0** | **skipped** |
| #684 | mise tool backend | **skipped** |
| #677 | morphir-rust submodule bump | ran, but only because it also touched `Cargo.lock` |

A compiler upgrade landed with nothing compiled. That's the same class of blind spot that let the pager clippy lints sit on `main` unnoticed until #679 — new clippy lints ship with new toolchains.

## Changes

**`rust` filter**

```yaml
- 'ecosystem/morphir-rust'   # path-dep source
- '.gitmodules'
- '.config/mise/**'          # pins the Rust toolchain
```

- **`ecosystem/morphir-rust`** — `crates/morphir` and `crates/morphir-live` path-depend on crates *inside* this submodule, so a ref bump changes the source being compiled. A submodule-only bump previously ran nothing.
- **`.gitmodules`** — same reasoning, for submodule wiring.
- **`.config/mise/**`** — pins the toolchain the jobs build with.

**`docs` filter**

```yaml
- '.config/mise/tasks/ci/validate_docs.py'
```

The Docs job runs this script, but editing it triggered no job.

## Verification

Validated both levels — the workflow itself, and the `filters` block as **dorny/paths-filter** parses it (it's a block scalar, so the `#` lines are YAML comments inside a string):

```json
{
 "rust": ["Cargo.toml","Cargo.lock","crates/**","ecosystem/morphir-rust",
          ".gitmodules",".config/mise/**",".github/workflows/ci.yml"],
 "docs": ["website/**","docs/**","**/*.md",
          ".config/mise/tasks/ci/validate_docs.py",".github/workflows/ci.yml"]
}
```

7 rust patterns, 5 docs patterns, comments stripped correctly.

This PR touches `ci.yml`, which is in both filters, so its own run exercises the change end to end.

## Note on the website

An earlier revision of this description claimed no job builds the website. **That was wrong** — Netlify does. `netlify.toml` runs the real Docusaurus build:

```toml
base = "website"
command = "npm run build"
ignore = "... git diff --quiet \"$CACHED_COMMIT_REF\" \"$COMMIT_REF\" -- ':(top)website' ':(top)docs'"
```

The `ignore` clause skips the build only when neither `website/` nor `docs/` changed, which is why Rust-only PRs show "Deploy Preview canceled" — that's the skip working as designed, not missing coverage.

So the website is covered; it's just covered by Netlify rather than by this workflow. No filter change is needed for it, and none is made here.
