### PR TITLE
Publish Morphir CLI release artifacts

### DIFF
--- a/.github/scripts/select_release_assets.py
+++ b/.github/scripts/select_release_assets.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import argparse
+import hashlib
+import shutil
+from pathlib import Path
+
+
+def read_checksum(path: Path) -> str:
+    fields = path.read_text(encoding="utf-8").split()
+    if not fields:
+        raise ValueError(f"Checksum file is empty: {path}")
+
+    digest = fields[0].lower()
+    if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+        raise ValueError(f"Checksum file does not contain a SHA-256 hash: {path}")
+    return digest
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def select_release_assets(
+    release_assets: Path,
+    published_checksums: Path,
+    published_assets: set[str],
+    upload_dir: Path,
+) -> list[str]:
+    checksum_files = sorted(release_assets.glob("*.sha256"))
+    if not checksum_files:
+        raise ValueError(f"No checksum files found in {release_assets}")
+
+    archives = sorted(
+        path
+        for path in release_assets.iterdir()
+        if path.is_file() and path.suffix != ".sha256"
+    )
+    missing_checksums = [
+        archive.name
+        for archive in archives
+        if not (release_assets / f"{archive.name}.sha256").is_file()
+    ]
+    if missing_checksums:
+        raise ValueError(
+            "Release assets are missing checksums: " + ", ".join(missing_checksums)
+        )
+
+    selected: list[str] = []
+    for checksum_file in checksum_files:
+        archive_name = checksum_file.name.removesuffix(".sha256")
+        archive = release_assets / archive_name
+        if not archive.is_file():
+            raise ValueError(f"Checksum has no matching release asset: {checksum_file.name}")
+
+        declared_hash = read_checksum(checksum_file)
+        actual_hash = sha256(archive)
+        if declared_hash != actual_hash:
+            raise ValueError(
+                f"Checksum for {archive_name} does not match the packaged artifact"
+            )
+
+        published_checksum = published_checksums / checksum_file.name
+        published_hash = None
+        if published_checksum.is_file():
+            try:
+                published_hash = read_checksum(published_checksum)
+            except ValueError:
+                published_hash = None
+
+        published_pair_exists = (
+            archive_name in published_assets and checksum_file.name in published_assets
+        )
+        if published_pair_exists and published_hash == actual_hash:
+            print(f"Skipping unchanged release asset: {archive_name}")
+            continue
+
+        upload_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(archive, upload_dir / archive.name)
+        shutil.copy2(checksum_file, upload_dir / checksum_file.name)
+        selected.extend([archive.name, checksum_file.name])
+        print(f"Selected release asset for upload: {archive_name}")
+
+    return selected
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Select release artifacts whose published SHA-256 hash changed."
+    )
+    parser.add_argument("--release-assets", type=Path, required=True)
+    parser.add_argument("--published-checksums", type=Path, required=True)
+    parser.add_argument("--published-assets", type=Path, required=True)
+    parser.add_argument("--upload-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    published_assets = (
+        set(args.published_assets.read_text(encoding="utf-8").splitlines())
+        if args.published_assets.is_file()
+        else set()
+    )
+    select_release_assets(
+        args.release_assets,
+        args.published_checksums,
+        published_assets,
+        args.upload_dir,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
               - '.github/workflows/ci.yml'
             release:
               - '.github/workflows/release.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
               - 'crates/morphir/Cargo.toml'
               - 'tests/ci/test_release_workflow.py'
               - 'tests/ci/test_select_release_assets.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
               - '.github/workflows/release.yml'
               - 'crates/morphir/Cargo.toml'
               - 'tests/ci/test_release_workflow.py'
+              - 'tests/ci/test_select_release_assets.py'
+              - '.github/scripts/select_release_assets.py'
               - '.github/workflows/ci.yml'
 
   # morphir-live: web UI application (depends on dioxus)
@@ -160,7 +162,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Validate release workflow
-        run: python3 -B -m unittest tests.ci.test_release_workflow
+        run: python3 -B -m unittest discover -s tests/ci
 
   check:
     name: All Checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       docs: ${{ steps.filter.outputs.docs }}
+      release: ${{ steps.filter.outputs.release }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -46,6 +47,11 @@ jobs:
               - '**/*.md'
               # the script the Docs job runs
               - '.config/mise/tasks/ci/validate_docs.py'
+              - '.github/workflows/ci.yml'
+            release:
+              - '.github/workflows/release.yml'
+              - 'crates/morphir/Cargo.toml'
+              - 'tests/ci/test_release_workflow.py'
               - '.github/workflows/ci.yml'
 
   # morphir-live: web UI application (depends on dioxus)
@@ -144,10 +150,22 @@ jobs:
       - name: Validate documentation
         run: python3 .config/mise/tasks/ci/validate_docs.py
 
+  release-workflow:
+    name: Release workflow
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.release == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Validate release workflow
+        run: python3 -B -m unittest tests.ci.test_release_workflow
+
   check:
     name: All Checks
     runs-on: ubuntu-latest
-    needs: [changes, morphir-live, morphir-cli, docs]
+    needs: [changes, morphir-live, morphir-cli, docs, release-workflow]
     if: always()
     steps:
       - name: Check results
@@ -167,6 +185,12 @@ jobs:
           if [[ "${{ needs.changes.outputs.docs }}" == "true" ]]; then
             if [[ "${{ needs.docs.result }}" != "success" ]]; then
               echo "docs failed"
+              exit 1
+            fi
+          fi
+          if [[ "${{ needs.changes.outputs.release }}" == "true" ]]; then
+            if [[ "${{ needs.release-workflow.result }}" != "success" ]]; then
+              echo "release workflow validation failed"
               exit 1
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,30 +7,54 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to release (e.g., v0.1.0)'
+        description: 'Existing tag to release (for example, v0.1.0)'
         required: true
         type: string
 
 permissions:
-  contents: write
-  pages: write
-  id-token: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build Release
+  release-info:
+    name: Validate release tag
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
-      - name: Fetch all tags
-        run: git fetch --force --tags
+      - name: Validate release tag
+        id: release
+        shell: bash
+        run: |
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          VERSION=$(python3 -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["workspace"]["package"]["version"])')
+          EXPECTED_TAG="v${VERSION}"
+          if [ "$TAG" != "$EXPECTED_TAG" ]; then
+            echo "Release tag $TAG does not match workspace version $VERSION."
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  package-live:
+    name: Package Morphir Live
+    runs-on: ubuntu-latest
+    needs: release-info
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-info.outputs.tag }}
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -39,97 +63,158 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          key: morphir-live-release
 
       - name: Install dioxus-cli
         run: cargo install dioxus-cli
-
-      - name: Determine version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
 
       - name: Build WASM release
         working-directory: crates/morphir-live
         run: dx build --release
 
       - name: Create release archive
+        shell: bash
         run: |
-          cd crates/morphir-live/dist
-          tar -czvf ../../../morphir-live-${{ steps.version.outputs.VERSION }}.tar.gz .
-          cd ../../..
+          ARCHIVE="morphir-live-${{ needs.release-info.outputs.version }}.tar.gz"
+          tar -C crates/morphir-live/dist -czf "$ARCHIVE" .
+          shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
           name: morphir-live-wasm
-          path: morphir-live-*.tar.gz
-
-  release:
-    name: Create Release
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Determine version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: morphir-live-wasm
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.version.outputs.VERSION }}
-          name: Release ${{ steps.version.outputs.VERSION }}
-          draft: false
-          prerelease: ${{ contains(steps.version.outputs.VERSION, '-') }}
-          files: |
+          path: |
             morphir-live-*.tar.gz
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            morphir-live-*.tar.gz.sha256
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
 
-  # Optional: Deploy to GitHub Pages
-  deploy-pages:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  package-cli:
+    name: Package Morphir CLI (${{ matrix.target }})
+    needs: release-info
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            archive: tgz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            archive: tgz
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+            archive: tgz
+          - os: macos-15
+            target: aarch64-apple-darwin
+            archive: tgz
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+            archive: zip
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            archive: zip
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-info.outputs.tag }}
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: ${{ matrix.target }}
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          key: morphir-cli-${{ matrix.target }}
 
-      - name: Install dioxus-cli
-        run: cargo install dioxus-cli
+      - name: Build CLI
+        run: cargo build --locked --release --package morphir --target ${{ matrix.target }}
 
-      - name: Build for GitHub Pages
-        working-directory: crates/morphir-live
-        run: dx build --release
+      - name: Package CLI
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          ARCHIVE="morphir-${{ needs.release-info.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}"
+          mkdir release-assets
+          tar -C "target/${{ matrix.target }}/release" -czf "release-assets/${ARCHIVE}" morphir
+          shasum -a 256 "release-assets/${ARCHIVE}" > "release-assets/${ARCHIVE}.sha256"
+
+      - name: Package CLI
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $archive = "morphir-${{ needs.release-info.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}"
+          New-Item -ItemType Directory -Path release-assets
+          Compress-Archive `
+            -Path "target/${{ matrix.target }}/release/morphir.exe" `
+            -DestinationPath "release-assets/$archive"
+          $hash = (Get-FileHash "release-assets/$archive" -Algorithm SHA256).Hash.ToLower()
+          "$hash  $archive" | Set-Content "release-assets/$archive.sha256"
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: morphir-cli-${{ matrix.target }}
+          path: release-assets/*
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+  publish-release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    needs: [release-info, package-live, package-cli]
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.release-info.outputs.tag }}
+          name: Release ${{ needs.release-info.outputs.tag }}
+          draft: false
+          prerelease: ${{ contains(needs.release-info.outputs.tag, '-') }}
+          files: |
+            release-assets/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-pages:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: [release-info, package-live]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download Morphir Live artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: morphir-live-wasm
+
+      - name: Extract Morphir Live artifact
+        run: |
+          mkdir pages-dist
+          tar -xzf morphir-live-*.tar.gz -C pages-dist
 
       - name: Setup Pages
         uses: actions/configure-pages@v6
@@ -137,7 +222,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: crates/morphir-live/dist
+          path: pages-dist
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to release (for example, v0.1.0)'
+        description: 'Existing tag to release (for example, v0.2.0-alpha-01)'
         required: true
         type: string
 
@@ -174,25 +174,64 @@ jobs:
     needs: [release-info, package-live, package-cli]
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ needs.release-info.outputs.tag }}
     steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.release-info.outputs.tag }}
+          sparse-checkout: .github/scripts
+
       - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
           path: release-assets
           merge-multiple: true
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.release-info.outputs.tag }}
-          name: Release ${{ needs.release-info.outputs.tag }}
-          draft: false
-          prerelease: ${{ contains(needs.release-info.outputs.tag, '-') }}
-          files: |
-            release-assets/*
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read published checksums
+        shell: bash
+        run: |
+          mkdir -p published-checksums
+          if gh release view "$TAG" --json assets --jq '.assets[].name' > published-assets.txt 2>/dev/null; then
+            gh release download "$TAG" --pattern '*.sha256' --dir published-checksums || true
+          else
+            : > published-assets.txt
+          fi
+
+      - name: Select changed artifacts
+        run: |
+          python3 .github/scripts/select_release_assets.py \
+            --release-assets release-assets \
+            --published-checksums published-checksums \
+            --published-assets published-assets.txt \
+            --upload-dir upload-assets
+
+      - name: Create GitHub release if needed
+        shell: bash
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists."
+            exit 0
+          fi
+
+          CREATE_ARGS=("$TAG" --title "Release $TAG" --generate-notes)
+          if [[ "$TAG" == *-* ]]; then
+            CREATE_ARGS+=(--prerelease)
+          fi
+          gh release create "${CREATE_ARGS[@]}"
+
+      - name: Upload changed artifacts
+        shell: bash
+        run: |
+          shopt -s nullglob
+          ASSETS=(upload-assets/*)
+          if (( ${#ASSETS[@]} == 0 )); then
+            echo "All release artifacts already match their published hashes."
+            exit 0
+          fi
+          gh release upload "$TAG" "${ASSETS[@]}" --clobber
 
   deploy-pages:
     name: Deploy to GitHub Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,10 @@ jobs:
           ARCHIVE="morphir-${{ needs.release-info.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}"
           mkdir release-assets
           tar -C "target/${{ matrix.target }}/release" -czf "release-assets/${ARCHIVE}" morphir
-          shasum -a 256 "release-assets/${ARCHIVE}" > "release-assets/${ARCHIVE}.sha256"
+          (
+            cd release-assets
+            shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
+          )
 
       - name: Package CLI
         if: runner.os == 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4920,7 +4920,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-common"
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4944,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-core"
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-daemon"
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-devkit"
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4994,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-extension-sdk"
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 dependencies = [
  "extism-pdk",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "morphir"
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-live"
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 dependencies = [
  "clap",
  "dioxus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/morphir-live", "crates/morphir"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0-alpha-01"
 edition = "2024"
 rust-version = "1.93"
 authors = [

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,0 +1,107 @@
+# Installing Morphir
+
+This repository publishes the Morphir CLI as a prebuilt executable for Linux,
+macOS, and Windows. Both x86-64 and ARM64 packages are available.
+
+## Install with mise
+
+[mise](https://mise.jdx.dev/) can download the correct executable from the
+Morphir GitHub release for your operating system and processor.
+
+Install the latest stable release globally:
+
+```shell
+mise use -g github:finos/morphir
+```
+
+Install a specific version:
+
+```shell
+mise use -g github:finos/morphir@VERSION
+```
+
+To pin Morphir in a project's `mise.toml`, add:
+
+```toml
+[tools]
+"github:finos/morphir" = "VERSION"
+```
+
+Replace `VERSION` with the version the project requires. Run `mise install`
+after changing the configuration.
+
+Check the installation:
+
+```shell
+morphir version
+```
+
+## Install a release archive manually
+
+Download the archive for your system from
+[GitHub Releases](https://github.com/finos/morphir/releases).
+
+| System | Processor | Asset suffix |
+| --- | --- | --- |
+| Linux | x86-64 | `x86_64-unknown-linux-gnu.tgz` |
+| Linux | ARM64 | `aarch64-unknown-linux-gnu.tgz` |
+| macOS | Intel | `x86_64-apple-darwin.tgz` |
+| macOS | Apple silicon | `aarch64-apple-darwin.tgz` |
+| Windows | x86-64 | `x86_64-pc-windows-msvc.zip` |
+| Windows | ARM64 | `aarch64-pc-windows-msvc.zip` |
+
+Each archive contains one executable named `morphir`, or `morphir.exe` on
+Windows. Extract it and move it to a directory on `PATH`.
+
+Linux and macOS:
+
+```shell
+mkdir -p "$HOME/.local/bin"
+tar -xzf morphir-<version>-<target>.tgz
+install -m 0755 morphir "$HOME/.local/bin/morphir"
+```
+
+Windows PowerShell:
+
+```powershell
+Expand-Archive morphir-<version>-<target>.zip
+Move-Item .\morphir.exe $env:LOCALAPPDATA\Microsoft\WindowsApps\morphir.exe
+```
+
+The release also includes a `.sha256` file for every archive. Verify the
+download before extracting it:
+
+```shell
+# Linux
+sha256sum -c morphir-<version>-<target>.tgz.sha256
+
+# macOS
+shasum -a 256 -c morphir-<version>-<target>.tgz.sha256
+```
+
+```powershell
+$expected = (Get-Content morphir-<version>-<target>.zip.sha256).Split()[0]
+$actual = (Get-FileHash morphir-<version>-<target>.zip -Algorithm SHA256).Hash
+if ($actual -ne $expected) { throw "Checksum verification failed" }
+```
+
+## Build from source
+
+Building from source requires Git, [mise](https://mise.jdx.dev/), and the
+platform build tools required by Rust.
+
+```shell
+git clone --recurse-submodules https://github.com/finos/morphir.git
+cd morphir
+mise install
+cargo build --locked --release --package morphir
+```
+
+The executable is written to `target/release/morphir` on Linux and macOS, or
+`target\release\morphir.exe` on Windows.
+
+## Morphir Live
+
+Each release includes `morphir-live-<version>.tar.gz`. This is the static web
+build used for hosted deployments. Extract the archive into the document root
+of a static web server. It is not a desktop installer.

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -8,27 +8,21 @@ macOS, and Windows. Both x86-64 and ARM64 packages are available.
 [mise](https://mise.jdx.dev/) can download the correct executable from the
 Morphir GitHub release for your operating system and processor.
 
-Install the latest stable release globally:
+Install the current prerelease globally:
 
 ```shell
-mise use -g github:finos/morphir
-```
-
-Install a specific version:
-
-```shell
-mise use -g github:finos/morphir@VERSION
+mise use -g github:finos/morphir@0.2.0-alpha-01
 ```
 
 To pin Morphir in a project's `mise.toml`, add:
 
 ```toml
 [tools]
-"github:finos/morphir" = "VERSION"
+"github:finos/morphir" = "0.2.0-alpha-01"
 ```
 
-Replace `VERSION` with the version the project requires. Run `mise install`
-after changing the configuration.
+Run `mise install` after changing the configuration. Prereleases must be
+selected explicitly. A request for `latest` does not select them by default.
 
 Check the installation:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Defines a standard format for storing and sharing business logic. A clear set of
 
 
 ## Documentation
-If you want to start using Morphir, start with the [Documentation](docs/).
+
+To install the Morphir CLI, see [Installing Morphir](INSTALLING.md). For guides,
+concepts, and reference material, start with the [Documentation](docs/).
 
 ### For Contributors
 

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 CARGO_TOML_PATH = REPO_ROOT / "crates" / "morphir" / "Cargo.toml"
 WORKSPACE_TOML_PATH = REPO_ROOT / "Cargo.toml"
 CARGO_LOCK_PATH = REPO_ROOT / "Cargo.lock"
@@ -14,6 +15,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.ci_workflow = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
         cls.cargo_toml = CARGO_TOML_PATH.read_text(encoding="utf-8")
 
     def test_workspace_uses_release_prerelease_version(self) -> None:
@@ -85,6 +87,23 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("name: morphir-cli-${{ matrix.target }}", self.workflow)
         self.assertIn("overwrite: true", self.workflow)
         self.assertIn("retention-days: 7", self.workflow)
+
+    def test_cli_checksum_uses_archive_basename(self) -> None:
+        self.assertIn("cd release-assets", self.workflow)
+        self.assertIn(
+            'shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"',
+            self.workflow,
+        )
+        self.assertNotIn(
+            'shasum -a 256 "release-assets/${ARCHIVE}"',
+            self.workflow,
+        )
+
+    def test_workspace_version_files_trigger_release_validation(self) -> None:
+        release_filter = self.ci_workflow.split("            release:\n", maxsplit=1)[1]
+        release_filter = release_filter.split("\n\n", maxsplit=1)[0]
+        self.assertIn("- 'Cargo.toml'", release_filter)
+        self.assertIn("- 'Cargo.lock'", release_filter)
 
     def test_publish_job_only_collects_release_artifacts(self) -> None:
         self.assertRegex(

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -1,3 +1,4 @@
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -5,6 +6,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
 CARGO_TOML_PATH = REPO_ROOT / "crates" / "morphir" / "Cargo.toml"
+WORKSPACE_TOML_PATH = REPO_ROOT / "Cargo.toml"
+CARGO_LOCK_PATH = REPO_ROOT / "Cargo.lock"
 
 
 class ReleaseWorkflowTests(unittest.TestCase):
@@ -12,6 +15,24 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         cls.cargo_toml = CARGO_TOML_PATH.read_text(encoding="utf-8")
+
+    def test_workspace_uses_release_prerelease_version(self) -> None:
+        workspace = tomllib.loads(WORKSPACE_TOML_PATH.read_text(encoding="utf-8"))
+        self.assertEqual("0.2.0-alpha-01", workspace["workspace"]["package"]["version"])
+
+        lockfile = tomllib.loads(CARGO_LOCK_PATH.read_text(encoding="utf-8"))
+        workspace_packages = {
+            package["name"]: package["version"]
+            for package in lockfile["package"]
+            if package["name"] in {"morphir", "morphir-live"}
+        }
+        self.assertEqual(
+            {
+                "morphir": "0.2.0-alpha-01",
+                "morphir-live": "0.2.0-alpha-01",
+            },
+            workspace_packages,
+        )
 
     def test_manual_release_checks_out_requested_tag(self) -> None:
         self.assertIn("release-info:", self.workflow)
@@ -72,14 +93,23 @@ class ReleaseWorkflowTests(unittest.TestCase):
             r"\[release-info, package-live, package-cli\]",
         )
         self.assertIn("merge-multiple: true", self.workflow)
-        self.assertIn("files: |\n            release-assets/*", self.workflow)
 
         publish_job = self.workflow.split("  publish-release:\n", maxsplit=1)[1]
         publish_job = publish_job.split("\n  deploy-pages:\n", maxsplit=1)[0]
         self.assertIn("permissions:\n      contents: write", publish_job)
-        self.assertNotIn("actions/checkout", publish_job)
         self.assertNotIn("cargo build", publish_job)
         self.assertNotIn("dx build", publish_job)
+
+    def test_publish_job_skips_artifacts_with_matching_hashes(self) -> None:
+        publish_job = self.workflow.split("  publish-release:\n", maxsplit=1)[1]
+        publish_job = publish_job.split("\n  deploy-pages:\n", maxsplit=1)[0]
+
+        self.assertIn('gh release view "$TAG"', publish_job)
+        self.assertIn('gh release download "$TAG"', publish_job)
+        self.assertIn("select_release_assets.py", publish_job)
+        self.assertIn('gh release upload "$TAG"', publish_job)
+        self.assertIn("--clobber", publish_job)
+        self.assertNotIn("softprops/action-gh-release", publish_job)
 
     def test_pages_deployment_reuses_packaged_live_artifact(self) -> None:
         pages_job = self.workflow.split("  deploy-pages:\n", maxsplit=1)[1]

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -1,0 +1,92 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+CARGO_TOML_PATH = REPO_ROOT / "crates" / "morphir" / "Cargo.toml"
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.cargo_toml = CARGO_TOML_PATH.read_text(encoding="utf-8")
+
+    def test_manual_release_checks_out_requested_tag(self) -> None:
+        self.assertIn("release-info:", self.workflow)
+        self.assertIn(
+            "ref: ${{ github.event_name == 'workflow_dispatch' "
+            "&& inputs.tag || github.ref }}",
+            self.workflow,
+        )
+        self.assertIn("ref: ${{ needs.release-info.outputs.tag }}", self.workflow)
+
+    def test_release_tag_matches_workspace_version(self) -> None:
+        self.assertIn("Validate release tag", self.workflow)
+        self.assertIn('EXPECTED_TAG="v${VERSION}"', self.workflow)
+        self.assertIn('if [ "$TAG" != "$EXPECTED_TAG" ]; then', self.workflow)
+
+    def test_cli_build_covers_supported_targets(self) -> None:
+        targets = {
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
+            "x86_64-apple-darwin",
+            "aarch64-apple-darwin",
+            "x86_64-pc-windows-msvc",
+            "aarch64-pc-windows-msvc",
+        }
+
+        self.assertIn("package-cli:", self.workflow)
+        self.assertIn("name: Package Morphir CLI (${{ matrix.target }})", self.workflow)
+        self.assertIn("fail-fast: false", self.workflow)
+        for target in targets:
+            self.assertIn(f"target: {target}", self.workflow)
+
+    def test_cli_archives_match_cargo_binstall_metadata(self) -> None:
+        self.assertIn(
+            'pkg-url = "{ repo }/releases/download/v{ version }/'
+            '{ name }-{ version }-{ target }.{ archive-format }"',
+            self.cargo_toml,
+        )
+        self.assertIn(
+            'ARCHIVE="morphir-${{ needs.release-info.outputs.version }}-'
+            '${{ matrix.target }}.${{ matrix.archive }}"',
+            self.workflow,
+        )
+        self.assertIn(
+            '$archive = "morphir-${{ needs.release-info.outputs.version }}-'
+            '${{ matrix.target }}.${{ matrix.archive }}"',
+            self.workflow,
+        )
+
+    def test_packaging_jobs_support_independent_retries(self) -> None:
+        self.assertIn("name: morphir-cli-${{ matrix.target }}", self.workflow)
+        self.assertIn("overwrite: true", self.workflow)
+        self.assertIn("retention-days: 7", self.workflow)
+
+    def test_publish_job_only_collects_release_artifacts(self) -> None:
+        self.assertRegex(
+            self.workflow,
+            r"publish-release:\n(?:.|\n)*?needs: "
+            r"\[release-info, package-live, package-cli\]",
+        )
+        self.assertIn("merge-multiple: true", self.workflow)
+        self.assertIn("files: |\n            release-assets/*", self.workflow)
+
+        publish_job = self.workflow.split("  publish-release:\n", maxsplit=1)[1]
+        publish_job = publish_job.split("\n  deploy-pages:\n", maxsplit=1)[0]
+        self.assertIn("permissions:\n      contents: write", publish_job)
+        self.assertNotIn("actions/checkout", publish_job)
+        self.assertNotIn("cargo build", publish_job)
+        self.assertNotIn("dx build", publish_job)
+
+    def test_pages_deployment_reuses_packaged_live_artifact(self) -> None:
+        pages_job = self.workflow.split("  deploy-pages:\n", maxsplit=1)[1]
+        self.assertIn("name: morphir-live-wasm", pages_job)
+        self.assertIn("tar -xzf morphir-live-*.tar.gz -C pages-dist", pages_job)
+        self.assertNotIn("dx build", pages_job)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_select_release_assets.py
+++ b/tests/ci/test_select_release_assets.py
@@ -1,0 +1,109 @@
+import hashlib
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "select_release_assets.py"
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("select_release_assets", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SelectReleaseAssetsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_script()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.local = self.root / "release-assets"
+        self.published = self.root / "published-checksums"
+        self.upload = self.root / "upload-assets"
+        self.local.mkdir()
+        self.published.mkdir()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def write_asset(self, name: str, content: bytes) -> str:
+        digest = hashlib.sha256(content).hexdigest()
+        (self.local / name).write_bytes(content)
+        (self.local / f"{name}.sha256").write_text(
+            f"{digest}  {name}\n", encoding="utf-8"
+        )
+        return digest
+
+    def write_published_checksum(self, name: str, digest: str) -> None:
+        (self.published / f"{name}.sha256").write_text(
+            f"{digest}  {name}\n", encoding="utf-8"
+        )
+
+    def test_skips_asset_when_archive_and_checksum_match(self) -> None:
+        name = "morphir-1.2.3-x86_64-unknown-linux-gnu.tgz"
+        digest = self.write_asset(name, b"same artifact")
+        self.write_published_checksum(name, digest)
+
+        selected = self.module.select_release_assets(
+            self.local,
+            self.published,
+            {name, f"{name}.sha256"},
+            self.upload,
+        )
+
+        self.assertEqual([], selected)
+
+    def test_selects_asset_when_published_hash_differs(self) -> None:
+        name = "morphir-1.2.3-aarch64-apple-darwin.tgz"
+        self.write_asset(name, b"new artifact")
+        self.write_published_checksum(name, "0" * 64)
+
+        selected = self.module.select_release_assets(
+            self.local,
+            self.published,
+            {name, f"{name}.sha256"},
+            self.upload,
+        )
+
+        self.assertEqual([name, f"{name}.sha256"], selected)
+        self.assertTrue((self.upload / name).is_file())
+        self.assertTrue((self.upload / f"{name}.sha256").is_file())
+
+    def test_selects_asset_when_published_archive_is_missing(self) -> None:
+        name = "morphir-1.2.3-aarch64-pc-windows-msvc.zip"
+        digest = self.write_asset(name, b"windows artifact")
+        self.write_published_checksum(name, digest)
+
+        selected = self.module.select_release_assets(
+            self.local,
+            self.published,
+            {f"{name}.sha256"},
+            self.upload,
+        )
+
+        self.assertEqual([name, f"{name}.sha256"], selected)
+
+    def test_rejects_local_archive_with_incorrect_checksum(self) -> None:
+        name = "morphir-live-1.2.3.tar.gz"
+        self.write_asset(name, b"live artifact")
+        (self.local / f"{name}.sha256").write_text(
+            f"{'0' * 64}  {name}\n", encoding="utf-8"
+        )
+
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            self.module.select_release_assets(
+                self.local,
+                self.published,
+                set(),
+                self.upload,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- publish Morphir CLI archives for Linux, macOS, and Windows on x64 and ARM64
- allow platform packaging jobs to be retried independently from publishing
- make release publishing idempotent by comparing SHA-256 sidecars before upload
- add mise, cargo-binstall, manual, and source installation instructions
- bump the workspace release to `0.2.0-alpha-01`

## Validation

- `python -B -m unittest discover -s tests/ci`
- `python .config/mise/tasks/ci/validate_docs.py`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`

## Notes

The full local Rust build is unavailable in this worktree because the existing `morphir-rust` submodule state contains staged deletions. The release workflow initializes submodules before building, and the workflow-specific tests pass locally.
