### PR TITLE
docs: specify morphir.yaml configuration format

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# Morphir
+
+Morphir represents business logic as a language-neutral model and provides tools that read, transform, and generate that model.
+
+## Language
+
+**Configuration model**:
+The nested set of Morphir settings after parsing, independent of the file syntax used to write them.
+_Avoid_: TOML model, YAML model
+
+**Configuration serialization**:
+A file syntax that represents the configuration model, such as TOML or YAML.
+_Avoid_: Configuration model
+
+**Effective configuration**:
+The configuration model produced after Morphir merges defaults and configured sources in precedence order.
+_Avoid_: Final file, merged file

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,3 +15,11 @@ _Avoid_: Configuration model
 **Effective configuration**:
 The configuration model produced after Morphir merges defaults and configured sources in precedence order.
 _Avoid_: Final file, merged file
+
+**Global user configuration**:
+Configuration that applies to every Morphir workspace for one operating-system user.
+_Avoid_: User override, project configuration
+
+**User override**:
+Personal configuration for one Morphir project, stored inside that project's `.morphir` directory.
+_Avoid_: Global user configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Understand the fundamental concepts behind Morphir
 Formal specifications for Morphir configuration and IR formats
 - [Overview](spec/index.md) - Specifications overview
 - [morphir.toml](spec/morphir-toml/morphir-toml-specification.md) - `morphir.toml` format
+- [morphir.yaml](spec/morphir-yaml/morphir-yaml-specification.md) - Proposed YAML equivalent of `morphir.toml`
 - [morphir.json](spec/morphir-json/morphir-json-specification.md) - `morphir.json` format (morphir-elm legacy)
 - [Morphir IR Specification](spec/ir/morphir-ir-specification.md) - Detailed IR specification
 - [Morphir IR JSON Schemas](spec/ir/schemas/) - JSON schemas for IR versions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ Morphir loads configuration from multiple sources, merged in priority order:
 |----------|--------|------|---------|
 | 1 (lowest) | Built-in defaults | (compiled in) | Sensible defaults |
 | 2 | System config | `/etc/morphir/morphir.toml` | System-wide settings |
-| 3 | Global user config | `~/.config/morphir/morphir.toml` or `~/.morphir/morphir.toml` | User preferences |
+| 3 | Global user config | Platform config directory or user-home `.morphir` directory | User preferences |
 | 4 | Project config | `morphir.toml` or `.morphir/morphir.toml` | Project settings |
 | 5 | User override | `.morphir/morphir.user.toml` | Local overrides (gitignored) |
 | 6 (highest) | Environment variables | `MORPHIR_*` | Runtime overrides |
@@ -53,14 +53,22 @@ my-project/
 
 ### Global User Configuration
 
-Create one global user file for settings that apply to all projects:
+Create one global user file for settings that apply to all projects.
 
-- `~/.config/morphir/morphir.toml`
-- `~/.morphir/morphir.toml`
-- `~/.config/morphir/morphir.yaml`
-- `~/.morphir/morphir.yaml`
+On Linux and other XDG systems, Morphir checks:
 
-The paths are alternatives at the same precedence. If more than one exists, Morphir reports an ambiguity error.
+- `$XDG_CONFIG_HOME/morphir/morphir.toml` or `morphir.yaml` when `XDG_CONFIG_HOME` is an absolute path
+- `$HOME/.config/morphir/morphir.toml` or `morphir.yaml` when `XDG_CONFIG_HOME` is unset, empty, or relative
+- `$HOME/.morphir/morphir.toml` or `morphir.yaml`
+
+On macOS, Morphir checks a valid `$XDG_CONFIG_HOME` first. Without it, the standard location is `$HOME/Library/Application Support/morphir/morphir.toml` or `morphir.yaml`. The `$HOME/.morphir` alternative also applies.
+
+On Windows, Morphir checks:
+
+- `%APPDATA%\morphir\morphir.toml` or `morphir.yaml`, resolved through the Windows `FOLDERID_RoamingAppData` known folder
+- `%USERPROFILE%\.morphir\morphir.toml` or `morphir.yaml`, resolved through `FOLDERID_Profile`
+
+The paths are alternatives at the same precedence. If more than one candidate exists, Morphir reports an ambiguity error.
 
 TOML example:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ Morphir loads configuration from multiple sources, merged in priority order:
 |----------|--------|------|---------|
 | 1 (lowest) | Built-in defaults | (compiled in) | Sensible defaults |
 | 2 | System config | `/etc/morphir/morphir.toml` | System-wide settings |
-| 3 | Global user config | `~/.config/morphir/morphir.toml` | User preferences |
+| 3 | Global user config | `~/.config/morphir/morphir.toml` or `~/.morphir/morphir.toml` | User preferences |
 | 4 | Project config | `morphir.toml` or `.morphir/morphir.toml` | Project settings |
 | 5 | User override | `.morphir/morphir.user.toml` | Local overrides (gitignored) |
 | 6 (highest) | Environment variables | `MORPHIR_*` | Runtime overrides |
@@ -53,7 +53,16 @@ my-project/
 
 ### Global User Configuration
 
-Create `~/.config/morphir/morphir.toml` for settings that apply to all projects:
+Create one global user file for settings that apply to all projects:
+
+- `~/.config/morphir/morphir.toml`
+- `~/.morphir/morphir.toml`
+- `~/.config/morphir/morphir.yaml`
+- `~/.morphir/morphir.yaml`
+
+The paths are alternatives at the same precedence. If more than one exists, Morphir reports an ambiguity error.
+
+TOML example:
 
 ```toml
 [logging]
@@ -61,6 +70,16 @@ level = "debug"
 
 [ui]
 theme = "dark"
+```
+
+YAML example:
+
+```yaml
+logging:
+  level: debug
+
+ui:
+  theme: dark
 ```
 
 ### System Configuration

--- a/docs/design/draft/daemon/environment.md
+++ b/docs/design/draft/daemon/environment.md
@@ -41,9 +41,10 @@ The Morphir configuration directory.
 
 | Aspect | Value |
 |--------|-------|
-| Default (Linux/macOS) | `$XDG_CONFIG_HOME/morphir` or `~/.config/morphir` |
-| Default (Windows) | `%APPDATA%\morphir` |
-| Contains | `config.toml`, credentials |
+| Default (Linux) | `$XDG_CONFIG_HOME/morphir` or `~/.config/morphir` |
+| Default (macOS) | `$XDG_CONFIG_HOME/morphir` or `~/Library/Application Support/morphir` |
+| Default (Windows) | `FOLDERID_RoamingAppData\morphir`, typically `%APPDATA%\morphir` |
+| Contains | `morphir.toml` or `morphir.yaml`, credentials |
 
 ```bash
 export MORPHIR_CONFIG_HOME="/etc/morphir"
@@ -385,7 +386,7 @@ export MORPHIR_PROFILE="true"
 
 ## Platform-Specific Variables
 
-### Linux/macOS
+### Linux and macOS
 
 ```bash
 # XDG Base Directory Specification
@@ -396,10 +397,12 @@ export XDG_CACHE_HOME="$HOME/.cache"
 
 Morphir respects XDG variables when `MORPHIR_*` equivalents are not set.
 
+XDG paths must be absolute. Morphir ignores a relative path and uses the platform default.
+
 ### Windows
 
 ```cmd
-REM Standard Windows locations
+REM Typical Windows locations. Implementations use Known Folder APIs.
 set LOCALAPPDATA=%USERPROFILE%\AppData\Local
 set APPDATA=%USERPROFILE%\AppData\Roaming
 ```

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -15,6 +15,8 @@ This section contains formal specifications for Morphir configuration and IR for
 
 - **[morphir.toml merge rules](./morphir-toml/morphir-toml-merge-rules/)**: How multiple configuration sources are merged into an effective configuration (precedence + deep-merge behavior).
 
+- **[morphir.yaml](./morphir-yaml/morphir-yaml-specification/)**: Proposed YAML serialization of the Morphir configuration model.
+
 - **[morphir.json](./morphir-json/morphir-json-specification/)**: Specification for the legacy `morphir.json` project configuration file used by `morphir-elm` (includes dependency fields).
 
 - **[Morphir IR Specification](./ir/morphir-ir-specification/)**: The complete Morphir IR specification document, describing the structure, semantics, and usage of the Morphir IR format.
@@ -40,4 +42,3 @@ This specifications section serves as the authoritative reference for:
 - [Morphir Project](https://morphir.finos.org/)
 - [Morphir Repository](https://github.com/finos/morphir)
 - [Morphir .NET Repository](https://github.com/finos/morphir-dotnet)
-

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -23,7 +23,7 @@ Sources are loaded from **lowest precedence** to **highest precedence**:
 |----------|--------|--------------|
 | 1 (lowest) | Built-in defaults | (compiled in) |
 | 2 | System config | `/etc/morphir/morphir.toml` |
-| 3 | Global user config | `~/.config/morphir/morphir.toml` or `~/.morphir/morphir.toml` |
+| 3 | Global user config | Platform config directory or user-home `.morphir` directory |
 | 4 | Project config | `morphir.toml` |
 | 5 | User override | `.morphir/morphir.user.toml` |
 | 6 (highest) | Environment variables | `MORPHIR_*` |
@@ -32,7 +32,38 @@ If the same setting is present in multiple sources, **the value from the highest
 
 > Note: A “hidden project config” variant (`.morphir/morphir.toml`) may also be used by some commands/workflows. The merge semantics are identical.
 
-The two global user paths are alternate locations at the same precedence. A loader accepts at most one global user configuration across these directories and the supported TOML and YAML serializations. If it finds more than one candidate, it reports an ambiguity error instead of merging the files or choosing one by path or extension.
+### Global user path resolution
+
+A loader MUST resolve the platform config directory as follows:
+
+| Platform | Config directory |
+| --- | --- |
+| Linux and other XDG systems | `$XDG_CONFIG_HOME` when it is set to a non-empty absolute path; otherwise `$HOME/.config` |
+| macOS | `$XDG_CONFIG_HOME` when it is set to a non-empty absolute path; otherwise `$HOME/Library/Application Support` |
+| Windows | `FOLDERID_RoamingAppData`, typically `%APPDATA%` |
+
+This follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/) and the Windows [Known Folder API](https://learn.microsoft.com/windows/win32/shell/known-folders). On an XDG system, a relative `XDG_CONFIG_HOME` value is invalid and MUST be ignored. The loader then uses the platform default. `XDG_CONFIG_DIRS` does not define the global user location.
+
+Examples:
+
+| Environment | Resolved YAML candidate |
+| --- | --- |
+| Linux with `XDG_CONFIG_HOME=/srv/alice/config` | `/srv/alice/config/morphir/morphir.yaml` |
+| Linux with `XDG_CONFIG_HOME` unset, empty, or relative | `/home/alice/.config/morphir/morphir.yaml` |
+| macOS without `XDG_CONFIG_HOME` | `/Users/Alice/Library/Application Support/morphir/morphir.yaml` |
+| Windows with Roaming AppData at `D:\Profiles\Alice\Roaming` | `D:\Profiles\Alice\Roaming\morphir\morphir.yaml` |
+
+The standard global user candidates are:
+
+- `<config-directory>/morphir/morphir.toml`
+- `<config-directory>/morphir/morphir.yaml`
+
+The user-home alternatives are:
+
+- `$HOME/.morphir/morphir.toml` and `$HOME/.morphir/morphir.yaml` on Unix-like systems
+- `%USERPROFILE%\.morphir\morphir.toml` and `%USERPROFILE%\.morphir\morphir.yaml` on Windows, where the implementation resolves the profile through `FOLDERID_Profile`
+
+These paths are alternate locations at the same precedence. A loader accepts at most one global user configuration across all candidates. If it finds more than one, it reports an ambiguity error that names every candidate. It MUST NOT merge the files or choose one by path or extension.
 
 ## Merge algorithm (normative)
 

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -1,13 +1,13 @@
 ---
 id: morphir-toml-merge-rules
-title: "Morphir TOML Configuration Merge Rules"
+title: "Morphir configuration merge rules"
 sidebar_position: 3
-description: "How Morphir merges morphir.toml configuration sources into an effective configuration"
+description: "How Morphir merges configuration sources into an effective configuration"
 ---
 
 ## Purpose
 
-Morphir configuration is **layered**: multiple configuration sources are loaded and merged to produce one **effective configuration**.
+Morphir configuration is **layered**: multiple configuration sources are loaded and merged to produce one **effective configuration**. The algorithm operates on parsed configuration values and is independent of whether a source uses TOML or YAML.
 
 This document specifies:
 
@@ -34,7 +34,7 @@ If the same setting is present in multiple sources, **the value from the highest
 
 ## Merge algorithm (normative)
 
-Let each configuration source be represented as a nested object \(map\) `map[string]any` produced from TOML or environment variables.
+Let each configuration source be represented as a nested object \(map\) `map[string]any` produced from TOML, YAML, or environment variables.
 
 The effective configuration is computed by applying `DeepMerge` from low precedence to high precedence:
 
@@ -80,4 +80,4 @@ Key mapping:
 
 - `docs/configuration.md` (user-facing configuration guide)
 - `docs/spec/morphir-toml/morphir-toml-specification.md` (format/structure specification)
-
+- `docs/spec/morphir-yaml/morphir-yaml-specification.md` (proposed YAML serialization)

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -23,7 +23,7 @@ Sources are loaded from **lowest precedence** to **highest precedence**:
 |----------|--------|--------------|
 | 1 (lowest) | Built-in defaults | (compiled in) |
 | 2 | System config | `/etc/morphir/morphir.toml` |
-| 3 | Global user config | `~/.config/morphir/morphir.toml` |
+| 3 | Global user config | `~/.config/morphir/morphir.toml` or `~/.morphir/morphir.toml` |
 | 4 | Project config | `morphir.toml` |
 | 5 | User override | `.morphir/morphir.user.toml` |
 | 6 (highest) | Environment variables | `MORPHIR_*` |
@@ -31,6 +31,8 @@ Sources are loaded from **lowest precedence** to **highest precedence**:
 If the same setting is present in multiple sources, **the value from the highest-precedence source wins**, subject to the merge algorithm described below.
 
 > Note: A “hidden project config” variant (`.morphir/morphir.toml`) may also be used by some commands/workflows. The merge semantics are identical.
+
+The two global user paths are alternate locations at the same precedence. A loader accepts at most one global user configuration across these directories and the supported TOML and YAML serializations. If it finds more than one candidate, it reports an ambiguity error instead of merging the files or choosing one by path or extension.
 
 ## Merge algorithm (normative)
 

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -19,6 +19,8 @@ This document specifies the **`morphir.toml`** configuration format used by Morp
 
 Morphir tooling treats a directory as a “workspace” when it contains a `morphir.toml` file (or the hidden variant `.morphir/morphir.toml`).
 
+Global user configuration may use `~/.config/morphir/morphir.toml` or `~/.morphir/morphir.toml`. These are alternate locations at the same precedence. See the merge rules for conflict handling across locations and serializations.
+
 > This spec focuses on the **file format**, not the multi-source merge rules. For merge precedence and merge behavior, see **[Morphir TOML Configuration Merge Rules](./morphir-toml-merge-rules/)**.
 
 ## Data model

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -13,6 +13,8 @@ This document specifies the **`morphir.toml`** configuration format used by Morp
 - **Applies to**: Configuration parsed into `pkg/config.Config`
 - **Out of scope**: Morphir IR JSON format (see the IR specification and schemas)
 
+`morphir.yaml` is a proposed second serialization of this configuration model. See the [Morphir YAML configuration specification](../morphir-yaml/morphir-yaml-specification/).
+
 ## Files and discovery
 
 Morphir tooling treats a directory as a “workspace” when it contains a `morphir.toml` file (or the hidden variant `.morphir/morphir.toml`).
@@ -198,4 +200,3 @@ This specification is accompanied by a JSON Schema for the equivalent JSON model
 
 - `https://morphir.finos.org/schemas/morphir-config-v1.yaml`
 - `https://morphir.finos.org/schemas/morphir-config-v1.json`
-

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -19,7 +19,7 @@ This document specifies the **`morphir.toml`** configuration format used by Morp
 
 Morphir tooling treats a directory as a “workspace” when it contains a `morphir.toml` file (or the hidden variant `.morphir/morphir.toml`).
 
-Global user configuration may use `~/.config/morphir/morphir.toml` or `~/.morphir/morphir.toml`. These are alternate locations at the same precedence. See the merge rules for conflict handling across locations and serializations.
+Global user configuration may use the platform config directory or the `.morphir` directory in the user's home. See the [global user path resolution rules](./morphir-toml-merge-rules/#global-user-path-resolution) for XDG, macOS, Windows, and conflict handling.
 
 > This spec focuses on the **file format**, not the multi-source merge rules. For merge precedence and merge behavior, see **[Morphir TOML Configuration Merge Rules](./morphir-toml-merge-rules/)**.
 

--- a/docs/spec/morphir-yaml/_category_.yml
+++ b/docs/spec/morphir-yaml/_category_.yml
@@ -1,0 +1,3 @@
+label: 'morphir.yaml'
+position: 2
+collapsed: true

--- a/docs/spec/morphir-yaml/morphir-yaml-specification.md
+++ b/docs/spec/morphir-yaml/morphir-yaml-specification.md
@@ -1,0 +1,274 @@
+---
+id: morphir-yaml-specification
+title: "Morphir YAML configuration specification"
+sidebar_position: 1
+description: "Proposed specification for morphir.yaml configuration files"
+---
+
+## Status and scope
+
+This document specifies the proposed `morphir.yaml` configuration format. It is a second serialization of the same configuration model as `morphir.toml`.
+
+- Status: Draft design. Repository tooling does not yet claim support for loading `morphir.yaml`.
+- Applies to: Project, workspace, user, and system configuration.
+- Out of scope: Morphir IR YAML and the legacy `morphir.json` project file.
+
+The words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY state requirements for conforming implementations.
+
+## Design rule
+
+Parsing equivalent TOML and YAML files MUST produce the same nested configuration value. Field names, defaults, validation, path resolution, and merge behavior do not change with the serialization.
+
+For example, these documents are equivalent:
+
+```toml title="morphir.toml"
+[project]
+name = "acme/orders"
+source_directory = "src"
+exposed_modules = ["Orders.Api", "Orders.Types"]
+
+[ir]
+format_version = 3
+strict_mode = true
+```
+
+```yaml title="morphir.yaml"
+project:
+  name: acme/orders
+  source_directory: src
+  exposed_modules:
+    - Orders.Api
+    - Orders.Types
+
+ir:
+  format_version: 3
+  strict_mode: true
+```
+
+Both parse to:
+
+```json
+{
+  "project": {
+    "name": "acme/orders",
+    "source_directory": "src",
+    "exposed_modules": ["Orders.Api", "Orders.Types"]
+  },
+  "ir": {
+    "format_version": 3,
+    "strict_mode": true
+  }
+}
+```
+
+## YAML profile
+
+A `morphir.yaml` file MUST meet these syntax rules:
+
+- Use YAML 1.2 and the Core Schema.
+- Encode the file as UTF-8.
+- Contain exactly one YAML document.
+- Use a mapping at the document root.
+- Use strings for every mapping key. Keys are case-sensitive.
+- Use only values that have a direct TOML and JSON representation: mappings, sequences, strings, finite numbers, and booleans.
+- Reject null values. Omit an optional key instead.
+- Reject duplicate mapping keys.
+- Reject custom tags, anchors, aliases, and the YAML merge key `<<`.
+
+These limits remove features that YAML libraries handle differently. They also make conversion to the shared JSON-equivalent configuration model deterministic.
+
+Authors SHOULD quote a string when a reader could mistake it for another scalar type. This is especially useful for versions, durations, dates, and strings such as `null`, `true`, or `1.0`.
+
+```yaml
+project:
+  version: "1.0"
+
+toolchain:
+  morphir-elm:
+    timeout: "5m"
+```
+
+## Configuration model
+
+The root mapping accepts the same optional keys as `morphir.toml`:
+
+| Key | Value | Meaning |
+| --- | --- | --- |
+| `morphir` | mapping | Morphir IR version constraints |
+| `workspace` | mapping | Workspace discovery and output layout |
+| `project` | mapping | Project metadata and decorations |
+| `ir` | mapping | IR processing settings |
+| `codegen` | mapping | Code generation settings |
+| `cache` | mapping | Cache settings |
+| `logging` | mapping | Logging settings |
+| `ui` | mapping | UI and TUI settings |
+| `tasks` | mapping | Project task definitions |
+| `workflows` | mapping | Named workflows |
+| `bindings` | mapping | External binding type mappings |
+| `toolchain` | mapping | External tool adapters and task catalogs |
+
+The field definitions, allowed values, defaults, and constraints in the [Morphir TOML configuration specification](../morphir-toml/morphir-toml-specification/) are normative for both serializations. In YAML, each TOML table becomes a mapping and each TOML array becomes a sequence. Snake-case field names remain unchanged.
+
+The machine-readable definition is the shared [Morphir configuration schema](/schemas/morphir-config-v1.yaml). A loader MUST validate the parsed configuration value, not the YAML syntax tree, against that schema.
+
+Unknown properties follow the shared schema. Version 1 currently permits them so tools can add settings without invalidating the whole document. A tool MAY warn when it does not recognize a property, but it MUST preserve the distinction between an unknown property and a known property with an invalid value.
+
+## File names and discovery
+
+`morphir.yaml` is the canonical YAML file name. A conforming implementation MUST NOT discover `morphir.yml` implicitly. A user may still select a `.yml` file through a command option that accepts an explicit path.
+
+YAML uses the locations corresponding to the TOML configuration sources:
+
+| Precedence | YAML path |
+| --- | --- |
+| System | `/etc/morphir/morphir.yaml` |
+| Global user | `~/.config/morphir/morphir.yaml` |
+| Project | `morphir.yaml` or `.morphir/morphir.yaml` |
+| User override | `.morphir/morphir.user.yaml` |
+
+Built-in defaults and `MORPHIR_*` environment variables have no file serialization.
+
+At one location, a loader MUST accept at most one serialization. If corresponding TOML and YAML files both exist, discovery MUST fail with an ambiguity error that names both files. A loader MUST NOT merge sibling TOML and YAML files or choose one by extension precedence.
+
+The hidden and non-hidden project paths are alternate locations, not two merge layers. If both exist, discovery MUST report the same kind of ambiguity.
+
+## Merge behavior
+
+After parsing, YAML sources use the [Morphir configuration merge rules](../morphir-toml/morphir-toml-merge-rules/). The merge algorithm operates on the configuration model, so maps merge recursively, sequences replace earlier sequences, and later sources take precedence.
+
+## Complete example
+
+```yaml title="morphir.yaml"
+morphir:
+  version: "^3.0.0"
+
+workspace:
+  output_dir: .morphir
+  members:
+    - packages/*
+  exclude:
+    - packages/experimental-*
+  default_member: packages/orders
+
+project:
+  name: acme/orders
+  version: "1.2.0"
+  source_directory: src
+  exposed_modules:
+    - Orders.Api
+  module_prefix: Orders
+  decorations:
+    pii:
+      display_name: Personal data
+      ir: decorations/pii-ir.json
+      entry_point: Acme.Decorations:Pii:Definition
+      storage_location: decorations/pii-values.json
+
+ir:
+  format_version: 3
+  strict_mode: true
+
+codegen:
+  targets:
+    - go
+    - json-schema
+  template_dir: templates
+  output_format: pretty
+
+cache:
+  enabled: true
+  dir: .morphir/cache
+  max_size: 1073741824
+
+logging:
+  level: info
+  format: text
+
+ui:
+  color: true
+  interactive: true
+  theme: default
+
+tasks:
+  compile:
+    kind: intrinsic
+    action: morphir.pipeline.compile
+    inputs:
+      - src/**/*.elm
+    outputs:
+      - .morphir/morphir-ir.json
+    params:
+      optimize: true
+  check-generated:
+    kind: command
+    cmd:
+      - git
+      - diff
+      - --exit-code
+      - generated
+    depends_on:
+      - compile
+    env:
+      CI: "true"
+
+workflows:
+  verify:
+    description: Compile the model and check generated files
+    stages:
+      - name: build
+        targets:
+          - compile
+      - name: check
+        targets:
+          - check-generated
+        parallel: false
+
+bindings:
+  wit:
+    primitives:
+      - external: u64
+        morphir: Morphir.SDK:Int:Int
+        bidirectional: true
+        priority: 100
+
+toolchain:
+  morphir-elm:
+    enabled: true
+    version: "2.90.0"
+    working_dir: .
+    timeout: "5m"
+    acquire:
+      backend: path
+      executable: morphir-elm
+    tasks:
+      make:
+        exec: morphir-elm
+        args:
+          - make
+        fulfills:
+          - make
+        inputs:
+          files:
+            - src/**/*.elm
+        outputs:
+          ir:
+            path: .morphir/morphir-ir.json
+            type: morphir-ir
+```
+
+## Conversion requirements
+
+A TOML-to-YAML converter MUST preserve the parsed configuration value. Comments, key order, quoting style, and whitespace are presentation details and do not need to survive conversion.
+
+A converter MUST report a value that the target serialization cannot represent without loss. It MUST NOT coerce that value silently. Every field defined by the shared configuration schema has a direct representation in both formats.
+
+## Implementation checklist
+
+A Morphir tool that adds YAML support should:
+
+1. Discover `morphir.yaml` at the supported source locations.
+2. Detect sibling-file and alternate-project-path ambiguity before loading configuration.
+3. Parse the restricted YAML 1.2 profile into the shared configuration model.
+4. Validate that value with `morphir-config-v1`.
+5. Apply the serialization-independent merge rules.
+6. Include the source path and YAML location in parse and validation diagnostics.

--- a/docs/spec/morphir-yaml/morphir-yaml-specification.md
+++ b/docs/spec/morphir-yaml/morphir-yaml-specification.md
@@ -122,13 +122,15 @@ YAML uses the locations corresponding to the TOML configuration sources:
 | Precedence | YAML path |
 | --- | --- |
 | System | `/etc/morphir/morphir.yaml` |
-| Global user | `~/.config/morphir/morphir.yaml` |
+| Global user | `~/.config/morphir/morphir.yaml` or `~/.morphir/morphir.yaml` |
 | Project | `morphir.yaml` or `.morphir/morphir.yaml` |
 | User override | `.morphir/morphir.user.yaml` |
 
 Built-in defaults and `MORPHIR_*` environment variables have no file serialization.
 
-At one location, a loader MUST accept at most one serialization. If corresponding TOML and YAML files both exist, discovery MUST fail with an ambiguity error that names both files. A loader MUST NOT merge sibling TOML and YAML files or choose one by extension precedence.
+The two global user paths are alternate locations at the same precedence. Across both directories and both serializations, a loader MUST discover at most one global user file. If it finds more than one, discovery MUST fail with an ambiguity error that names every candidate. A loader MUST NOT merge global user files or choose one by directory or extension precedence.
+
+At any other location, a loader MUST accept at most one serialization. If corresponding TOML and YAML files both exist, discovery MUST fail with an ambiguity error that names both files. A loader MUST NOT merge sibling TOML and YAML files or choose one by extension precedence.
 
 The hidden and non-hidden project paths are alternate locations, not two merge layers. If both exist, discovery MUST report the same kind of ambiguity.
 

--- a/docs/spec/morphir-yaml/morphir-yaml-specification.md
+++ b/docs/spec/morphir-yaml/morphir-yaml-specification.md
@@ -122,13 +122,13 @@ YAML uses the locations corresponding to the TOML configuration sources:
 | Precedence | YAML path |
 | --- | --- |
 | System | `/etc/morphir/morphir.yaml` |
-| Global user | `~/.config/morphir/morphir.yaml` or `~/.morphir/morphir.yaml` |
+| Global user | `<platform-config-directory>/morphir/morphir.yaml` or `<user-home>/.morphir/morphir.yaml` |
 | Project | `morphir.yaml` or `.morphir/morphir.yaml` |
 | User override | `.morphir/morphir.user.yaml` |
 
 Built-in defaults and `MORPHIR_*` environment variables have no file serialization.
 
-The two global user paths are alternate locations at the same precedence. Across both directories and both serializations, a loader MUST discover at most one global user file. If it finds more than one, discovery MUST fail with an ambiguity error that names every candidate. A loader MUST NOT merge global user files or choose one by directory or extension precedence.
+The [global user path resolution rules](../morphir-toml/morphir-toml-merge-rules/#global-user-path-resolution) define the XDG, macOS, and Windows directories for both serializations. The two directories are alternate locations at the same precedence. Across both directories and both serializations, a loader MUST discover at most one global user file. If it finds more than one, discovery MUST fail with an ambiguity error that names every candidate. A loader MUST NOT merge global user files or choose one by directory or extension precedence.
 
 At any other location, a loader MUST accept at most one serialization. If corresponding TOML and YAML files both exist, discovery MUST fail with an ambiguity error that names both files. A loader MUST NOT merge sibling TOML and YAML files or choose one by extension precedence.
 

--- a/examples/morphir.toml
+++ b/examples/morphir.toml
@@ -5,6 +5,7 @@
 #   1. Built-in defaults (lowest priority)
 #   2. System config: /etc/morphir/morphir.toml
 #   3. Global user config: ~/.config/morphir/morphir.toml
+#      or ~/.morphir/morphir.toml (alternate location at the same priority)
 #   4. This project config: morphir.toml or .morphir/morphir.toml
 #   5. User override: .morphir/morphir.user.toml (gitignored)
 #   6. Environment variables: MORPHIR_* (highest priority)

--- a/examples/morphir.toml
+++ b/examples/morphir.toml
@@ -4,8 +4,8 @@
 # Configuration is loaded from multiple sources in priority order:
 #   1. Built-in defaults (lowest priority)
 #   2. System config: /etc/morphir/morphir.toml
-#   3. Global user config: ~/.config/morphir/morphir.toml
-#      or ~/.morphir/morphir.toml (alternate location at the same priority)
+#   3. Global user config: <platform-config-dir>/morphir/morphir.toml
+#      or <user-home>/.morphir/morphir.toml (same priority)
 #   4. This project config: morphir.toml or .morphir/morphir.toml
 #   5. User override: .morphir/morphir.user.toml (gitignored)
 #   6. Environment variables: MORPHIR_* (highest priority)

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,8 @@
 		"write-heading-ids": "npm run docusaurus -- write-heading-ids",
 		"typecheck": "tsc",
 		"build:worker": "node scripts/build-validation-worker.js",
-		"build:schemas": "node scripts/yaml-to-json-schemas.js"
+		"build:schemas": "node scripts/yaml-to-json-schemas.js",
+		"test:config-schema": "node scripts/test-morphir-config-schema.js"
 	},
 	"dependencies": {
 		"effect": "3.22.1",

--- a/website/scripts/test-morphir-config-schema.js
+++ b/website/scripts/test-morphir-config-schema.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+const yaml = require('js-yaml');
+
+const schemasDirectory = path.resolve(__dirname, '..', 'static', 'schemas');
+
+const cases = [
+  ['empty configuration', {}, true],
+  ['intrinsic task with omitted kind', { tasks: { build: { action: 'morphir.pipeline.compile' } } }, true],
+  ['explicit intrinsic task', { tasks: { build: { kind: 'intrinsic', action: 'morphir.pipeline.compile' } } }, true],
+  ['command task', { tasks: { build: { kind: 'command', cmd: ['echo', 'hello'] } } }, true],
+  ['task extension property', { tasks: { build: { action: 'compile', extension_setting: true } } }, true],
+  ['unknown task kind', { tasks: { build: { kind: 'bogus' } } }, false],
+  ['command with string cmd', { tasks: { build: { kind: 'command', cmd: 'echo hello' } } }, false],
+  ['command kind omitted', { tasks: { build: { cmd: ['echo', 'hello'] } } }, false],
+  ['intrinsic task with cmd', { tasks: { build: { kind: 'intrinsic', cmd: ['echo', 'hello'] } } }, false],
+  ['command task with action', { tasks: { build: { kind: 'command', action: 'compile' } } }, false],
+];
+
+const schemaFiles = ['morphir-config-v1.yaml', 'morphir-config-v1.json'];
+const failures = schemaFiles.flatMap(schemaFile => {
+  const schemaPath = path.join(schemasDirectory, schemaFile);
+  const schema = schemaFile.endsWith('.yaml')
+    ? yaml.load(fs.readFileSync(schemaPath, 'utf8'))
+    : JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
+
+  return cases.flatMap(([name, value, expected]) => {
+    const actual = validate(value);
+    return actual === expected
+      ? []
+      : [`${schemaFile}, ${name}: expected ${expected}, received ${actual}\n${JSON.stringify(validate.errors, null, 2)}`];
+  });
+});
+
+if (failures.length > 0) {
+  console.error(failures.join('\n\n'));
+  process.exit(1);
+}
+
+console.log(`Validated ${cases.length} task cases against ${schemaFiles.length} Morphir configuration schemas.`);

--- a/website/scripts/yaml-to-json-schemas.js
+++ b/website/scripts/yaml-to-json-schemas.js
@@ -38,10 +38,12 @@ function convertSchemas() {
   }
 
   const files = fs.readdirSync(schemasDir);
-  const yamlFiles = files.filter(f => f.endsWith('.yaml') && f.startsWith('morphir-ir-'));
+  const yamlFiles = files.filter(
+    f => f.endsWith('.yaml') && (f.startsWith('morphir-ir-') || f === 'morphir-config-v1.yaml')
+  );
 
   if (yamlFiles.length === 0) {
-    console.log('No morphir-ir-*.yaml files found in', schemasDir);
+    console.log('No Morphir YAML schema files found in', schemasDir);
     return;
   }
 

--- a/website/static/schemas/morphir-config-v1.json
+++ b/website/static/schemas/morphir-config-v1.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://morphir.finos.org/schemas/morphir-config-v1.json",
-  "title": "Morphir Configuration (morphir.toml)",
-  "description": "JSON Schema for the JSON-equivalent model of morphir.toml configuration files.",
+  "title": "Morphir Configuration",
+  "description": "JSON Schema for the serialization-independent Morphir configuration model underlying morphir.toml and the proposed morphir.yaml format.",
   "type": "object",
   "additionalProperties": true,
   "definitions": {

--- a/website/static/schemas/morphir-config-v1.json
+++ b/website/static/schemas/morphir-config-v1.json
@@ -16,6 +16,22 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "intrinsic",
+            "command"
+          ]
+        },
+        "action": {
+          "type": "string"
+        },
+        "cmd": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "depends_on": {
           "type": "array",
           "items": {
@@ -66,6 +82,11 @@
         {
           "type": "object",
           "additionalProperties": true,
+          "not": {
+            "required": [
+              "cmd"
+            ]
+          },
           "properties": {
             "kind": {
               "type": "string",
@@ -88,6 +109,14 @@
         {
           "type": "object",
           "additionalProperties": true,
+          "required": [
+            "kind"
+          ],
+          "not": {
+            "required": [
+              "action"
+            ]
+          },
           "properties": {
             "kind": {
               "type": "string",
@@ -113,22 +142,6 @@
         },
         {
           "$ref": "#/definitions/intrinsicTask"
-        },
-        {
-          "allOf": [
-            {
-              "$ref": "#/definitions/taskCommon"
-            },
-            {
-              "type": "object",
-              "additionalProperties": true,
-              "properties": {
-                "action": {
-                  "type": "string"
-                }
-              }
-            }
-          ]
         }
       ]
     },

--- a/website/static/schemas/morphir-config-v1.yaml
+++ b/website/static/schemas/morphir-config-v1.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 $id: "https://morphir.finos.org/schemas/morphir-config-v1.yaml"
-title: "Morphir Configuration (morphir.toml)"
-description: "JSON Schema for the JSON-equivalent model of morphir.toml configuration files."
+title: "Morphir Configuration"
+description: "JSON Schema for the serialization-independent Morphir configuration model underlying morphir.toml and the proposed morphir.yaml format."
 type: object
 additionalProperties: true
 
@@ -321,4 +321,3 @@ properties:
     type: object
     additionalProperties:
       $ref: "#/definitions/toolchain"
-

--- a/website/static/schemas/morphir-config-v1.yaml
+++ b/website/static/schemas/morphir-config-v1.yaml
@@ -15,6 +15,14 @@ definitions:
     type: object
     additionalProperties: true
     properties:
+      kind:
+        type: string
+        enum: ["intrinsic", "command"]
+      action:
+        type: string
+      cmd:
+        type: array
+        items: { type: string }
       depends_on:
         type: array
         items: { type: string }
@@ -43,6 +51,8 @@ definitions:
       - $ref: "#/definitions/taskCommon"
       - type: object
         additionalProperties: true
+        not:
+          required: ["cmd"]
         properties:
           kind:
             type: string
@@ -55,6 +65,9 @@ definitions:
       - $ref: "#/definitions/taskCommon"
       - type: object
         additionalProperties: true
+        required: ["kind"]
+        not:
+          required: ["action"]
         properties:
           kind:
             type: string
@@ -68,13 +81,6 @@ definitions:
     anyOf:
       - $ref: "#/definitions/commandTask"
       - $ref: "#/definitions/intrinsicTask"
-      - allOf:
-          - $ref: "#/definitions/taskCommon"
-          - type: object
-            additionalProperties: true
-            properties:
-              action:
-                type: string
 
   workflowStage:
     type: object


### PR DESCRIPTION
## Summary

- define `morphir.yaml` as a YAML serialization of the existing Morphir configuration model
- specify a portable YAML 1.2 profile, discovery paths, ambiguity handling, merge behavior, and conversion requirements
- add a complete configuration example and implementation checklist
- make the shared configuration schema and merge documentation serialization-neutral

## Validation

- parsed all YAML examples with `js-yaml`
- validated the complete example against `morphir-config-v1`
- confirmed the Docusaurus client and server bundles compile

The final Docusaurus build still fails on the repository's existing `prism-gleam` module-resolution error.