### PR TITLE
feat(spec): secret references, provenance, and a complete configuration schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ website/.docusaurus/
 # Added by cargo
 
 /target
+
+# Local working area: temp scripts, agent and script outputs, superpowers specs/plans
+.dev/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,16 @@ npm install
 npm start
 ```
 
+### The `.dev/` Working Area
+
+`.dev/` is a gitignored scratch area for AI-assisted development: temporary scripts, agent and script outputs, and working documents. Nothing in it is committed. Suggested layout:
+
+- Specs from the superpowers `brainstorming` skill: `.dev/docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+- Plans from the superpowers `writing-plans` skill: `.dev/docs/superpowers/plans/YYYY-MM-DD-<topic>-plan.md`
+- Scratch scripts and their outputs: `.dev/scripts/`, `.dev/out/`
+
+Never place working documents under `docs/`: everything in `docs/` is published to morphir.finos.org by the website build. When a design is final and meant for readers, write it up under `docs/design/` with the usual front matter.
+
 ## Questions?
 
 When in doubt:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,7 +235,7 @@ morphir config show
 morphir config show --json
 ```
 
-Credentials are redacted before printing: any key containing `token`, `password`, `secret`, `credential`, or `api_key` is shown as `<redacted>`.
+See [Secrets](#secrets) for how credentials are displayed.
 
 ### Show Configuration Sources
 
@@ -307,6 +307,28 @@ file = ".morphir/debug.log"
 [ui]
 theme = "dark"
 ```
+
+## Secrets
+
+Never put credentials in a committed configuration file. Reference them instead:
+
+```toml
+[registry]
+token = { env = "GITHUB_TOKEN" }
+password = { file = "~/.config/morphir/registry-password" }
+```
+
+```yaml
+registry:
+  token: { env: GITHUB_TOKEN }
+  password: { file: ~/.config/morphir/registry-password }
+```
+
+`env` reads the named environment variable; `file` reads the file's contents (relative paths resolve against the configuration file that declares them, `~` is your home directory). Morphir resolves a reference only when a command actually needs the credential, so `morphir config show` prints the reference itself rather than the secret.
+
+A plain-string credential at a position the schema marks as secret, or under a key that looks like one (`token`, `password`, `secret`, `credential`, `api_key`, ...), is treated as a secret and shown as `<redacted>`.
+
+Environment variables can carry a reference too: `MORPHIR_REGISTRY__TOKEN='{"env":"GH_TOKEN"}'`.
 
 ## Validation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,7 +310,7 @@ theme = "dark"
 
 ## Secrets
 
-Never put credentials in a committed configuration file. Reference them instead:
+Never put credentials in a committed configuration file. The configuration format specifies a **secret reference** for this, written instead of the secret itself:
 
 ```toml
 [registry]
@@ -321,14 +321,16 @@ password = { file = "~/.config/morphir/registry-password" }
 ```yaml
 registry:
   token: { env: GITHUB_TOKEN }
-  password: { file: ~/.config/morphir/registry-password }
+  password: { file: "~/.config/morphir/registry-password" }
 ```
 
-`env` reads the named environment variable; `file` reads the file's contents (relative paths resolve against the configuration file that declares them, `~` is your home directory). Morphir resolves a reference only when a command actually needs the credential, so `morphir config show` prints the reference itself rather than the secret.
+`env` is specified to read the named environment variable; `file` is specified to read the file's contents (relative paths resolving against the configuration file that declares them, `~` expanding to your home directory). **This resolution is specified but not yet implemented by the shipped CLI.** Today, writing a reference like the ones above has no special effect: the value is stored and displayed like any other configuration value, subject to the redaction described below. No Morphir command currently reads the named environment variable or file on a reference's behalf.
 
-A plain-string credential at a position the schema marks as secret, or under a key that looks like one (`token`, `password`, `secret`, `credential`, `api_key`, ...), is treated as a secret and shown as `<redacted>`.
+### How `morphir config show` displays values today
 
-Environment variables can carry a reference too: `MORPHIR_REGISTRY__TOKEN='{"env":"GH_TOKEN"}'`.
+`morphir config show` redacts sensitive values before printing them. Redaction is a **key-name heuristic**, not a check on the value's shape: any configuration key whose name (case-insensitively, treating `-` as `_`) contains `token`, `password`, `passwd`, `secret`, `credential`, `api_key`, `apikey`, `private_key`, or `access_key` has its **entire value** replaced with `<redacted>`, whatever that value's type — a plain string, a number, a secret-reference table, or an arbitrary nested table. For example, the `token = { env = "GITHUB_TOKEN" }` example above prints as `token = <redacted>`, the same as it would for a plain-string token; today's redaction does not recognize, preserve, or resolve the reference shape.
+
+Environment variables under a sensitive key are redacted the same way, whatever value they carry: `MORPHIR_REGISTRY__TOKEN='{"env":"GH_TOKEN"}'` also displays as `<redacted>`.
 
 ## Validation
 

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -99,13 +99,17 @@ Given two maps: `base` and `overlay`, `DeepMerge(base, overlay)` produces a new 
 - **Rule 3 — Arrays/slices replace**: if values are arrays/slices, the overlay replaces the base entirely (no concatenation).
 - **Rule 4 — `nil` overlay is ignored**: if an overlay value is `nil`, it does **not** override the base value.
 - **Rule 5 — No mutation**: the merge result is independent; inputs are not modified.
-- **Rule 6 — Secret values are leaves**: a secret reference (`{ env = ... }` / `{ file = ... }`) or a secret string is never merged recursively; the overlay value replaces the base value entirely.
+- **Rule 6 — Secret values are leaves**: if the base value, the overlay value, or both are a secret reference (`{ env = ... }` / `{ file = ... }`) or a secret string, the overlay value replaces the base value entirely; the two are never deep-merged as maps, even when both look like ordinary tables. This rule takes precedence over Rule 2: an ordinary table overlaying a base secret reference (or a secret reference overlaying an ordinary table) still replaces wholesale rather than merging recursively, because merging would otherwise produce a table that is no longer a valid secret reference.
 
 These rules are implemented by `deep_merge` and `merge_all` in the `morphir_common::config::merge` module of morphir-rust. The layered loader in `morphir_devkit::config` (`load_effective_config`) applies them across the sources above and records which sources were consulted; `morphir config path` and `morphir config show` expose that result.
 
 ## Provenance
 
-The effective configuration records, for every leaf value and every array, which source supplied it (the source kind and, for file sources, the path). Provenance follows the winning value through `DeepMerge`: an overlay value that replaces or is added to the base brings its own provenance. Tables carry no provenance of their own; they exist because a child does. Tooling uses provenance to explain values (`morphir config show --provenance`) and to name the file responsible for a validation error.
+This section is specified for future implementation; it is not implemented today. Nothing named `provenance` exists in the codebase, and `morphir config show` has no `--provenance` flag.
+
+Once implemented, a conforming loader MUST record, for every leaf value and every array in the effective configuration, which source supplied it (the source kind and, for file sources, the path). Provenance MUST follow the winning value through `DeepMerge`: an overlay value that replaces or is added to the base brings its own provenance with it. A table SHOULD NOT itself carry provenance separate from its children, since a table exists in the effective configuration only because at least one descendant leaf does.
+
+Tooling MAY expose provenance to explain values (for example, a future `--provenance` option on `morphir config show`) and to name the file responsible for a validation error. The flag name and output shape are not yet finalized.
 
 ## Environment variable mapping (informative)
 

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -99,8 +99,13 @@ Given two maps: `base` and `overlay`, `DeepMerge(base, overlay)` produces a new 
 - **Rule 3 — Arrays/slices replace**: if values are arrays/slices, the overlay replaces the base entirely (no concatenation).
 - **Rule 4 — `nil` overlay is ignored**: if an overlay value is `nil`, it does **not** override the base value.
 - **Rule 5 — No mutation**: the merge result is independent; inputs are not modified.
+- **Rule 6 — Secret values are leaves**: a secret reference (`{ env = ... }` / `{ file = ... }`) or a secret string is never merged recursively; the overlay value replaces the base value entirely.
 
 These rules are implemented by `deep_merge` and `merge_all` in the `morphir_common::config::merge` module of morphir-rust. The layered loader in `morphir_devkit::config` (`load_effective_config`) applies them across the sources above and records which sources were consulted; `morphir config path` and `morphir config show` expose that result.
+
+## Provenance
+
+The effective configuration records, for every leaf value and every array, which source supplied it (the source kind and, for file sources, the path). Provenance follows the winning value through `DeepMerge`: an overlay value that replaces or is added to the base brings its own provenance. Tables carry no provenance of their own; they exist because a child does. Tooling uses provenance to explain values (`morphir config show --provenance`) and to name the file responsible for a validation error.
 
 ## Environment variable mapping (informative)
 

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -45,6 +45,10 @@ All top-level keys are optional; absent sections use defaults.
 - **`cache`**: Cache settings
 - **`logging`**: Logging settings
 - **`ui`**: UI / TUI settings
+- **`frontend`**: Frontend parsing settings
+- **`sources`**: Remote source settings
+- **`dependencies`** and **`dev-dependencies`**: Project dependencies and development-only dependencies
+- **`extensions`**: Extension definitions
 - **`tasks`**: Project task definitions (intrinsic or command tasks)
 - **`workflows`**: Named workflows (staged orchestration of targets)
 - **`bindings`**: External binding type-mapping configuration (WIT/Protobuf/JSON)

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -55,6 +55,8 @@ All top-level keys are optional; absent sections use defaults.
 ### `[morphir]`
 
 - **`version`** (`string`, optional): SemVer constraint indicating compatible Morphir IR versions for the project (example: `"^3.0.0"`). Empty means “any”.
+- **`min_cli_version`** (`string`, optional): Minimum Morphir CLI version required to work with this configuration.
+- **`dev_mode`** (`bool`, optional, default: `false`): Enables development-mode behavior.
 
 ### `[workspace]`
 
@@ -71,6 +73,11 @@ All top-level keys are optional; absent sections use defaults.
 - **`source_directory`** (`string`, optional): Source directory containing project source files.
 - **`exposed_modules`** (`string[]`, optional): Modules exposed by the project’s public API.
 - **`module_prefix`** (`string`, optional): Optional module prefix for qualified names.
+- **`description`** (`string`, optional): Short description of the project.
+- **`license`** (`string`, optional): SPDX license identifier.
+- **`repository`** (`string`, optional): URL of the project's source repository.
+- **`authors`** (`string[]`, optional): Project authors.
+- **`output_directory`** (`string`, optional, default: `".morphir/out"`): Directory for project-level build output.
 
 #### `[project.decorations.<decorationId>]`
 
@@ -85,6 +92,7 @@ Decorations are sidecar metadata schemas/values attached to IR nodes.
 
 - **`format_version`** (`int`, optional, default: `3`): IR format version (supported range: 1–10).
 - **`strict_mode`** (`bool`, optional, default: `false`): When true, validation warnings are treated as errors.
+- **`mode`** (`string`, optional, default: `"vfs"`): One of `classic`, `vfs`.
 
 ### `[codegen]`
 
@@ -110,6 +118,76 @@ Decorations are sidecar metadata schemas/values attached to IR nodes.
 - **`interactive`** (`bool`, optional, default: `true`)
 - **`theme`** (`string`, optional, default: `"default"`): One of `default`, `light`, `dark`.
 
+### `[frontend]`
+
+Frontend parsing settings.
+
+- **`language`** (`string`, optional): Source language handled by the frontend parser.
+- **`emit_parse_stage`** (`bool`, optional, default: `true`): Emit the parse-stage intermediate output.
+- **`emit_parse_stage_fatal`** (`bool`, optional, default: `false`): Treat parse-stage errors as fatal.
+
+### `[sources]`
+
+Remote source settings. See the [machine-readable schema](#machine-readable-schema) for the current field set (`morphir_common::remote::config`).
+
+### `[dependencies]` and `[dev-dependencies]`
+
+Maps of dependency name to a version constraint or a detailed table. `dependencies` lists the project's dependencies; `dev-dependencies` lists dependencies needed only for development.
+
+```toml
+[dependencies]
+acme-sdk = "^1.2.0"
+local-lib = { path = "../local-lib" }
+upstream = { git = "https://example.com/upstream.git", tag = "v2.0.0" }
+
+[dev-dependencies]
+test-utils = { workspace = true }
+```
+
+Each entry is either:
+
+- **A version string**: a SemVer constraint.
+- **A table**:
+  - **`version`** (`string`, optional)
+  - **`path`** (`string`, optional)
+  - **`git`** (`string`, optional)
+  - **`tag`** (`string`, optional)
+  - **`branch`** (`string`, optional)
+  - **`rev`** (`string`, optional)
+  - **`workspace`** (`bool`, optional)
+
+### `[extensions.<name>]`
+
+- **`path`** (`string`, optional)
+- **`url`** (`string`, optional)
+- **`command`** (`string`, optional)
+- **`args`** (`string[]`, optional)
+- **`enabled`** (`bool`, optional, default: `true`)
+- **`config`** (table, optional): Extension-specific configuration.
+
+## Secret values
+
+Some settings hold credentials. A conforming loader MUST treat a value at a position the schema declares as `secretValue` as secret: it MUST NOT display, log, or serialize the value, and tooling MUST obtain it only through an explicit exposing operation.
+
+A secret can also be supplied as a **secret reference**, which names where to obtain the secret instead of containing it:
+
+```toml
+[registry]
+token = { env = "GITHUB_TOKEN" }
+password = { file = "~/.config/morphir/registry-password" }
+```
+
+A secret reference is an inline table whose keys are exactly `env`, or exactly `file`, with a string value. Any other table, including one with both keys or with extra keys, is an ordinary table. A loader MUST recognise references at every position, not only at positions the schema declares as secret.
+
+- `env`: the secret is the value of the named environment variable. A missing or empty variable is an error when the secret is resolved.
+- `file`: the secret is the file's contents with one trailing newline removed. A relative path resolves against the directory of the configuration file that declares the reference; a leading `~` expands to the user's home directory. A missing or unreadable file is an error when the secret is resolved.
+
+Resolution happens only when tooling explicitly exposes the secret. Displaying the configuration, reporting sources, validating, and decoding MUST NOT resolve references. A reference MAY be displayed verbatim because it contains no secret; a plain-string secret MUST be displayed as a placeholder such as `<redacted>`.
+
+For merging, a secret reference is a leaf: a higher-precedence reference replaces a lower one entirely (see the [merge rules](./morphir-toml-merge-rules/)).
+
+The `command` reference kind and operating-system keyrings are reserved for a later version and MUST be rejected as unknown tables today.
+
 ## Tasks and workflows
 
 ### `[tasks.<taskName>]`
@@ -118,6 +196,8 @@ Tasks are project-scoped execution units. Each task is either:
 
 - **Intrinsic**: a built-in Morphir action (`kind = "intrinsic"`; `action = "..."`)
 - **Command**: an external command (`kind = "command"`; `cmd = ["..."]`)
+
+A string value is shorthand for a command task run through the shell: `build = "cargo build"`.
 
 Common task fields:
 
@@ -129,6 +209,10 @@ Common task fields:
 - **`params`** (table/object, optional): Arbitrary parameters
 - **`env`** (table/object, optional): `string -> string`
 - **`mounts`** (table/object, optional): mount name to permission (`"ro"`/`"rw"`)
+- **`description`** (`string`, optional)
+- **`run`** (`string`, optional): Shell command to run (alternative to `cmd`)
+- **`depends`** (`string[]`, optional)
+- **`cwd`** (`string`, optional)
 
 Intrinsic task fields:
 

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -171,7 +171,7 @@ Each entry is either:
 
 ## Secret values
 
-Some settings hold credentials. A conforming loader MUST treat a value at a position the schema declares as `secretValue` as secret: it MUST NOT display, log, or serialize the value, and tooling MUST obtain it only through an explicit exposing operation.
+Some settings hold credentials. A conforming loader MUST treat a value at a position the schema declares as `secretValue` as secret: it MUST NOT display, log, or serialize the value, and tooling MUST obtain it only through an explicit exposing operation. Schema version 1 defines `secretValue` but does not yet reference it from any property; the rule takes effect as soon as a credential field such as `registry.token` is declared with that type.
 
 A secret can also be supplied as a **secret reference**, which names where to obtain the secret instead of containing it:
 
@@ -190,7 +190,7 @@ Resolution happens only when tooling explicitly exposes the secret. Displaying t
 
 For merging, a secret reference is a leaf: a higher-precedence reference replaces a lower one entirely (see the [merge rules](./morphir-toml-merge-rules/)).
 
-The `command` reference kind and operating-system keyrings are reserved for a later version and MUST be rejected as unknown tables today.
+The `command` reference kind and operating-system keyrings are reserved for a later version. A table using them today (for example `{ command = [...] }`) matches neither `secretReference` branch: at a position the schema types as `secretValue` it therefore MUST be rejected as invalid, while at any other position it is an ordinary table and is merely an unrecognized property, treated like any other undeclared field.
 
 ## Tasks and workflows
 

--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -94,7 +94,7 @@ Decorations are sidecar metadata schemas/values attached to IR nodes.
 
 ### `[ir]`
 
-- **`format_version`** (`int`, optional, default: `3`): IR format version (supported range: 1–10).
+- **`format_version`** (`int`, optional, default: `4`): IR format version (supported range: 1–10).
 - **`strict_mode`** (`bool`, optional, default: `false`): When true, validation warnings are treated as errors.
 - **`mode`** (`string`, optional, default: `"vfs"`): One of `classic`, `vfs`.
 
@@ -132,7 +132,26 @@ Frontend parsing settings.
 
 ### `[sources]`
 
-Remote source settings. See the [machine-readable schema](#machine-readable-schema) for the current field set (`morphir_common::remote::config`).
+Remote source settings (`morphir_common::remote::config::RemoteSourceConfig`). Unlike most sections in this document, these fields serialize in **camelCase**, not snake_case.
+
+- **`enabled`** (`bool`, optional, default: `true`): Whether remote sources are enabled.
+- **`allow`** (`string[]`, optional): Glob patterns. If non-empty, only URLs matching an entry are allowed.
+- **`deny`** (`string[]`, optional): Glob patterns denied even when `allow` matches. Takes precedence over `allow`.
+- **`trustedGithubOrgs`** (`string[]`, optional): Trusted GitHub organizations/users.
+
+#### `[sources.cache]`
+
+- **`directory`** (`string`, optional): Cache directory (defaults to a platform cache directory under `morphir/sources`).
+- **`maxSizeMb`** (`int`, optional, default: `0`): Maximum cache size in MB (`0` = unlimited).
+- **`ttlSecs`** (`int`, optional, default: `0`): TTL for cached sources in seconds (`0` = never expire).
+
+#### `[sources.network]`
+
+- **`timeoutSecs`** (`int`, optional, default: `30`): Connection timeout in seconds.
+- **`httpProxy`** (`string`, optional): HTTP proxy URL.
+- **`httpsProxy`** (`string`, optional): HTTPS proxy URL.
+- **`maxRedirects`** (`int`, optional, default: `10`): Maximum number of redirects to follow.
+- **`userAgent`** (`string`, optional): User agent string.
 
 ### `[dependencies]` and `[dev-dependencies]`
 
@@ -203,9 +222,17 @@ Tasks are project-scoped execution units. Each task is either:
 
 A string value is shorthand for a command task run through the shell: `build = "cargo build"`.
 
+`depends` and `run` relate to the pre-existing `depends_on` and `cmd`/`action` fields as follows:
+
+- **`depends`** is an accepted alternative spelling of **`depends_on`**. A task MUST NOT set both `depends_on` and `depends`.
+- **`run`** is the string form of a command task: it is equivalent to the string shorthand above, and its presence implies `kind = "command"`. A task MUST NOT set both `run` and `cmd`, and MUST NOT set both `run` and `action`.
+
+> The schema enforces the two MUST-NOT rules above (a task cannot declare both members of either pair). It does not separately enforce that `run` implies `kind = "command"` when `kind` is omitted, because doing so would require restructuring the intrinsic/command task variants in the schema. A conforming loader MUST still apply the implication: a task with `run` set and `kind` omitted (and no conflicting `action`) is a command task, not an intrinsic one.
+
 Common task fields:
 
 - **`depends_on`** (`string[]`, optional)
+- **`depends`** (`string[]`, optional): Alternative spelling of `depends_on` (see above).
 - **`pre`** (`string[]`, optional)
 - **`post`** (`string[]`, optional)
 - **`inputs`** (`string[]`, optional)
@@ -214,13 +241,12 @@ Common task fields:
 - **`env`** (table/object, optional): `string -> string`
 - **`mounts`** (table/object, optional): mount name to permission (`"ro"`/`"rw"`)
 - **`description`** (`string`, optional)
-- **`run`** (`string`, optional): Shell command to run (alternative to `cmd`)
-- **`depends`** (`string[]`, optional)
+- **`run`** (`string`, optional): Shell command to run (alternative to `cmd`; see above).
 - **`cwd`** (`string`, optional)
 
 Intrinsic task fields:
 
-- **`kind`**: `"intrinsic"` (or omitted; omitted defaults to intrinsic)
+- **`kind`**: `"intrinsic"` (or omitted; omitted defaults to intrinsic, unless `run` is present without `action`, in which case the task is a command task per the rule above)
 - **`action`** (`string`, optional): Intrinsic action identifier (example: `morphir.pipeline.compile`)
 
 Command task fields:

--- a/docs/spec/morphir-yaml/morphir-yaml-specification.md
+++ b/docs/spec/morphir-yaml/morphir-yaml-specification.md
@@ -102,6 +102,11 @@ The root mapping accepts the same optional keys as `morphir.toml`:
 | `cache` | mapping | Cache settings |
 | `logging` | mapping | Logging settings |
 | `ui` | mapping | UI and TUI settings |
+| `frontend` | mapping | Frontend parsing settings |
+| `sources` | mapping | Remote source settings |
+| `dependencies` | mapping | Project dependencies |
+| `dev-dependencies` | mapping | Development-only dependencies |
+| `extensions` | mapping | Extension definitions |
 | `tasks` | mapping | Project task definitions |
 | `workflows` | mapping | Named workflows |
 | `bindings` | mapping | External binding type mappings |
@@ -145,7 +150,7 @@ Secret references use the same reserved shape as TOML, written as an ordinary ma
 ```yaml
 registry:
   token: { env: GITHUB_TOKEN }
-  password: { file: ~/.config/morphir/registry-password }
+  password: { file: "~/.config/morphir/registry-password" }
 ```
 
 Block style is equivalent:

--- a/docs/spec/morphir-yaml/morphir-yaml-specification.md
+++ b/docs/spec/morphir-yaml/morphir-yaml-specification.md
@@ -138,6 +138,26 @@ The hidden and non-hidden project paths are alternate locations, not two merge l
 
 After parsing, YAML sources use the [Morphir configuration merge rules](../morphir-toml/morphir-toml-merge-rules/). The merge algorithm operates on the configuration model, so maps merge recursively, sequences replace earlier sequences, and later sources take precedence.
 
+## Secret values
+
+Secret references use the same reserved shape as TOML, written as an ordinary mapping. No YAML tag is involved, so the [YAML profile](#yaml-profile) is unchanged:
+
+```yaml
+registry:
+  token: { env: GITHUB_TOKEN }
+  password: { file: ~/.config/morphir/registry-password }
+```
+
+Block style is equivalent:
+
+```yaml
+registry:
+  token:
+    env: GITHUB_TOKEN
+```
+
+The recognition rule, resolution rules, display rules, and merge behaviour are defined once in the [TOML specification](../morphir-toml/morphir-toml-specification/#secret-values) and apply unchanged: a mapping whose keys are exactly `env`, or exactly `file`, with a string value is a secret reference; anything else is an ordinary mapping.
+
 ## Complete example
 
 ```yaml title="morphir.yaml"

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,8 @@
 		"typecheck": "tsc",
 		"build:worker": "node scripts/build-validation-worker.js",
 		"build:schemas": "node scripts/yaml-to-json-schemas.js",
-		"test:config-schema": "node scripts/test-morphir-config-schema.js"
+		"test:config-schema": "node scripts/test-morphir-config-schema.js",
+		"check:schema-sync": "node scripts/check-config-schema-sync.js"
 	},
 	"dependencies": {
 		"effect": "3.22.1",

--- a/website/scripts/check-config-schema-sync.js
+++ b/website/scripts/check-config-schema-sync.js
@@ -21,6 +21,11 @@ const copy = path.join(repoRoot, 'ecosystem', 'morphir-rust', 'crates', 'morphir
 function read(file) {
   if (!fs.existsSync(file)) {
     console.error(`Missing: ${path.relative(repoRoot, file)}`);
+    if (file === copy) {
+      console.error('The embedded copy in morphir-rust has not been created yet.');
+      console.error(`Create ${path.relative(repoRoot, copy)} by copying the generated`);
+      console.error(`${path.relative(repoRoot, source)} over it, then bump the submodule.`);
+    }
     process.exit(1);
   }
   return fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');

--- a/website/scripts/check-config-schema-sync.js
+++ b/website/scripts/check-config-schema-sync.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Fails when morphir-rust's embedded copy of the configuration schema
+ * differs from the generated schema in this repository.
+ *
+ * The parent repository is the source of truth (static/schemas/*.yaml,
+ * converted by yaml-to-json-schemas.js). morphir-rust embeds the JSON so the
+ * loader can validate offline. This check runs in the parent's CI, where both
+ * files exist thanks to the submodule.
+ *
+ * Usage: node scripts/check-config-schema-sync.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const source = path.join(repoRoot, 'website', 'static', 'schemas', 'morphir-config-v1.json');
+const copy = path.join(repoRoot, 'ecosystem', 'morphir-rust', 'crates', 'morphir-common', 'schemas', 'morphir-config-v1.json');
+
+function read(file) {
+  if (!fs.existsSync(file)) {
+    console.error(`Missing: ${path.relative(repoRoot, file)}`);
+    process.exit(1);
+  }
+  return fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+}
+
+const sourceText = read(source);
+const copyText = read(copy);
+
+if (sourceText !== copyText) {
+  console.error('morphir-rust embeds an out-of-date morphir-config-v1.json.');
+  console.error(`  source: ${path.relative(repoRoot, source)}`);
+  console.error(`  copy:   ${path.relative(repoRoot, copy)}`);
+  console.error('Copy the source over the embedded file in morphir-rust and bump the submodule.');
+  process.exit(1);
+}
+
+console.log('morphir-config-v1.json is in sync with morphir-rust.');

--- a/website/scripts/test-morphir-config-schema.js
+++ b/website/scripts/test-morphir-config-schema.js
@@ -20,20 +20,52 @@ const cases = [
   ['command task with action', { tasks: { build: { kind: 'command', action: 'compile' } } }, false],
 ];
 
+// Cases validated against a single definition rather than the root schema.
+const definitionCases = [
+  ['secretValue', 'plain string', 'ghp_abc', true],
+  ['secretValue', 'env reference', { env: 'GITHUB_TOKEN' }, true],
+  ['secretValue', 'file reference', { file: '~/.config/morphir/token' }, true],
+  ['secretValue', 'env and file together', { env: 'A', file: 'b' }, false],
+  ['secretValue', 'env with extra key', { env: 'A', extra: true }, false],
+  ['secretValue', 'non-string env', { env: 1 }, false],
+  ['secretValue', 'empty object', {}, false],
+  ['secretValue', 'number', 42, false],
+];
+
 const schemaFiles = ['morphir-config-v1.yaml', 'morphir-config-v1.json'];
-const failures = schemaFiles.flatMap(schemaFile => {
+
+function loadSchema(schemaFile) {
   const schemaPath = path.join(schemasDirectory, schemaFile);
-  const schema = schemaFile.endsWith('.yaml')
+  return schemaFile.endsWith('.yaml')
     ? yaml.load(fs.readFileSync(schemaPath, 'utf8'))
     : JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
-  const validate = new Ajv({ allErrors: true, strict: false }).compile(schema);
+}
 
-  return cases.flatMap(([name, value, expected]) => {
+function definitionSchema(schema, name) {
+  return { $schema: schema.$schema, definitions: schema.definitions, $ref: `#/definitions/${name}` };
+}
+
+const failures = schemaFiles.flatMap(schemaFile => {
+  const schema = loadSchema(schemaFile);
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const validate = ajv.compile(schema);
+
+  const rootFailures = cases.flatMap(([name, value, expected]) => {
     const actual = validate(value);
     return actual === expected
       ? []
       : [`${schemaFile}, ${name}: expected ${expected}, received ${actual}\n${JSON.stringify(validate.errors, null, 2)}`];
   });
+
+  const definitionFailures = definitionCases.flatMap(([definition, name, value, expected]) => {
+    const validateDefinition = new Ajv({ allErrors: true, strict: false }).compile(definitionSchema(schema, definition));
+    const actual = validateDefinition(value);
+    return actual === expected
+      ? []
+      : [`${schemaFile}, ${definition} ${name}: expected ${expected}, received ${actual}\n${JSON.stringify(validateDefinition.errors, null, 2)}`];
+  });
+
+  return [...rootFailures, ...definitionFailures];
 });
 
 if (failures.length > 0) {
@@ -41,4 +73,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`Validated ${cases.length} task cases against ${schemaFiles.length} Morphir configuration schemas.`);
+console.log(`Validated ${cases.length} root cases and ${definitionCases.length} definition cases against ${schemaFiles.length} Morphir configuration schemas.`);

--- a/website/scripts/test-morphir-config-schema.js
+++ b/website/scripts/test-morphir-config-schema.js
@@ -20,6 +20,12 @@ const cases = [
   ['command task with action', { tasks: { build: { kind: 'command', action: 'compile' } } }, false],
   ['task string shorthand', { tasks: { build: 'cargo build' } }, true],
   ['task with run and depends', { tasks: { build: { description: 'Build', run: 'cargo build', depends: ['fmt'], cwd: 'crates/x', env: { CI: 'true' } } } }, true],
+  ['task depends alt spelling accepted alone', { tasks: { build: { kind: 'command', cmd: ['echo'], depends: ['fmt'] } } }, true],
+  ['task depends and depends_on together', { tasks: { build: { kind: 'command', cmd: ['echo'], depends: ['fmt'], depends_on: ['lint'] } } }, false],
+  ['task run alone implies command shorthand', { tasks: { build: { run: 'cargo build' } } }, true],
+  ['task run and cmd together', { tasks: { build: { kind: 'command', cmd: ['echo'], run: 'echo hi' } } }, false],
+  ['task run and action together', { tasks: { build: { kind: 'intrinsic', action: 'x', run: 'echo hi' } } }, false],
+  ['task action alone without run', { tasks: { build: { kind: 'intrinsic', action: 'compile' } } }, true],
   ['frontend section', { frontend: { language: 'elm', emit_parse_stage: true, emit_parse_stage_fatal: false } }, true],
   ['frontend with wrong type', { frontend: { emit_parse_stage: 'yes' } }, false],
   ['project extras', { project: { name: 'acme/orders', description: 'Orders', authors: ['Alice'], license: 'Apache-2.0', repository: 'https://example.com/r', output_directory: '.morphir/out' } }, true],
@@ -27,7 +33,10 @@ const cases = [
   ['ir mode wrong type', { ir: { mode: 4 } }, false],
   ['dependencies string and detailed', { dependencies: { 'finos/morphir-sdk': '1.0.0', local: { path: '../local', workspace: true } }, 'dev-dependencies': { git: { git: 'https://example.com/r.git', tag: 'v1' } } }, true],
   ['dependency detailed with wrong path type', { dependencies: { local: { path: 3 } } }, false],
-  ['extensions and sources', { extensions: { gleam: { path: 'ext/gleam.wasm', enabled: true, args: ['--x'], config: { a: 1 } } }, sources: { cache_dir: '.morphir/cache' } }, true],
+  ['extensions and sources', { extensions: { gleam: { path: 'ext/gleam.wasm', enabled: true, args: ['--x'], config: { a: 1 } } }, sources: { enabled: true, allow: ['https://github.com/*'], cache: { maxSizeMb: 100 } } }, true],
+  ['project.authors wrong element type', { project: { authors: [123] } }, false],
+  ['extensions enabled wrong type', { extensions: { gleam: { enabled: 'yes' } } }, false],
+  ['morphir.dev_mode wrong type', { morphir: { dev_mode: 'yes' } }, false],
 ];
 
 // Cases validated against a single definition rather than the root schema.

--- a/website/scripts/test-morphir-config-schema.js
+++ b/website/scripts/test-morphir-config-schema.js
@@ -18,6 +18,16 @@ const cases = [
   ['command kind omitted', { tasks: { build: { cmd: ['echo', 'hello'] } } }, false],
   ['intrinsic task with cmd', { tasks: { build: { kind: 'intrinsic', cmd: ['echo', 'hello'] } } }, false],
   ['command task with action', { tasks: { build: { kind: 'command', action: 'compile' } } }, false],
+  ['task string shorthand', { tasks: { build: 'cargo build' } }, true],
+  ['task with run and depends', { tasks: { build: { description: 'Build', run: 'cargo build', depends: ['fmt'], cwd: 'crates/x', env: { CI: 'true' } } } }, true],
+  ['frontend section', { frontend: { language: 'elm', emit_parse_stage: true, emit_parse_stage_fatal: false } }, true],
+  ['frontend with wrong type', { frontend: { emit_parse_stage: 'yes' } }, false],
+  ['project extras', { project: { name: 'acme/orders', description: 'Orders', authors: ['Alice'], license: 'Apache-2.0', repository: 'https://example.com/r', output_directory: '.morphir/out' } }, true],
+  ['ir mode and morphir extras', { ir: { mode: 'vfs' }, morphir: { min_cli_version: '0.2.0', dev_mode: true } }, true],
+  ['ir mode wrong type', { ir: { mode: 4 } }, false],
+  ['dependencies string and detailed', { dependencies: { 'finos/morphir-sdk': '1.0.0', local: { path: '../local', workspace: true } }, 'dev-dependencies': { git: { git: 'https://example.com/r.git', tag: 'v1' } } }, true],
+  ['dependency detailed with wrong path type', { dependencies: { local: { path: 3 } } }, false],
+  ['extensions and sources', { extensions: { gleam: { path: 'ext/gleam.wasm', enabled: true, args: ['--x'], config: { a: 1 } } }, sources: { cache_dir: '.morphir/cache' } }, true],
 ];
 
 // Cases validated against a single definition rather than the root schema.
@@ -30,6 +40,8 @@ const definitionCases = [
   ['secretValue', 'non-string env', { env: 1 }, false],
   ['secretValue', 'empty object', {}, false],
   ['secretValue', 'number', 42, false],
+  ['secretValue', 'file with extra key', { file: 'p', extra: true }, false],
+  ['secretValue', 'non-string file', { file: 1 }, false],
 ];
 
 const schemaFiles = ['morphir-config-v1.yaml', 'morphir-config-v1.json'];

--- a/website/static/schemas/morphir-config-v1.json
+++ b/website/static/schemas/morphir-config-v1.json
@@ -6,6 +6,49 @@
   "type": "object",
   "additionalProperties": true,
   "definitions": {
+    "secretReference": {
+      "description": "Where to obtain a secret. Exactly one of env or file.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "env"
+          ],
+          "properties": {
+            "env": {
+              "type": "string",
+              "description": "Name of the environment variable that holds the secret."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "file"
+          ],
+          "properties": {
+            "file": {
+              "type": "string",
+              "description": "Path to a file whose contents are the secret. Relative paths resolve against the declaring configuration file; ~ expands to the home directory."
+            }
+          }
+        }
+      ]
+    },
+    "secretValue": {
+      "description": "A credential. Either a plain string (treated as a secret and never displayed) or a secret reference.",
+      "x-secret": true,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/secretReference"
+        }
+      ]
+    },
     "stringMap": {
       "type": "object",
       "additionalProperties": {

--- a/website/static/schemas/morphir-config-v1.json
+++ b/website/static/schemas/morphir-config-v1.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://morphir.finos.org/schemas/morphir-config-v1.json",
   "title": "Morphir Configuration",
-  "description": "JSON Schema for the serialization-independent Morphir configuration model underlying morphir.toml and the proposed morphir.yaml format.",
+  "description": "JSON Schema for the serialization-independent Morphir configuration model underlying morphir.toml and morphir.yaml.",
   "type": "object",
   "additionalProperties": true,
   "definitions": {
@@ -217,7 +217,7 @@
       ]
     },
     "task": {
-      "description": "Project task definition. A string is shorthand for a command task run through the shell. kind omitted implies intrinsic.",
+      "description": "Project task definition. A string is shorthand for a command task run through the shell; with kind omitted, a table that sets run is a command task, and any other table is intrinsic.",
       "anyOf": [
         {
           "type": "string"

--- a/website/static/schemas/morphir-config-v1.json
+++ b/website/static/schemas/morphir-config-v1.json
@@ -58,6 +58,29 @@
     "taskCommon": {
       "type": "object",
       "additionalProperties": true,
+      "not": {
+        "description": "depends is an alternative spelling of depends_on (not both); run is the string form of a command task and is incompatible with cmd and with action (see the TOML specification's Tasks and workflows section).",
+        "anyOf": [
+          {
+            "required": [
+              "depends_on",
+              "depends"
+            ]
+          },
+          {
+            "required": [
+              "run",
+              "cmd"
+            ]
+          },
+          {
+            "required": [
+              "run",
+              "action"
+            ]
+          }
+        ]
+      },
       "properties": {
         "kind": {
           "type": "string",
@@ -511,6 +534,48 @@
           "additionalProperties": true
         }
       }
+    },
+    "sourcesCache": {
+      "description": "morphir_common::remote::config::CacheConfig. Fields serialize in camelCase.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "directory": {
+          "type": "string"
+        },
+        "maxSizeMb": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "ttlSecs": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "sourcesNetwork": {
+      "description": "morphir_common::remote::config::NetworkConfig. Fields serialize in camelCase.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "timeoutSecs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "httpProxy": {
+          "type": "string"
+        },
+        "httpsProxy": {
+          "type": "string"
+        },
+        "maxRedirects": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "userAgent": {
+          "type": "string"
+        }
+      }
     }
   },
   "properties": {
@@ -758,9 +823,38 @@
       }
     },
     "sources": {
-      "description": "Remote source settings (see morphir_common::remote::config).",
+      "description": "Remote source settings (morphir_common::remote::config::RemoteSourceConfig). Fields serialize in camelCase.",
       "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "allow": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deny": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trustedGithubOrgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cache": {
+          "$ref": "#/definitions/sourcesCache"
+        },
+        "network": {
+          "$ref": "#/definitions/sourcesNetwork"
+        }
+      }
     },
     "dependencies": {
       "type": "object",

--- a/website/static/schemas/morphir-config-v1.json
+++ b/website/static/schemas/morphir-config-v1.json
@@ -114,6 +114,22 @@
         },
         "mounts": {
           "$ref": "#/definitions/stringMap"
+        },
+        "description": {
+          "type": "string"
+        },
+        "run": {
+          "type": "string",
+          "description": "Shell command to run (alternative to cmd)."
+        },
+        "depends": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "type": "string"
         }
       }
     },
@@ -178,8 +194,11 @@
       ]
     },
     "task": {
-      "description": "Project task definition. kind omitted implies intrinsic.",
+      "description": "Project task definition. A string is shorthand for a command task run through the shell. kind omitted implies intrinsic.",
       "anyOf": [
+        {
+          "type": "string"
+        },
         {
           "$ref": "#/definitions/commandTask"
         },
@@ -429,6 +448,69 @@
           "type": "string"
         }
       }
+    },
+    "dependency": {
+      "description": "A dependency: a version string, or a detailed table.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "version": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "git": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "rev": {
+              "type": "string"
+            },
+            "workspace": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "extension": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
     }
   },
   "properties": {
@@ -438,6 +520,12 @@
       "properties": {
         "version": {
           "type": "string"
+        },
+        "min_cli_version": {
+          "type": "string"
+        },
+        "dev_mode": {
+          "type": "boolean"
         }
       }
     },
@@ -495,6 +583,24 @@
           "additionalProperties": {
             "$ref": "#/definitions/decoration"
           }
+        },
+        "description": {
+          "type": "string"
+        },
+        "authors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "license": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "output_directory": {
+          "type": "string"
         }
       }
     },
@@ -509,6 +615,13 @@
         },
         "strict_mode": {
           "type": "boolean"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "classic",
+            "vfs"
+          ]
         }
       }
     },
@@ -627,6 +740,44 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/toolchain"
+      }
+    },
+    "frontend": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "language": {
+          "type": "string"
+        },
+        "emit_parse_stage": {
+          "type": "boolean"
+        },
+        "emit_parse_stage_fatal": {
+          "type": "boolean"
+        }
+      }
+    },
+    "sources": {
+      "description": "Remote source settings (see morphir_common::remote::config).",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/dependency"
+      }
+    },
+    "dev-dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/dependency"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/extension"
       }
     }
   }

--- a/website/static/schemas/morphir-config-v1.yaml
+++ b/website/static/schemas/morphir-config-v1.yaml
@@ -70,6 +70,16 @@ definitions:
         $ref: "#/definitions/stringMap"
       mounts:
         $ref: "#/definitions/stringMap"
+      description:
+        type: string
+      run:
+        type: string
+        description: "Shell command to run (alternative to cmd)."
+      depends:
+        type: array
+        items: { type: string }
+      cwd:
+        type: string
 
   intrinsicTask:
     allOf:
@@ -102,8 +112,9 @@ definitions:
             items: { type: string }
 
   task:
-    description: "Project task definition. kind omitted implies intrinsic."
+    description: "Project task definition. A string is shorthand for a command task run through the shell. kind omitted implies intrinsic."
     anyOf:
+      - type: string
       - $ref: "#/definitions/commandTask"
       - $ref: "#/definitions/intrinsicTask"
 
@@ -239,12 +250,44 @@ definitions:
       entry_point: { type: string }
       storage_location: { type: string }
 
+  dependency:
+    description: "A dependency: a version string, or a detailed table."
+    anyOf:
+      - type: string
+      - type: object
+        additionalProperties: true
+        properties:
+          version: { type: string }
+          path: { type: string }
+          git: { type: string }
+          tag: { type: string }
+          branch: { type: string }
+          rev: { type: string }
+          workspace: { type: boolean }
+
+  extension:
+    type: object
+    additionalProperties: true
+    properties:
+      path: { type: string }
+      url: { type: string }
+      command: { type: string }
+      args:
+        type: array
+        items: { type: string }
+      enabled: { type: boolean }
+      config:
+        type: object
+        additionalProperties: true
+
 properties:
   morphir:
     type: object
     additionalProperties: true
     properties:
       version: { type: string }
+      min_cli_version: { type: string }
+      dev_mode: { type: boolean }
 
   workspace:
     type: object
@@ -275,6 +318,13 @@ properties:
         type: object
         additionalProperties:
           $ref: "#/definitions/decoration"
+      description: { type: string }
+      authors:
+        type: array
+        items: { type: string }
+      license: { type: string }
+      repository: { type: string }
+      output_directory: { type: string }
 
   ir:
     type: object
@@ -285,6 +335,9 @@ properties:
         minimum: 1
         maximum: 10
       strict_mode: { type: boolean }
+      mode:
+        type: string
+        enum: ["classic", "vfs"]
 
   codegen:
     type: object
@@ -352,3 +405,31 @@ properties:
     type: object
     additionalProperties:
       $ref: "#/definitions/toolchain"
+
+  frontend:
+    type: object
+    additionalProperties: true
+    properties:
+      language: { type: string }
+      emit_parse_stage: { type: boolean }
+      emit_parse_stage_fatal: { type: boolean }
+
+  sources:
+    description: "Remote source settings (see morphir_common::remote::config)."
+    type: object
+    additionalProperties: true
+
+  dependencies:
+    type: object
+    additionalProperties:
+      $ref: "#/definitions/dependency"
+
+  dev-dependencies:
+    type: object
+    additionalProperties:
+      $ref: "#/definitions/dependency"
+
+  extensions:
+    type: object
+    additionalProperties:
+      $ref: "#/definitions/extension"

--- a/website/static/schemas/morphir-config-v1.yaml
+++ b/website/static/schemas/morphir-config-v1.yaml
@@ -39,6 +39,12 @@ definitions:
   taskCommon:
     type: object
     additionalProperties: true
+    not:
+      description: "depends is an alternative spelling of depends_on (not both); run is the string form of a command task and is incompatible with cmd and with action (see the TOML specification's Tasks and workflows section)."
+      anyOf:
+        - required: ["depends_on", "depends"]
+        - required: ["run", "cmd"]
+        - required: ["run", "action"]
     properties:
       kind:
         type: string
@@ -280,6 +286,34 @@ definitions:
         type: object
         additionalProperties: true
 
+  sourcesCache:
+    description: "morphir_common::remote::config::CacheConfig. Fields serialize in camelCase."
+    type: object
+    additionalProperties: true
+    properties:
+      directory: { type: string }
+      maxSizeMb:
+        type: integer
+        minimum: 0
+      ttlSecs:
+        type: integer
+        minimum: 0
+
+  sourcesNetwork:
+    description: "morphir_common::remote::config::NetworkConfig. Fields serialize in camelCase."
+    type: object
+    additionalProperties: true
+    properties:
+      timeoutSecs:
+        type: integer
+        minimum: 0
+      httpProxy: { type: string }
+      httpsProxy: { type: string }
+      maxRedirects:
+        type: integer
+        minimum: 0
+      userAgent: { type: string }
+
 properties:
   morphir:
     type: object
@@ -415,9 +449,22 @@ properties:
       emit_parse_stage_fatal: { type: boolean }
 
   sources:
-    description: "Remote source settings (see morphir_common::remote::config)."
+    description: "Remote source settings (morphir_common::remote::config::RemoteSourceConfig). Fields serialize in camelCase."
     type: object
     additionalProperties: true
+    properties:
+      enabled: { type: boolean }
+      allow:
+        type: array
+        items: { type: string }
+      deny:
+        type: array
+        items: { type: string }
+      trustedGithubOrgs:
+        type: array
+        items: { type: string }
+      cache: { $ref: "#/definitions/sourcesCache" }
+      network: { $ref: "#/definitions/sourcesNetwork" }
 
   dependencies:
     type: object

--- a/website/static/schemas/morphir-config-v1.yaml
+++ b/website/static/schemas/morphir-config-v1.yaml
@@ -1,7 +1,7 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 $id: "https://morphir.finos.org/schemas/morphir-config-v1.yaml"
 title: "Morphir Configuration"
-description: "JSON Schema for the serialization-independent Morphir configuration model underlying morphir.toml and the proposed morphir.yaml format."
+description: "JSON Schema for the serialization-independent Morphir configuration model underlying morphir.toml and morphir.yaml."
 type: object
 additionalProperties: true
 
@@ -118,7 +118,7 @@ definitions:
             items: { type: string }
 
   task:
-    description: "Project task definition. A string is shorthand for a command task run through the shell. kind omitted implies intrinsic."
+    description: "Project task definition. A string is shorthand for a command task run through the shell; with kind omitted, a table that sets run is a command task, and any other table is intrinsic."
     anyOf:
       - type: string
       - $ref: "#/definitions/commandTask"

--- a/website/static/schemas/morphir-config-v1.yaml
+++ b/website/static/schemas/morphir-config-v1.yaml
@@ -6,6 +6,31 @@ type: object
 additionalProperties: true
 
 definitions:
+  secretReference:
+    description: "Where to obtain a secret. Exactly one of env or file."
+    oneOf:
+      - type: object
+        additionalProperties: false
+        required: ["env"]
+        properties:
+          env:
+            type: string
+            description: "Name of the environment variable that holds the secret."
+      - type: object
+        additionalProperties: false
+        required: ["file"]
+        properties:
+          file:
+            type: string
+            description: "Path to a file whose contents are the secret. Relative paths resolve against the declaring configuration file; ~ expands to the home directory."
+
+  secretValue:
+    description: "A credential. Either a plain string (treated as a secret and never displayed) or a secret reference."
+    x-secret: true
+    anyOf:
+      - type: string
+      - $ref: "#/definitions/secretReference"
+
   stringMap:
     type: object
     additionalProperties:


### PR DESCRIPTION
Makes `morphir-config-v1` the authoritative, complete description of Morphir's configuration model, and specifies **secret values** in both serializations. This is step 2 of the configuration value tree design; the Rust loader change follows and depends on it.

## Secret values

A credential can be written as a plain string, or as a **secret reference** that names where the secret lives instead of containing it — the same shape in both serializations:

```toml
[registry]
token = { env = "GITHUB_TOKEN" }
password = { file = "~/.config/morphir/registry-password" }
```

The recognition rule is deliberately narrow, and `definitions.secretReference` encodes exactly it: an object whose keys are **exactly** `env`, or **exactly** `file`, with a string value. Both keys together, an extra key, a non-string value, or an empty object is an ordinary object. Ten schema cases pin that boundary from both branches. `definitions.secretValue` (`anyOf [string, secretReference]`, annotated `x-secret: true`) is the type credential properties will use; v1 references it from no property yet, and the spec says so rather than leaving readers to wonder.

## Closing the schema's drift from the model

The schema is now the contract that every Morphir binding implements against, and the Rust loader will soon validate against it strictly — so a section the schema failed to document would become a spurious failure for a config that loads fine today. Added: `frontend`, `sources` (with `[sources.cache]` / `[sources.network]`, fields and defaults taken from `RemoteSourceConfig`), `dependencies` / `dev-dependencies`, `extensions`, `ir.mode`, `morphir.min_cli_version` / `dev_mode`, five more `project` fields, the task string shorthand, and `run` / `depends` / `cwd` / `description`.

Adding `run` and `depends` beside the existing `cmd` and `depends_on` created an ambiguity a second binding could not resolve, so the spec now states the relationship normatively — `depends` is an alternative spelling of `depends_on`; `run` is the string form of a command task — and the schema encodes the mutual exclusions it can express. The one implication it cannot express without restructuring (`run` with `kind` omitted means a command task) is stated in prose and explicitly flagged as unenforced by the schema.

## Specifications

Secret values are specified once in the TOML specification, with the YAML spelling in the YAML specification pointing back rather than restating. The merge rules gain a secret-leaf rule — if **either** side is a secret value the overlay replaces the base, so a plain table can never deep-merge into a reference and corrupt it — and a provenance section, marked as specified-for-future-implementation. The user guide's Secrets section says plainly that references are specified but not yet implemented, and describes what `morphir config show` actually does today.

## Drift guard

`website/scripts/check-config-schema-sync.js` compares the generated JSON with the copy morphir-rust will embed. That copy does not exist yet, so the guard exits 1 with an explanation of why and what to do; the Rust change creates the copy and wires the guard into CI.

## Verification

`npm run test:config-schema` — 29 root cases and 10 definition cases against both the YAML and JSON schemas. `npm run build:schemas` is idempotent, so the committed JSON is provably generator output. Both specifications and the schema list exactly the same 17 top-level keys.

Also carries one housekeeping commit gitignoring a `.dev/` scratch directory and documenting it in AGENTS.md.