### PR TITLE
chore: adopt the morphir-devkit crate name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,7 +4894,7 @@ dependencies = [
  "morphir-common",
  "morphir-core",
  "morphir-daemon",
- "morphir-design",
+ "morphir-devkit",
  "morphir-extension-sdk",
  "owo-colors",
  "ratatui",
@@ -4967,7 +4967,7 @@ dependencies = [
  "jsonrpsee",
  "morphir-common",
  "morphir-core",
- "morphir-design",
+ "morphir-devkit",
  "morphir-extension-sdk",
  "notify",
  "reqwest 0.13.4",
@@ -4981,7 +4981,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "morphir-design"
+name = "morphir-devkit"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/crates/morphir/BUILD_WASM.md
+++ b/crates/morphir/BUILD_WASM.md
@@ -41,7 +41,7 @@ The `build.rs` script in `crates/morphir/` can be extended to:
 ### Current Status
 
 Currently, the WASM file must be built manually and placed in the expected location.
-The extension discovery logic in `morphir-design` will look for:
+The extension discovery logic in `morphir-devkit` will look for:
 - `extensions/gleam.wasm` (relative to binary)
 - `resources/extensions/gleam.wasm` (relative to binary)
 - Bundled resources (when build script is updated)

--- a/crates/morphir/Cargo.toml
+++ b/crates/morphir/Cargo.toml
@@ -32,7 +32,7 @@ async-trait = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 morphir-core = { path = "../../ecosystem/morphir-rust/crates/morphir-core" }
 morphir-common = { path = "../../ecosystem/morphir-rust/crates/morphir-common" }
-morphir-design = { path = "../../ecosystem/morphir-rust/crates/morphir-design" }
+morphir-devkit = { path = "../../ecosystem/morphir-rust/crates/morphir-devkit" }
 morphir-daemon = { path = "../../ecosystem/morphir-rust/crates/morphir-daemon" }
 morphir-extension-sdk = { path = "../../ecosystem/morphir-rust/crates/morphir-extension-sdk" }
 walkdir = "2"

--- a/crates/morphir/src/commands/compile.rs
+++ b/crates/morphir/src/commands/compile.rs
@@ -3,7 +3,7 @@
 use crate::error::CliError;
 use crate::output::Diagnostic;
 use morphir_daemon::extensions::registry::ExtensionRegistry;
-use morphir_design::{
+use morphir_devkit::{
     discover_config, ensure_morphir_structure, load_config_context, resolve_compile_output,
     resolve_path_relative_to_config,
 };
@@ -128,7 +128,7 @@ pub async fn run_compile(options: CompileOptions) -> AppResult<miette::Report> {
     })?;
 
     // Register builtin extensions
-    let builtins = morphir_design::discover_builtin_extensions();
+    let builtins = morphir_devkit::discover_builtin_extensions();
     for builtin in builtins {
         if let Some(path) = builtin.path {
             registry

--- a/crates/morphir/src/commands/config.rs
+++ b/crates/morphir/src/commands/config.rs
@@ -3,7 +3,7 @@
 use crate::error::CliError;
 use crate::output::{OutputFormat, write_output};
 use morphir_common::config::redact_secrets;
-use morphir_design::{
+use morphir_devkit::{
     ConfigLoadOptions, ConfigSource, ConfigSourceStatus, EffectiveConfig, discover_config,
     load_effective_config,
 };

--- a/crates/morphir/src/commands/extension.rs
+++ b/crates/morphir/src/commands/extension.rs
@@ -149,7 +149,7 @@ pub fn run_extension_list() -> AppResult<miette::Report> {
     println!("Listing Morphir extensions...\n");
 
     // Discover builtin extensions
-    let builtins = morphir_design::discover_builtin_extensions();
+    let builtins = morphir_devkit::discover_builtin_extensions();
 
     // Load registry extensions
     let registry = match ExtensionRegistry::load() {

--- a/crates/morphir/src/commands/generate.rs
+++ b/crates/morphir/src/commands/generate.rs
@@ -4,7 +4,7 @@ use crate::error::CliError;
 use crate::output::Diagnostic;
 use morphir_common::loader::load_ir;
 use morphir_daemon::extensions::registry::ExtensionRegistry;
-use morphir_design::{
+use morphir_devkit::{
     discover_config, ensure_morphir_structure, load_config_context, resolve_generate_output,
 };
 use starbase::AppResult;
@@ -65,7 +65,7 @@ pub async fn run_generate(
         PathBuf::from(inp)
     } else {
         // Default to compile output for the target language
-        morphir_design::resolve_compile_output(&proj_name, &target_lang, &ctx.morphir_dir)
+        morphir_devkit::resolve_compile_output(&proj_name, &target_lang, &ctx.morphir_dir)
     };
 
     if !input_path.exists() {
@@ -96,7 +96,7 @@ pub async fn run_generate(
     })?;
 
     // Register builtin extensions
-    let builtins = morphir_design::discover_builtin_extensions();
+    let builtins = morphir_devkit::discover_builtin_extensions();
     for builtin in builtins {
         if let Some(path) = builtin.path {
             registry

--- a/crates/morphir/tests/cli_integration.rs
+++ b/crates/morphir/tests/cli_integration.rs
@@ -64,7 +64,7 @@ async fn test_generate_command_basic() {
 
 #[test]
 fn test_config_discovery() {
-    use morphir_design::discover_config;
+    use morphir_devkit::discover_config;
 
     let temp_dir = TempDir::new().unwrap();
     let project_root = temp_dir.path();
@@ -87,7 +87,7 @@ fn test_config_discovery() {
 
 #[test]
 fn test_morphir_dir_discovery() {
-    use morphir_design::discover_morphir_dir;
+    use morphir_devkit::discover_morphir_dir;
 
     let temp_dir = TempDir::new().unwrap();
     let project_root = temp_dir.path();
@@ -107,7 +107,7 @@ fn test_morphir_dir_discovery() {
 
 #[test]
 fn test_path_resolution() {
-    use morphir_design::{resolve_compile_output, resolve_generate_output, sanitize_project_name};
+    use morphir_devkit::{resolve_compile_output, resolve_generate_output, sanitize_project_name};
 
     let morphir_dir = PathBuf::from(".morphir");
 

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -100,7 +100,7 @@ Given two maps: `base` and `overlay`, `DeepMerge(base, overlay)` produces a new 
 - **Rule 4 — `nil` overlay is ignored**: if an overlay value is `nil`, it does **not** override the base value.
 - **Rule 5 — No mutation**: the merge result is independent; inputs are not modified.
 
-These rules are implemented by `deep_merge` and `merge_all` in the `morphir_common::config::merge` module of morphir-rust. The layered loader in `morphir_design::config` (`load_effective_config`) applies them across the sources above and records which sources were consulted; `morphir config path` and `morphir config show` expose that result.
+These rules are implemented by `deep_merge` and `merge_all` in the `morphir_common::config::merge` module of morphir-rust. The layered loader in `morphir_devkit::config` (`load_effective_config`) applies them across the sources above and records which sources were consulted; `morphir config path` and `morphir config show` expose that result.
 
 ## Environment variable mapping (informative)
 


### PR DESCRIPTION
Follows finos/morphir-rust#81, which renamed the `morphir-design` crate to `morphir-devkit`.

This repository's `crates/morphir` path-depends on that crate through the `ecosystem/morphir-rust` submodule, so the rename has to land here in the same breath: without it `cargo metadata` at the repo root fails, because the path dependency points at a directory that no longer exists.

Contents: the path dependency, the imports in `compile`/`config`/`extension`/`generate` and the CLI integration tests, two prose references (`BUILD_WASM.md`, and the merge-rules spec which named `morphir_design::config` as the layered loader), a regenerated `Cargo.lock`, and the submodule bump to the merged rename.

No behaviour change. Verified with `cargo +1.98.0 clippy -p morphir --all-targets -- -D warnings` (Finished) and `cargo fmt --all -- --check` (silent).