### PR TITLE
fix: restore ir.format_version default 3

### DIFF
--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -94,7 +94,7 @@ Decorations are sidecar metadata schemas/values attached to IR nodes.
 
 ### `[ir]`
 
-- **`format_version`** (`int`, optional, default: `4`): IR format version (supported range: 1–10).
+- **`format_version`** (`int`, optional, default: `3`): IR format version (supported range: 1–10). Version 4 is under active development; a project opts into it explicitly.
 - **`strict_mode`** (`bool`, optional, default: `false`): When true, validation warnings are treated as errors.
 - **`mode`** (`string`, optional, default: `"vfs"`): One of `classic`, `vfs`.
 


### PR DESCRIPTION
Restores `ir.format_version` default 3 and picks up the implementation fix.

IR 3 is the current default; version 4 is under active development, so a project opts into it explicitly. Two places had drifted to 4 — `default_format_version()` in the typed configuration model and the built-in defaults layer the loader seeds — which silently opted every project that does not set the field into the in-progress format. finos/morphir-rust#84 fixed those; this reverts the spec line that had been changed to match the drifted implementation, and notes that 4 is in development.

The submodule bump also carries the devkit documentation follow-ups (retired-URL redirect, retired crate-name note) merged since the last bump.