### PR TITLE
feat: enable YAML configuration in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,11 +4931,13 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tar",
  "tempfile",
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "uuid",
+ "yaml-rust",
  "zip",
 ]
 
@@ -4981,10 +4983,10 @@ name = "morphir-design"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dirs",
  "morphir-common",
- "serde",
  "serde_json",
- "toml 1.1.4+spec-1.1.0",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,6 +4966,7 @@ dependencies = [
  "jsonrpsee",
  "morphir-common",
  "morphir-core",
+ "morphir-design",
  "morphir-extension-sdk",
  "notify",
  "reqwest 0.13.4",

--- a/crates/morphir/src/commands/compile.rs
+++ b/crates/morphir/src/commands/compile.rs
@@ -50,9 +50,11 @@ pub async fn run_compile(options: CompileOptions) -> AppResult<miette::Report> {
     let config_file = if let Some(cfg) = config_path {
         PathBuf::from(cfg)
     } else {
-        discover_config(&start_dir).ok_or_else(|| CliError::Config {
-            error: anyhow::anyhow!("No morphir.toml or morphir.json found"),
-        })?
+        discover_config(&start_dir)
+            .map_err(|error| CliError::Config { error })?
+            .ok_or_else(|| CliError::Config {
+                error: anyhow::anyhow!("No morphir.toml, morphir.yaml, or morphir.json found"),
+            })?
     };
 
     // Load config context

--- a/crates/morphir/src/commands/generate.rs
+++ b/crates/morphir/src/commands/generate.rs
@@ -27,9 +27,11 @@ pub async fn run_generate(
     let config_file = if let Some(cfg) = config_path {
         PathBuf::from(cfg)
     } else {
-        discover_config(&start_dir).ok_or_else(|| CliError::Config {
-            error: anyhow::anyhow!("No morphir.toml or morphir.json found"),
-        })?
+        discover_config(&start_dir)
+            .map_err(|error| CliError::Config { error })?
+            .ok_or_else(|| CliError::Config {
+                error: anyhow::anyhow!("No morphir.toml, morphir.yaml, or morphir.json found"),
+            })?
     };
 
     // Load config context

--- a/crates/morphir/tests/cli_integration.rs
+++ b/crates/morphir/tests/cli_integration.rs
@@ -80,7 +80,7 @@ fn test_config_discovery() {
     let subdir = project_root.join("subdir");
     std::fs::create_dir_all(&subdir).unwrap();
 
-    let config_path = discover_config(&subdir);
+    let config_path = discover_config(&subdir).unwrap();
     assert!(config_path.is_some());
     assert_eq!(config_path.unwrap(), project_root.join("morphir.toml"));
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ Understand the fundamental concepts behind Morphir
 Formal specifications for Morphir configuration and IR formats
 - [Overview](spec/index.md) - Specifications overview
 - [morphir.toml](spec/morphir-toml/morphir-toml-specification.md) - `morphir.toml` format
-- [morphir.yaml](spec/morphir-yaml/morphir-yaml-specification.md) - Proposed YAML equivalent of `morphir.toml`
+- [morphir.yaml](spec/morphir-yaml/morphir-yaml-specification.md) - YAML equivalent of `morphir.toml`
 - [morphir.json](spec/morphir-json/morphir-json-specification.md) - `morphir.json` format (morphir-elm legacy)
 - [Morphir IR Specification](spec/ir/morphir-ir-specification.md) - Detailed IR specification
 - [Morphir IR JSON Schemas](spec/ir/schemas/) - JSON schemas for IR versions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ Morphir loads configuration from multiple sources, merged in priority order:
 | 1 (lowest) | Built-in defaults | (compiled in) | Sensible defaults |
 | 2 | System config | `/etc/morphir/morphir.toml` | System-wide settings |
 | 3 | Global user config | Platform config directory or user-home `.morphir` directory | User preferences |
-| 4 | Project config | `morphir.toml` or `.morphir/morphir.toml` | Project settings |
+| 4 | Project config | `morphir.toml`, `morphir.yaml`, or the corresponding hidden path | Project settings |
 | 5 | User override | `.morphir/morphir.user.toml` | Local overrides (gitignored) |
 | 6 (highest) | Environment variables | `MORPHIR_*` | Runtime overrides |
 
@@ -31,11 +31,11 @@ Higher-priority sources override lower-priority ones for the same setting.
 
 ### Project Configuration
 
-Place `morphir.toml` in your project root:
+Place `morphir.toml` or `morphir.yaml` in your project root:
 
 ```
 my-project/
-├── morphir.toml          # Project configuration
+├── morphir.toml          # Project configuration (morphir.yaml is also supported)
 ├── .morphir/
 │   └── morphir.user.toml # User overrides (gitignored)
 └── src/
@@ -46,7 +46,7 @@ Or use the hidden style with `morphir workspace init --hidden`:
 ```
 my-project/
 ├── .morphir/
-│   ├── morphir.toml      # Project configuration
+│   ├── morphir.toml      # Project configuration (morphir.yaml is also supported)
 │   └── morphir.user.toml # User overrides
 └── src/
 ```

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -15,7 +15,7 @@ This section contains formal specifications for Morphir configuration and IR for
 
 - **[morphir.toml merge rules](./morphir-toml/morphir-toml-merge-rules/)**: How multiple configuration sources are merged into an effective configuration (precedence + deep-merge behavior).
 
-- **[morphir.yaml](./morphir-yaml/morphir-yaml-specification/)**: Proposed YAML serialization of the Morphir configuration model.
+- **[morphir.yaml](./morphir-yaml/morphir-yaml-specification/)**: YAML serialization of the Morphir configuration model.
 
 - **[morphir.json](./morphir-json/morphir-json-specification/)**: Specification for the legacy `morphir.json` project configuration file used by `morphir-elm` (includes dependency fields).
 

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -113,4 +113,4 @@ Key mapping:
 
 - `docs/configuration.md` (user-facing configuration guide)
 - `docs/spec/morphir-toml/morphir-toml-specification.md` (format/structure specification)
-- `docs/spec/morphir-yaml/morphir-yaml-specification.md` (proposed YAML serialization)
+- `docs/spec/morphir-yaml/morphir-yaml-specification.md` (YAML serialization)

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -13,7 +13,7 @@ This document specifies the **`morphir.toml`** configuration format used by Morp
 - **Applies to**: Configuration parsed into `pkg/config.Config`
 - **Out of scope**: Morphir IR JSON format (see the IR specification and schemas)
 
-`morphir.yaml` is a proposed second serialization of this configuration model. See the [Morphir YAML configuration specification](../morphir-yaml/morphir-yaml-specification/).
+`morphir.yaml` is a supported second serialization of this configuration model. See the [Morphir YAML configuration specification](../morphir-yaml/morphir-yaml-specification/).
 
 ## Files and discovery
 

--- a/docs/spec/morphir-yaml/morphir-yaml-specification.md
+++ b/docs/spec/morphir-yaml/morphir-yaml-specification.md
@@ -2,7 +2,7 @@
 id: morphir-yaml-specification
 title: "Morphir YAML configuration specification"
 sidebar_position: 1
-description: "Proposed specification for morphir.yaml configuration files"
+description: "Specification for morphir.yaml configuration files"
 ---
 
 ## Status and scope

--- a/docs/spec/morphir-yaml/morphir-yaml-specification.md
+++ b/docs/spec/morphir-yaml/morphir-yaml-specification.md
@@ -7,9 +7,9 @@ description: "Proposed specification for morphir.yaml configuration files"
 
 ## Status and scope
 
-This document specifies the proposed `morphir.yaml` configuration format. It is a second serialization of the same configuration model as `morphir.toml`.
+This document specifies the `morphir.yaml` configuration format. It is a second serialization of the same configuration model as `morphir.toml`.
 
-- Status: Draft design. Repository tooling does not yet claim support for loading `morphir.yaml`.
+- Status: Supported by the Morphir Rust configuration loader and CLI.
 - Applies to: Project, workspace, user, and system configuration.
 - Out of scope: Morphir IR YAML and the legacy `morphir.json` project file.
 


### PR DESCRIPTION
Enables the top-level Morphir CLI to use the YAML/global configuration implementation from finos/morphir-rust#79, updates discovery errors and the lockfile, and changes the configuration docs from proposed to supported. Depends on https://github.com/finos/morphir-rust/pull/79. Validation: cargo +1.98.0-x86_64-pc-windows-msvc check -p morphir; cargo fmt -p morphir -- --check. Focused morphir-common and morphir-design tests and clippy pass in the dependency PR.