### PR TITLE
feat: layer system, user override, and env configuration sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,6 +4907,7 @@ dependencies = [
  "termimad",
  "thiserror 2.0.20",
  "tokio",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -4986,6 +4987,7 @@ dependencies = [
  "anyhow",
  "dirs",
  "morphir-common",
+ "serde",
  "serde_json",
  "tempfile",
 ]

--- a/crates/morphir/Cargo.toml
+++ b/crates/morphir/Cargo.toml
@@ -38,6 +38,7 @@ morphir-extension-sdk = { path = "../../ecosystem/morphir-rust/crates/morphir-ex
 walkdir = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = { workspace = true }
 dirs = "6.0"
 schemars = "1.0"
 indexmap = { version = "2", features = ["serde"] }

--- a/crates/morphir/src/commands/config.rs
+++ b/crates/morphir/src/commands/config.rs
@@ -1,0 +1,103 @@
+//! Config command for inspecting the effective Morphir configuration
+
+use crate::error::CliError;
+use crate::output::{OutputFormat, write_output};
+use morphir_design::{
+    ConfigLoadOptions, ConfigSource, ConfigSourceStatus, EffectiveConfig, discover_config,
+    load_effective_config,
+};
+use serde::Serialize;
+use starbase::AppResult;
+use std::path::PathBuf;
+
+/// Output of `morphir config path`
+#[derive(Debug, Serialize)]
+pub struct ConfigPathOutput {
+    /// Project configuration that anchored the lookup, if any
+    pub project_config: Option<PathBuf>,
+    /// Sources considered, from lowest to highest precedence
+    pub sources: Vec<ConfigSource>,
+}
+
+/// Output of `morphir config show`
+#[derive(Debug, Serialize)]
+pub struct ConfigShowOutput {
+    /// Project configuration that anchored the lookup, if any
+    pub project_config: Option<PathBuf>,
+    /// Effective configuration value
+    pub config: serde_json::Value,
+}
+
+fn resolve_project_config(config_path: Option<String>) -> Result<Option<PathBuf>, CliError> {
+    match config_path {
+        Some(path) => Ok(Some(PathBuf::from(path))),
+        None => {
+            let start_dir =
+                std::env::current_dir().map_err(|error| CliError::FileSystem { error })?;
+            discover_config(&start_dir).map_err(|error| CliError::Config { error })
+        }
+    }
+}
+
+fn load(config_path: Option<String>) -> Result<(Option<PathBuf>, EffectiveConfig), CliError> {
+    let project_config = resolve_project_config(config_path)?;
+    let effective = load_effective_config(project_config.as_deref(), &ConfigLoadOptions::default())
+        .map_err(|error| CliError::Config { error })?;
+    Ok((project_config, effective))
+}
+
+/// Show which configuration sources were considered
+pub fn run_config_path(config_path: Option<String>, json: bool) -> AppResult<miette::Report> {
+    let (project_config, effective) = load(config_path)?;
+    let format = OutputFormat::from_flags(json, false);
+
+    if format == OutputFormat::Human {
+        print_sources(&effective.sources);
+    } else {
+        let output = ConfigPathOutput {
+            project_config,
+            sources: effective.sources,
+        };
+        write_output(format, &output).map_err(CliError::from)?;
+    }
+
+    Ok(None)
+}
+
+fn print_sources(sources: &[ConfigSource]) {
+    println!("Configuration sources (in priority order):");
+    println!();
+    for source in sources.iter().rev() {
+        let marker = match source.status {
+            ConfigSourceStatus::Loaded => "✓",
+            ConfigSourceStatus::NotFound | ConfigSourceStatus::Skipped => "✗",
+        };
+        println!("  [{marker}] {}", source.kind.name());
+        println!("      Path: {}", source.location());
+        println!("      Status: {}", source.status.label());
+        println!("      Priority: {}", source.priority);
+        println!();
+    }
+}
+
+/// Show the effective configuration after merging every source
+pub fn run_config_show(config_path: Option<String>, json: bool) -> AppResult<miette::Report> {
+    let (project_config, effective) = load(config_path)?;
+    let format = OutputFormat::from_flags(json, false);
+
+    if format == OutputFormat::Human {
+        let rendered =
+            toml::to_string_pretty(&effective.value).map_err(|error| CliError::Config {
+                error: anyhow::anyhow!("Failed to render effective configuration as TOML: {error}"),
+            })?;
+        print!("{rendered}");
+    } else {
+        let output = ConfigShowOutput {
+            project_config,
+            config: effective.value,
+        };
+        write_output(format, &output).map_err(CliError::from)?;
+    }
+
+    Ok(None)
+}

--- a/crates/morphir/src/commands/config.rs
+++ b/crates/morphir/src/commands/config.rs
@@ -2,6 +2,7 @@
 
 use crate::error::CliError;
 use crate::output::{OutputFormat, write_output};
+use morphir_common::config::redact_secrets;
 use morphir_design::{
     ConfigLoadOptions, ConfigSource, ConfigSourceStatus, EffectiveConfig, discover_config,
     load_effective_config,
@@ -80,21 +81,24 @@ fn print_sources(sources: &[ConfigSource]) {
     }
 }
 
-/// Show the effective configuration after merging every source
+/// Show the effective configuration after merging every source.
+///
+/// Credentials (tokens, passwords, secrets, API keys) are redacted before
+/// anything is printed, in both the human and JSON forms.
 pub fn run_config_show(config_path: Option<String>, json: bool) -> AppResult<miette::Report> {
     let (project_config, effective) = load(config_path)?;
     let format = OutputFormat::from_flags(json, false);
+    let config = redact_secrets(&effective.value);
 
     if format == OutputFormat::Human {
-        let rendered =
-            toml::to_string_pretty(&effective.value).map_err(|error| CliError::Config {
-                error: anyhow::anyhow!("Failed to render effective configuration as TOML: {error}"),
-            })?;
+        let rendered = toml::to_string_pretty(&config).map_err(|error| CliError::Config {
+            error: anyhow::anyhow!("Failed to render effective configuration as TOML: {error}"),
+        })?;
         print!("{rendered}");
     } else {
         let output = ConfigShowOutput {
             project_config,
-            config: effective.value,
+            config,
         };
         write_output(format, &output).map_err(CliError::from)?;
     }

--- a/crates/morphir/src/commands/mod.rs
+++ b/crates/morphir/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod compile;
+pub mod config;
 pub mod dist;
 pub mod extension;
 pub mod generate;
@@ -11,6 +12,7 @@ pub mod validate;
 pub mod version;
 
 pub use compile::*;
+pub use config::*;
 pub use dist::*;
 pub use extension::*;
 pub use generate::*;

--- a/crates/morphir/src/main.rs
+++ b/crates/morphir/src/main.rs
@@ -9,11 +9,11 @@ pub mod output;
 mod tui;
 
 use commands::{
-    compile::CompileOptions, run_compile, run_dist_install, run_dist_list, run_dist_uninstall,
-    run_dist_update, run_extension_install, run_extension_list, run_extension_uninstall,
-    run_extension_update, run_generate, run_gleam_compile, run_gleam_generate, run_gleam_roundtrip,
-    run_migrate, run_tool_install, run_tool_list, run_tool_uninstall, run_tool_update,
-    run_transform, run_validate, run_version,
+    compile::CompileOptions, run_compile, run_config_path, run_config_show, run_dist_install,
+    run_dist_list, run_dist_uninstall, run_dist_update, run_extension_install, run_extension_list,
+    run_extension_uninstall, run_extension_update, run_generate, run_gleam_compile,
+    run_gleam_generate, run_gleam_roundtrip, run_migrate, run_tool_install, run_tool_list,
+    run_tool_uninstall, run_tool_update, run_transform, run_validate, run_version,
 };
 
 /// Morphir CLI - Tools for functional domain modeling and business logic
@@ -108,6 +108,11 @@ enum Commands {
     },
 
     // ===== Management Commands =====
+    /// Inspect the effective Morphir configuration
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
     /// Manage Morphir tools, distributions, and extensions
     Tool {
         #[command(subcommand)]
@@ -156,6 +161,28 @@ enum Commands {
     /// Output usage spec for documentation generation
     #[command(hide = true)]
     Usage,
+}
+
+#[derive(Clone, Subcommand)]
+enum ConfigAction {
+    /// Show the effective configuration after merging every source
+    Show {
+        /// Explicit project config file path
+        #[arg(long)]
+        config: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show which configuration sources were considered
+    Path {
+        /// Explicit project config file path
+        #[arg(long)]
+        config: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Clone, Subcommand)]
@@ -398,6 +425,10 @@ impl AppSession for MorphirSession {
                 .await
             }
             Commands::Transform { input, output } => run_transform(input.clone(), output.clone()),
+            Commands::Config { action } => match action {
+                ConfigAction::Show { config, json } => run_config_show(config.clone(), *json),
+                ConfigAction::Path { config, json } => run_config_path(config.clone(), *json),
+            },
             Commands::Tool { action } => match action {
                 ToolAction::Install { name, version } => {
                     run_tool_install(name.clone(), version.clone())

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,6 +235,8 @@ morphir config show
 morphir config show --json
 ```
 
+Credentials are redacted before printing: any key containing `token`, `password`, `secret`, `credential`, or `api_key` is shown as `<redacted>`.
+
 ### Show Configuration Sources
 
 See which files were loaded:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,13 +19,13 @@ Morphir loads configuration from multiple sources, merged in priority order:
 | Priority | Source | Path | Purpose |
 |----------|--------|------|---------|
 | 1 (lowest) | Built-in defaults | (compiled in) | Sensible defaults |
-| 2 | System config | `/etc/morphir/morphir.toml` | System-wide settings |
+| 2 | System config | `/etc/morphir/morphir.toml` (`%PROGRAMDATA%\morphir\morphir.toml` on Windows) | System-wide settings |
 | 3 | Global user config | Platform config directory or user-home `.morphir` directory | User preferences |
 | 4 | Project config | `morphir.toml`, `morphir.yaml`, or the corresponding hidden path | Project settings |
-| 5 | User override | `.morphir/morphir.user.toml` | Local overrides (gitignored) |
+| 5 | User override | `.morphir/morphir.user.toml` or `.morphir/morphir.user.yaml` | Local overrides (gitignored) |
 | 6 (highest) | Environment variables | `MORPHIR_*` | Runtime overrides |
 
-Higher-priority sources override lower-priority ones for the same setting.
+Higher-priority sources override lower-priority ones for the same setting. Every file source accepts either a `morphir.toml` or a `morphir.yaml` serialization at the same location; if both exist, Morphir reports an ambiguity error instead of choosing one. See the [merge rules](spec/morphir-toml/morphir-toml-merge-rules.md) for the full algorithm.
 
 ## File Locations
 
@@ -92,7 +92,7 @@ ui:
 
 ### System Configuration
 
-Administrators can create `/etc/morphir/morphir.toml` for organization-wide defaults.
+Administrators can create `/etc/morphir/morphir.toml` (or `morphir.yaml`) for organization-wide defaults. On Windows the system location is `%PROGRAMDATA%\morphir\morphir.toml`, which falls back to `C:\ProgramData\morphir\morphir.toml` when `PROGRAMDATA` is not set.
 
 ## Configuration Sections
 
@@ -198,25 +198,28 @@ theme = "default"
 
 ## Environment Variables
 
-Override any setting with environment variables using the `MORPHIR_` prefix:
+Override any setting with environment variables using the `MORPHIR_` prefix. A double underscore (`__`) separates nesting levels; single underscores stay part of the key name:
 
 ```sh
 # Override logging level
-export MORPHIR_LOGGING_LEVEL=debug
+export MORPHIR_LOGGING__LEVEL=debug
 
 # Disable caching
-export MORPHIR_CACHE_ENABLED=false
+export MORPHIR_CACHE__ENABLED=false
 
 # Set IR format version
-export MORPHIR_IR_FORMAT_VERSION=3
+export MORPHIR_IR__FORMAT_VERSION=3
 
 # Disable colors
-export MORPHIR_UI_COLOR=false
+export MORPHIR_UI__COLOR=false
 ```
 
-Environment variable names use underscores for nested keys:
-- `logging.level` → `MORPHIR_LOGGING_LEVEL`
-- `ir.format_version` → `MORPHIR_IR_FORMAT_VERSION`
+Mapping examples:
+- `logging.level` → `MORPHIR_LOGGING__LEVEL`
+- `ir.format_version` → `MORPHIR_IR__FORMAT_VERSION`
+- `codegen.go.package` → `MORPHIR_CODEGEN__GO__PACKAGE`
+
+Values are typed mechanically: `true` and `false` become booleans, integers become numbers, values that start with `[` or `{` and parse as JSON become arrays or objects, and anything else stays a string. Key segments are lower-cased.
 
 ## CLI Commands
 
@@ -283,7 +286,7 @@ morphir workspace init --json
 
 ## User Overrides
 
-The `.morphir/morphir.user.toml` file is for personal settings that shouldn't be committed to version control. It's automatically added to `.morphir/.gitignore`.
+The `.morphir/morphir.user.toml` file (or `.morphir/morphir.user.yaml`; not both) is for personal settings that shouldn't be committed to version control. It's automatically added to `.morphir/.gitignore`. In a workspace, Morphir also applies the override in the selected member's `.morphir` directory after the workspace-level one.
 
 Common uses:
 - Debug logging during development
@@ -335,10 +338,10 @@ For CI environments, use environment variables:
 ```yaml
 # GitHub Actions example
 env:
-  MORPHIR_LOGGING_LEVEL: warn
-  MORPHIR_UI_COLOR: false
-  MORPHIR_UI_INTERACTIVE: false
-  MORPHIR_CACHE_DIR: /tmp/morphir-cache
+  MORPHIR_LOGGING__LEVEL: warn
+  MORPHIR_UI__COLOR: false
+  MORPHIR_UI__INTERACTIVE: false
+  MORPHIR_CACHE__DIR: /tmp/morphir-cache
 ```
 
 ### Multi-Target Code Generation

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -22,7 +22,7 @@ Sources are loaded from **lowest precedence** to **highest precedence**:
 | Priority | Source | Typical path |
 |----------|--------|--------------|
 | 1 (lowest) | Built-in defaults | (compiled in) |
-| 2 | System config | `/etc/morphir/morphir.toml` |
+| 2 | System config | `/etc/morphir/morphir.toml`, or `%PROGRAMDATA%\morphir\morphir.toml` on Windows |
 | 3 | Global user config | Platform config directory or user-home `.morphir` directory |
 | 4 | Project config | `morphir.toml` |
 | 5 | User override | `.morphir/morphir.user.toml` |
@@ -30,7 +30,13 @@ Sources are loaded from **lowest precedence** to **highest precedence**:
 
 If the same setting is present in multiple sources, **the value from the highest-precedence source wins**, subject to the merge algorithm described below.
 
+Each file source accepts a `morphir.yaml` serialization at the corresponding location (`morphir.user.yaml` for the user override). A loader MUST accept at most one serialization per location and MUST report an ambiguity error that names both files when a TOML and a YAML file coexist. See the [YAML specification](../morphir-yaml/morphir-yaml-specification/) for discovery details.
+
+On Windows, `%PROGRAMDATA%` resolves through the `PROGRAMDATA` environment variable and falls back to `C:\ProgramData` when it is unset.
+
 > Note: A “hidden project config” variant (`.morphir/morphir.toml`) may also be used by some commands/workflows. The merge semantics are identical.
+>
+> When a workspace configuration selects a member project, the member's configuration is merged after the workspace configuration and before the user overrides. The workspace-level `.morphir/morphir.user.*` file is applied first, then the member's.
 
 ### Global user path resolution
 
@@ -94,7 +100,7 @@ Given two maps: `base` and `overlay`, `DeepMerge(base, overlay)` produces a new 
 - **Rule 4 — `nil` overlay is ignored**: if an overlay value is `nil`, it does **not** override the base value.
 - **Rule 5 — No mutation**: the merge result is independent; inputs are not modified.
 
-These rules are implemented by `pkg/config/internal/configloader.DeepMerge` and `MergeAll`.
+These rules are implemented by `deep_merge` and `merge_all` in the `morphir_common::config::merge` module of morphir-rust. The layered loader in `morphir_design::config` (`load_effective_config`) applies them across the sources above and records which sources were consulted; `morphir config path` and `morphir config show` expose that result.
 
 ## Environment variable mapping (informative)
 
@@ -106,6 +112,16 @@ Key mapping:
   - `MORPHIR_CODEGEN__GO__PACKAGE=foo` → `codegen.go.package = "foo"`
 - Single underscores are not split into nested keys by the loader; they remain part of the key name at that level:
   - `MORPHIR_IR_FORMAT_VERSION=3` → `ir_format_version = 3` (as a single key in the env-derived map)
+- Key segments are lower-cased. Underscores immediately after the prefix are ignored, so `MORPHIR__IR__STRICT_MODE` and `MORPHIR_IR__STRICT_MODE` map to the same key.
+
+Value mapping:
+
+- `true` and `false` (any case) become booleans.
+- Integers become numbers.
+- A value that starts with `[` or `{` and parses as JSON becomes an array or object.
+- Anything else stays a string.
+
+When a scalar and a nested key conflict (`MORPHIR_IR=x` together with `MORPHIR_IR__STRICT_MODE=true`), the shorter path wins and the nested variable is dropped, regardless of environment iteration order.
 
 > The env mapping behavior is intentionally mechanical; it does not attempt to “guess” dotted paths. The final effective configuration still follows the same DeepMerge rules.
 


### PR DESCRIPTION
## Summary

Lands the layered configuration loader on the Rust side, completing what #687 (spec) and #688 (YAML in the CLI) started. Depends on finos/morphir-rust#80.

- Effective configuration now merges every source from the [merge rules spec](docs/spec/morphir-toml/morphir-toml-merge-rules.md) in precedence order: built-in defaults, system (`/etc/morphir`, or `%PROGRAMDATA%\morphir` on Windows), global user, project, workspace member, `.morphir/morphir.user.{toml,yaml}` override, and `MORPHIR_*` environment variables.
- `morphir config path` and `morphir config show` (with `--json`) are added to the CLI, matching what `docs/configuration.md` already documented.
- Docs: `docs/configuration.md` used single-underscore environment variables (`MORPHIR_LOGGING_LEVEL`), which contradicts the normative merge-rules spec and the original Go loader (`__` between nesting levels). The guide now uses `MORPHIR_LOGGING__LEVEL` and documents value typing, the YAML user override, and the Windows system location. The merge-rules spec now points at the Rust implementation instead of the removed Go package.

## Submodule

`ecosystem/morphir-rust` points at `dc766cc` on the `feature/layered-config-loading` branch. Once finos/morphir-rust#80 is squash-merged, this PR needs one more commit re-pointing the submodule at the merged `main` SHA (the current `main` pointer `8d65463` already dangles for the same reason after #79).

## Testing

- morphir-rust: `cargo test -p morphir-common -p morphir-design` (76 tests) and the Cucumber configuration scenarios pass; clippy `-D warnings` and rustfmt clean.
- Parent: `cargo clippy -p morphir --all-targets -- -D warnings` clean with the pinned Rust 1.98 toolchain.