### PR TITLE
feat: default ir.format_version to 4

### DIFF
--- a/docs/spec/morphir-toml/morphir-toml-specification.md
+++ b/docs/spec/morphir-toml/morphir-toml-specification.md
@@ -94,7 +94,7 @@ Decorations are sidecar metadata schemas/values attached to IR nodes.
 
 ### `[ir]`
 
-- **`format_version`** (`int`, optional, default: `3`): IR format version (supported range: 1–10). Version 4 is under active development; a project opts into it explicitly.
+- **`format_version`** (`int`, optional, default: `4`): IR format version (supported range: 1–10). Version 4 is where active development happens. Version 3 remains supported; a project stays on it by setting this field explicitly.
 - **`strict_mode`** (`bool`, optional, default: `false`): When true, validation warnings are treated as errors.
 - **`mode`** (`string`, optional, default: `"vfs"`): One of `classic`, `vfs`.
 


### PR DESCRIPTION
Version 4 is where active development happens, so it is the default for `ir.format_version`. Follows finos/morphir-rust#85, which makes the implementation agree and — the part that matters — pins version 3 with tests so it does not rot now that it is no longer the default path.

Version 3 remains supported; a project stays on it by setting `ir.format_version = 3`.

Bumps the submodule to that change.