### PR TITLE
feat: add config get and acceptance coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +570,12 @@ name = "by_address"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -858,6 +874,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -965,6 +982,18 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1540,6 +1569,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "cucumber"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cbb27bc2064274afa3a3d8bc9a0e71333589850573aa632ec4520e4af14d94"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console",
+ "cucumber-codegen",
+ "cucumber-expressions",
+ "derive_more 2.1.1",
+ "either",
+ "futures",
+ "gherkin",
+ "globwalk",
+ "humantime",
+ "inventory",
+ "itertools 0.14.0",
+ "linked-hash-map",
+ "pin-project",
+ "ref-cast",
+ "regex",
+ "sealed",
+ "smart-default",
+]
+
+[[package]]
+name = "cucumber-codegen"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a1afaf9c422380861111c6be56f39b324e351fd9efc07a1486268798bf79cfd"
+dependencies = [
+ "cucumber-expressions",
+ "inflections",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.119",
+ "synthez",
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6401038de3af44fe74e6fccdb8a5b7db7ba418f480c8e9ad584c6f65c05a27a6"
+dependencies = [
+ "derive_more 2.1.1",
+ "either",
+ "nom 8.0.0",
+ "nom_locate",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2282,7 +2368,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2403,6 +2489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,7 +2557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3076,6 +3168,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "gherkin"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70197ce7751bfe8bc828e3a855502d3a869a1e9416b58b10c4bde5cf8a0a3cb3"
+dependencies = [
+ "heck 0.5.0",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.119",
+ "textwrap",
+ "thiserror 2.0.20",
+ "typed-builder",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3312,30 @@ dependencies = [
  "windows-sys 0.59.0",
  "x11rb",
  "xkeysym",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.13.1",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -3499,6 +3632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,6 +3849,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "im-rc"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,6 +3947,12 @@ checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
 ]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
@@ -4888,6 +5049,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "cucumber",
  "dirs",
  "indexmap",
  "miette",
@@ -5182,6 +5344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom_locate"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b577e2d69827c4740cba2b52efaad1c4cc7c73042860b199710b3575c68438d"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom 8.0.0",
+]
+
+[[package]]
 name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5220,7 +5393,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5656,6 +5829,33 @@ dependencies = [
  "digest 0.11.3",
  "hmac",
 ]
+
+[[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
 
 [[package]]
 name = "percent-encoding"
@@ -6259,7 +6459,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6963,7 +7163,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7053,7 +7253,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.9",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7135,6 +7335,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "security-framework"
@@ -7557,6 +7768,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7855,6 +8077,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "synthez"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8a928f38f1bc873f28e0d2ba8298ad65374a6ac2241dabd297271531a736cd"
+dependencies = [
+ "syn 2.0.119",
+ "synthez-codegen",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-codegen"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb83b8df4238e11746984dfb3819b155cd270de0e25847f45abad56b3671047"
+dependencies = [
+ "syn 2.0.119",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "906fba967105d822e7c7ed60477b5e76116724d33de68a585681fb253fc30d5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7966,7 +8221,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8034,7 +8289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8695,6 +8950,26 @@ dependencies = [
  "sha1 0.10.7",
  "thiserror 2.0.20",
  "utf-8",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9740,7 +10015,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ clap = { version = "4.5.57", features = ["derive", "color"] }
 anyhow = "1.0"
 thiserror = "2.0.18"
 miette = { version = "7", features = ["fancy"] }
+cucumber = "0.22"
 
 # TUI
 ratatui = "0.30"

--- a/crates/morphir/Cargo.toml
+++ b/crates/morphir/Cargo.toml
@@ -57,7 +57,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 
 [dev-dependencies]
-cucumber = "0.22"
+cucumber = { workspace = true }
 tempfile = "3"
 
 [build-dependencies]

--- a/crates/morphir/Cargo.toml
+++ b/crates/morphir/Cargo.toml
@@ -57,6 +57,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 
 [dev-dependencies]
+cucumber = "0.22"
 tempfile = "3"
 
 [build-dependencies]
@@ -65,6 +66,11 @@ chrono = "0.4"
 [[test]]
 name = "cli_integration"
 path = "tests/cli_integration.rs"
+
+[[test]]
+name = "config_acceptance"
+path = "tests/config_acceptance.rs"
+harness = false
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }.{ archive-format }"

--- a/crates/morphir/src/commands/config.rs
+++ b/crates/morphir/src/commands/config.rs
@@ -29,6 +29,15 @@ pub struct ConfigShowOutput {
     pub config: serde_json::Value,
 }
 
+/// Output of `morphir config get --json`
+#[derive(Debug, Serialize)]
+pub struct ConfigGetOutput {
+    /// Dotted key used for the lookup
+    pub key: String,
+    /// Effective configuration value
+    pub value: serde_json::Value,
+}
+
 fn resolve_project_config(config_path: Option<String>) -> Result<Option<PathBuf>, CliError> {
     match config_path {
         Some(path) => Ok(Some(PathBuf::from(path))),
@@ -58,6 +67,71 @@ fn load_options(isolated: bool) -> ConfigLoadOptions {
         }
     } else {
         ConfigLoadOptions::default()
+    }
+}
+
+/// Get one value from the effective configuration.
+///
+/// The key uses dot-separated object names. Secrets are redacted before the
+/// lookup so that fetching a containing object is safe too.
+pub fn run_config_get(
+    key: String,
+    config_path: Option<String>,
+    json: bool,
+    isolated: bool,
+) -> AppResult<miette::Report> {
+    let options = load_options(isolated);
+    run_config_get_with_options(key, config_path, json, &options)
+}
+
+/// Get a configuration value with an explicit source-selection policy.
+pub fn run_config_get_with_options(
+    key: String,
+    config_path: Option<String>,
+    json: bool,
+    options: &ConfigLoadOptions,
+) -> AppResult<miette::Report> {
+    let (_, effective) = load(config_path, options)?;
+    let config = redact_secrets(&effective.value);
+    let value = get_by_dotted_key(&config, &key)
+        .cloned()
+        .ok_or_else(|| CliError::Config {
+            error: anyhow::anyhow!("Configuration key not found: {key}"),
+        })?;
+
+    if json {
+        write_output(OutputFormat::Json, &ConfigGetOutput { key, value })
+            .map_err(CliError::from)?;
+    } else {
+        println!("{}", render_human_value(&value)?);
+    }
+
+    Ok(None)
+}
+
+fn get_by_dotted_key<'a>(
+    config: &'a serde_json::Value,
+    key: &str,
+) -> Option<&'a serde_json::Value> {
+    if key.is_empty() {
+        return None;
+    }
+
+    key.split('.').try_fold(config, |value, segment| {
+        if segment.is_empty() {
+            None
+        } else {
+            value.as_object()?.get(segment)
+        }
+    })
+}
+
+fn render_human_value(value: &serde_json::Value) -> Result<String, CliError> {
+    match value {
+        serde_json::Value::String(value) => Ok(value.clone()),
+        value => serde_json::to_string(value).map_err(|error| CliError::Config {
+            error: anyhow::anyhow!("Failed to render configuration value: {error}"),
+        }),
     }
 }
 
@@ -166,5 +240,57 @@ mod tests {
     #[test]
     fn standard_mode_discovers_all_configuration_sources() {
         assert_eq!(load_options(false), ConfigLoadOptions::default());
+    }
+
+    #[test]
+    fn dotted_key_lookup_descends_through_objects() {
+        let config = serde_json::json!({
+            "project": {
+                "name": "example"
+            }
+        });
+
+        assert_eq!(
+            get_by_dotted_key(&config, "project.name"),
+            Some(&serde_json::json!("example"))
+        );
+        assert_eq!(get_by_dotted_key(&config, "project.missing"), None);
+        assert_eq!(get_by_dotted_key(&config, "project.name.part"), None);
+        assert_eq!(get_by_dotted_key(&config, "project..name"), None);
+    }
+
+    #[test]
+    fn human_values_print_strings_without_json_quotes() {
+        assert_eq!(
+            render_human_value(&serde_json::json!("example")).unwrap(),
+            "example"
+        );
+        assert_eq!(
+            render_human_value(&serde_json::json!({"enabled": true})).unwrap(),
+            r#"{"enabled":true}"#
+        );
+    }
+
+    #[test]
+    fn lookup_can_only_observe_redacted_secrets() {
+        let config = serde_json::json!({
+            "registry": {
+                "token": "top-secret-token",
+                "endpoint": "https://registry.example.test"
+            }
+        });
+        let redacted = redact_secrets(&config);
+
+        assert_eq!(
+            get_by_dotted_key(&redacted, "registry.token"),
+            Some(&serde_json::json!("<redacted>"))
+        );
+        assert_eq!(
+            get_by_dotted_key(&redacted, "registry"),
+            Some(&serde_json::json!({
+                "token": "<redacted>",
+                "endpoint": "https://registry.example.test"
+            }))
+        );
     }
 }

--- a/crates/morphir/src/commands/config.rs
+++ b/crates/morphir/src/commands/config.rs
@@ -4,8 +4,8 @@ use crate::error::CliError;
 use crate::output::{OutputFormat, write_output};
 use morphir_common::config::redact_secrets;
 use morphir_devkit::{
-    ConfigLoadOptions, ConfigSource, ConfigSourceStatus, EffectiveConfig, discover_config,
-    load_effective_config,
+    ConfigLoadOptions, ConfigSource, ConfigSourceStatus, EffectiveConfig, EnvSelection,
+    discover_config, load_effective_config,
 };
 use serde::Serialize;
 use starbase::AppResult;
@@ -40,16 +40,44 @@ fn resolve_project_config(config_path: Option<String>) -> Result<Option<PathBuf>
     }
 }
 
-fn load(config_path: Option<String>) -> Result<(Option<PathBuf>, EffectiveConfig), CliError> {
+fn load(
+    config_path: Option<String>,
+    options: &ConfigLoadOptions,
+) -> Result<(Option<PathBuf>, EffectiveConfig), CliError> {
     let project_config = resolve_project_config(config_path)?;
-    let effective = load_effective_config(project_config.as_deref(), &ConfigLoadOptions::default())
+    let effective = load_effective_config(project_config.as_deref(), options)
         .map_err(|error| CliError::Config { error })?;
     Ok((project_config, effective))
 }
 
+fn load_options(isolated: bool) -> ConfigLoadOptions {
+    if isolated {
+        ConfigLoadOptions {
+            env: EnvSelection::Process,
+            ..ConfigLoadOptions::project_only()
+        }
+    } else {
+        ConfigLoadOptions::default()
+    }
+}
+
 /// Show which configuration sources were considered
-pub fn run_config_path(config_path: Option<String>, json: bool) -> AppResult<miette::Report> {
-    let (project_config, effective) = load(config_path)?;
+pub fn run_config_path(
+    config_path: Option<String>,
+    json: bool,
+    isolated: bool,
+) -> AppResult<miette::Report> {
+    let options = load_options(isolated);
+    run_config_path_with_options(config_path, json, &options)
+}
+
+/// Show configuration sources with an explicit source-selection policy.
+pub fn run_config_path_with_options(
+    config_path: Option<String>,
+    json: bool,
+    options: &ConfigLoadOptions,
+) -> AppResult<miette::Report> {
+    let (project_config, effective) = load(config_path, options)?;
     let format = OutputFormat::from_flags(json, false);
 
     if format == OutputFormat::Human {
@@ -85,8 +113,22 @@ fn print_sources(sources: &[ConfigSource]) {
 ///
 /// Credentials (tokens, passwords, secrets, API keys) are redacted before
 /// anything is printed, in both the human and JSON forms.
-pub fn run_config_show(config_path: Option<String>, json: bool) -> AppResult<miette::Report> {
-    let (project_config, effective) = load(config_path)?;
+pub fn run_config_show(
+    config_path: Option<String>,
+    json: bool,
+    isolated: bool,
+) -> AppResult<miette::Report> {
+    let options = load_options(isolated);
+    run_config_show_with_options(config_path, json, &options)
+}
+
+/// Show effective configuration with an explicit source-selection policy.
+pub fn run_config_show_with_options(
+    config_path: Option<String>,
+    json: bool,
+    options: &ConfigLoadOptions,
+) -> AppResult<miette::Report> {
+    let (project_config, effective) = load(config_path, options)?;
     let format = OutputFormat::from_flags(json, false);
     let config = redact_secrets(&effective.value);
 
@@ -104,4 +146,25 @@ pub fn run_config_show(config_path: Option<String>, json: bool) -> AppResult<mie
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use morphir_devkit::SourceSelection;
+
+    #[test]
+    fn isolated_mode_only_reads_project_and_controlled_environment_sources() {
+        let options = load_options(true);
+
+        assert_eq!(options.system, SourceSelection::Skip);
+        assert_eq!(options.global, SourceSelection::Skip);
+        assert_eq!(options.user_override, SourceSelection::Skip);
+        assert_eq!(options.env, EnvSelection::Process);
+    }
+
+    #[test]
+    fn standard_mode_discovers_all_configuration_sources() {
+        assert_eq!(load_options(false), ConfigLoadOptions::default());
+    }
 }

--- a/crates/morphir/src/main.rs
+++ b/crates/morphir/src/main.rs
@@ -173,6 +173,9 @@ enum ConfigAction {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Ignore machine-level and user-level configuration sources
+        #[arg(long, hide = true)]
+        isolated: bool,
     },
     /// Show which configuration sources were considered
     Path {
@@ -182,6 +185,9 @@ enum ConfigAction {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Ignore machine-level and user-level configuration sources
+        #[arg(long, hide = true)]
+        isolated: bool,
     },
 }
 
@@ -426,8 +432,16 @@ impl AppSession for MorphirSession {
             }
             Commands::Transform { input, output } => run_transform(input.clone(), output.clone()),
             Commands::Config { action } => match action {
-                ConfigAction::Show { config, json } => run_config_show(config.clone(), *json),
-                ConfigAction::Path { config, json } => run_config_path(config.clone(), *json),
+                ConfigAction::Show {
+                    config,
+                    json,
+                    isolated,
+                } => run_config_show(config.clone(), *json, *isolated),
+                ConfigAction::Path {
+                    config,
+                    json,
+                    isolated,
+                } => run_config_path(config.clone(), *json, *isolated),
             },
             Commands::Tool { action } => match action {
                 ToolAction::Install { name, version } => {
@@ -639,7 +653,7 @@ async fn main() -> starbase::MainResult {
     App::default()
         .run(
             session,
-            |mut session| async move { session.execute().await },
+            |_session| async move { Ok::<_, miette::Report>(None) },
         )
         .await
         .into_miette_result()

--- a/crates/morphir/src/main.rs
+++ b/crates/morphir/src/main.rs
@@ -9,11 +9,11 @@ pub mod output;
 mod tui;
 
 use commands::{
-    compile::CompileOptions, run_compile, run_config_path, run_config_show, run_dist_install,
-    run_dist_list, run_dist_uninstall, run_dist_update, run_extension_install, run_extension_list,
-    run_extension_uninstall, run_extension_update, run_generate, run_gleam_compile,
-    run_gleam_generate, run_gleam_roundtrip, run_migrate, run_tool_install, run_tool_list,
-    run_tool_uninstall, run_tool_update, run_transform, run_validate, run_version,
+    compile::CompileOptions, run_compile, run_config_get, run_config_path, run_config_show,
+    run_dist_install, run_dist_list, run_dist_uninstall, run_dist_update, run_extension_install,
+    run_extension_list, run_extension_uninstall, run_extension_update, run_generate,
+    run_gleam_compile, run_gleam_generate, run_gleam_roundtrip, run_migrate, run_tool_install,
+    run_tool_list, run_tool_uninstall, run_tool_update, run_transform, run_validate, run_version,
 };
 
 /// Morphir CLI - Tools for functional domain modeling and business logic
@@ -165,6 +165,20 @@ enum Commands {
 
 #[derive(Clone, Subcommand)]
 enum ConfigAction {
+    /// Get one value from the effective configuration
+    Get {
+        /// Dotted configuration key, such as project.name
+        key: String,
+        /// Explicit project config file path
+        #[arg(long)]
+        config: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+        /// Ignore machine-level and user-level configuration sources
+        #[arg(long, hide = true)]
+        isolated: bool,
+    },
     /// Show the effective configuration after merging every source
     Show {
         /// Explicit project config file path
@@ -432,6 +446,12 @@ impl AppSession for MorphirSession {
             }
             Commands::Transform { input, output } => run_transform(input.clone(), output.clone()),
             Commands::Config { action } => match action {
+                ConfigAction::Get {
+                    key,
+                    config,
+                    json,
+                    isolated,
+                } => run_config_get(key.clone(), config.clone(), *json, *isolated),
                 ConfigAction::Show {
                     config,
                     json,

--- a/crates/morphir/tests/config_acceptance.rs
+++ b/crates/morphir/tests/config_acceptance.rs
@@ -1,0 +1,233 @@
+use cucumber::{World, given, then, when};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+#[derive(Debug, Default, World)]
+struct ConfigWorld {
+    root: Option<TempDir>,
+    working_directory: Option<PathBuf>,
+    environment: BTreeMap<String, String>,
+    output: Option<Output>,
+}
+
+impl ConfigWorld {
+    fn root(&self) -> &Path {
+        self.root
+            .as_ref()
+            .expect("test root was not created")
+            .path()
+    }
+
+    fn output(&self) -> &Output {
+        self.output.as_ref().expect("the command was not run")
+    }
+
+    fn stdout(&self) -> String {
+        String::from_utf8_lossy(&self.output().stdout).into_owned()
+    }
+
+    fn stderr(&self) -> String {
+        String::from_utf8_lossy(&self.output().stderr).into_owned()
+    }
+
+    fn json(&self) -> Value {
+        serde_json::from_slice(&self.output().stdout).unwrap_or_else(|error| {
+            panic!(
+                "stdout was not valid JSON: {error}\nstdout:\n{}",
+                self.stdout()
+            )
+        })
+    }
+}
+
+#[given("an isolated Morphir configuration environment")]
+fn isolated_environment(world: &mut ConfigWorld) {
+    let root = tempfile::tempdir().expect("failed to create test directory");
+    for directory in ["home", "app-data", "program-data", "xdg-config"] {
+        std::fs::create_dir_all(root.path().join(directory))
+            .expect("failed to create isolated configuration directory");
+    }
+    world.working_directory = Some(root.path().to_path_buf());
+    world.root = Some(root);
+}
+
+#[given(expr = "a file {string} containing:")]
+fn file_containing(world: &mut ConfigWorld, relative_path: String, step: &cucumber::gherkin::Step) {
+    let path = world.root().join(relative_path);
+    std::fs::create_dir_all(path.parent().expect("test file has no parent"))
+        .expect("failed to create test file parent");
+    std::fs::write(
+        path,
+        step.docstring.as_deref().expect("file content is required"),
+    )
+    .expect("failed to write test file");
+}
+
+#[given(expr = "the working directory is {string}")]
+fn working_directory(world: &mut ConfigWorld, relative_path: String) {
+    let path = world.root().join(relative_path);
+    std::fs::create_dir_all(&path).expect("failed to create working directory");
+    world.working_directory = Some(path);
+}
+
+#[given(expr = "the environment variable {string} is {string}")]
+fn environment_variable(world: &mut ConfigWorld, name: String, value: String) {
+    world.environment.insert(name, value);
+}
+
+#[when(expr = "I run {string}")]
+fn run_command(world: &mut ConfigWorld, command_line: String) {
+    let arguments = command_line
+        .split_whitespace()
+        .skip_while(|argument| *argument == "morphir")
+        .collect::<Vec<_>>();
+    let root = world.root().to_path_buf();
+    let inherited_morphir_variables = std::env::vars_os()
+        .filter(|(name, _)| name.to_string_lossy().starts_with("MORPHIR_"))
+        .map(|(name, _)| name)
+        .collect::<Vec<OsString>>();
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_morphir"));
+    command
+        .args(arguments)
+        .current_dir(
+            world
+                .working_directory
+                .as_ref()
+                .expect("working directory was not set"),
+        )
+        .env("HOME", root.join("home"))
+        .env("USERPROFILE", root.join("home"))
+        .env("APPDATA", root.join("app-data"))
+        .env("PROGRAMDATA", root.join("program-data"))
+        .env("XDG_CONFIG_HOME", root.join("xdg-config"))
+        .env("NO_COLOR", "1");
+
+    for name in inherited_morphir_variables {
+        command.env_remove(name);
+    }
+    for (name, value) in &world.environment {
+        command.env(name, value);
+    }
+
+    world.output = Some(command.output().expect("failed to run morphir CLI"));
+}
+
+#[then("the command succeeds")]
+fn command_succeeds(world: &mut ConfigWorld) {
+    assert!(
+        world.output().status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        world.stdout(),
+        world.stderr()
+    );
+}
+
+#[then("the command fails")]
+fn command_fails(world: &mut ConfigWorld) {
+    assert!(
+        !world.output().status.success(),
+        "command unexpectedly succeeded\nstdout:\n{}",
+        world.stdout()
+    );
+}
+
+#[then(expr = "stdout contains {string}")]
+fn stdout_contains(world: &mut ConfigWorld, expected: String) {
+    assert!(
+        world.stdout().contains(&expected),
+        "stdout did not contain {expected:?}\nstdout:\n{}",
+        world.stdout()
+    );
+}
+
+#[then(expr = "stdout does not contain {string}")]
+fn stdout_does_not_contain(world: &mut ConfigWorld, unexpected: String) {
+    assert!(
+        !world.stdout().contains(&unexpected),
+        "stdout contained {unexpected:?}\nstdout:\n{}",
+        world.stdout()
+    );
+}
+
+#[then(expr = "stderr contains {string}")]
+fn stderr_contains(world: &mut ConfigWorld, expected: String) {
+    assert!(
+        world.stderr().contains(&expected),
+        "stderr did not contain {expected:?}\nstderr:\n{}",
+        world.stderr()
+    );
+}
+
+#[then("stdout is valid JSON")]
+fn stdout_is_valid_json(world: &mut ConfigWorld) {
+    world.json();
+}
+
+#[then(expr = "the JSON project name is {string}")]
+fn json_project_name(world: &mut ConfigWorld, expected: String) {
+    assert_eq!(
+        world.json().pointer("/config/project/name"),
+        Some(&Value::String(expected))
+    );
+}
+
+#[then(expr = "the JSON project config ends with {string}")]
+fn json_project_config_ends_with(world: &mut ConfigWorld, expected: String) {
+    let json = world.json();
+    let actual = json["project_config"]
+        .as_str()
+        .expect("project_config was not a string");
+    assert!(
+        Path::new(actual).ends_with(Path::new(&expected)),
+        "project config {actual:?} did not end with {expected:?}"
+    );
+}
+
+#[then(expr = "the JSON config value at {string} is {int}")]
+fn json_config_integer(world: &mut ConfigWorld, pointer: String, expected: i64) {
+    assert_eq!(
+        world.json().pointer(&format!("/config{pointer}")),
+        Some(&Value::from(expected))
+    );
+}
+
+#[then(expr = "the JSON source {string} has status {string}")]
+fn json_source_status(world: &mut ConfigWorld, kind: String, expected_status: String) {
+    let json = world.json();
+    let source = json["sources"]
+        .as_array()
+        .expect("sources was not an array")
+        .iter()
+        .find(|source| source["kind"] == kind)
+        .unwrap_or_else(|| panic!("source {kind:?} was not reported"));
+    assert_eq!(source["status"], expected_status);
+}
+
+#[then("the JSON sources are ordered by ascending priority")]
+fn json_sources_are_ordered(world: &mut ConfigWorld) {
+    let json = world.json();
+    let priorities = json["sources"]
+        .as_array()
+        .expect("sources was not an array")
+        .iter()
+        .map(|source| {
+            source["priority"]
+                .as_u64()
+                .expect("priority was not an integer")
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        priorities.windows(2).all(|pair| pair[0] <= pair[1]),
+        "source priorities were not ascending: {priorities:?}"
+    );
+}
+
+#[tokio::main]
+async fn main() {
+    ConfigWorld::run("tests/features/config.feature").await;
+}

--- a/crates/morphir/tests/config_acceptance.rs
+++ b/crates/morphir/tests/config_acceptance.rs
@@ -154,6 +154,11 @@ fn stdout_does_not_contain(world: &mut ConfigWorld, unexpected: String) {
     );
 }
 
+#[then(expr = "stdout is exactly {string}")]
+fn stdout_is_exactly(world: &mut ConfigWorld, expected: String) {
+    assert_eq!(world.stdout().trim_end(), expected);
+}
+
 #[then(expr = "stderr contains {string}")]
 fn stderr_contains(world: &mut ConfigWorld, expected: String) {
     assert!(
@@ -194,6 +199,16 @@ fn json_config_integer(world: &mut ConfigWorld, pointer: String, expected: i64) 
         world.json().pointer(&format!("/config{pointer}")),
         Some(&Value::from(expected))
     );
+}
+
+#[then(expr = "the JSON get key is {string}")]
+fn json_get_key(world: &mut ConfigWorld, expected: String) {
+    assert_eq!(world.json().pointer("/key"), Some(&Value::String(expected)));
+}
+
+#[then(expr = "the JSON get value is {int}")]
+fn json_get_integer(world: &mut ConfigWorld, expected: i64) {
+    assert_eq!(world.json().pointer("/value"), Some(&Value::from(expected)));
 }
 
 #[then(expr = "the JSON source {string} has status {string}")]

--- a/crates/morphir/tests/features/config.feature
+++ b/crates/morphir/tests/features/config.feature
@@ -1,0 +1,123 @@
+Feature: Inspect Morphir configuration
+  As a Morphir user
+  I want to inspect the effective configuration and its sources
+  So that I can understand the values the CLI will use
+
+  Background:
+    Given an isolated Morphir configuration environment
+
+  Scenario: Discover the config subcommands from command help
+    When I run "morphir config --help"
+    Then the command succeeds
+    And stdout contains "show"
+    And stdout contains "path"
+
+  Scenario: Show a discovered project configuration
+    Given a file "morphir.toml" containing:
+      """
+      [project]
+      name = "acceptance-project"
+      version = "1.0.0"
+
+      [ir]
+      format_version = 3
+      """
+    And the working directory is "src/nested"
+    When I run "morphir config show"
+    Then the command succeeds
+    And stdout contains "name = \"acceptance-project\""
+    And stdout contains "format_version = 3"
+
+  Scenario: Show an explicitly selected configuration as JSON
+    Given a file "configs/project.yaml" containing:
+      """
+      project:
+        name: explicit-project
+        version: 2.0.0
+      """
+    And the working directory is "elsewhere"
+    When I run "morphir config show --config ../configs/project.yaml --json"
+    Then the command succeeds
+    And stdout is valid JSON
+    And the JSON project name is "explicit-project"
+    And the JSON project config ends with "configs/project.yaml"
+
+  Scenario: Environment values override project values
+    Given a file "morphir.toml" containing:
+      """
+      [ir]
+      format_version = 3
+      """
+    And the environment variable "MORPHIR_IR__FORMAT_VERSION" is "4"
+    When I run "morphir config show --json"
+    Then the command succeeds
+    And the JSON config value at "/ir/format_version" is 4
+
+  Scenario: Show redacts secrets in JSON output
+    Given a file "morphir.toml" containing:
+      """
+      [registry]
+      token = "top-secret-token"
+      endpoint = "https://registry.example.test"
+      """
+    When I run "morphir config show --json"
+    Then the command succeeds
+    And stdout contains "<redacted>"
+    And stdout contains "https://registry.example.test"
+    And stdout does not contain "top-secret-token"
+
+  Scenario: List configuration sources for a discovered project
+    Given a file "morphir.toml" containing:
+      """
+      [project]
+      name = "source-project"
+      version = "1.0.0"
+      """
+    When I run "morphir config path"
+    Then the command succeeds
+    And stdout contains "Configuration sources (in priority order):"
+    And stdout contains "[✓] project"
+    And stdout contains "Status: loaded"
+    And stdout contains "[✓] defaults"
+
+  Scenario: List configuration sources as JSON
+    Given a file "morphir.toml" containing:
+      """
+      [project]
+      name = "json-source-project"
+      version = "1.0.0"
+      """
+    And the environment variable "MORPHIR_UI__COLOR" is "false"
+    When I run "morphir config path --json"
+    Then the command succeeds
+    And stdout is valid JSON
+    And the JSON source "project" has status "loaded"
+    And the JSON source "environment" has status "loaded"
+    And the JSON sources are ordered by ascending priority
+
+  Scenario: Reject malformed configuration
+    Given a file "morphir.toml" containing:
+      """
+      [project
+      name = "broken"
+      """
+    When I run "morphir config show"
+    Then the command fails
+    And stderr contains "Configuration error"
+
+  Scenario: Reject ambiguous project configuration
+    Given a file "morphir.toml" containing:
+      """
+      [project]
+      name = "toml-project"
+      version = "1.0.0"
+      """
+    And a file "morphir.yaml" containing:
+      """
+      project:
+        name: yaml-project
+        version: 1.0.0
+      """
+    When I run "morphir config path"
+    Then the command fails
+    And stderr contains "Ambiguous Morphir configuration"

--- a/crates/morphir/tests/features/config.feature
+++ b/crates/morphir/tests/features/config.feature
@@ -11,6 +11,53 @@ Feature: Inspect Morphir configuration
     Then the command succeeds
     And stdout contains "show"
     And stdout contains "path"
+    And stdout contains "get"
+
+  Scenario: Get a configuration value by dotted key
+    Given a file "morphir.toml" containing:
+      """
+      [project]
+      name = "acceptance-project"
+      version = "1.0.0"
+      """
+    When I run "morphir config get project.name --isolated"
+    Then the command succeeds
+    And stdout is exactly "acceptance-project"
+
+  Scenario: Get a typed configuration value as JSON
+    Given a file "morphir.toml" containing:
+      """
+      [ir]
+      format_version = 3
+      """
+    And the environment variable "MORPHIR_IR__FORMAT_VERSION" is "4"
+    When I run "morphir config get ir.format_version --json --isolated"
+    Then the command succeeds
+    And stdout is valid JSON
+    And the JSON get key is "ir.format_version"
+    And the JSON get value is 4
+
+  Scenario: Get redacts a secret value
+    Given a file "morphir.toml" containing:
+      """
+      [registry]
+      token = "top-secret-token"
+      """
+    When I run "morphir config get registry.token --json --isolated"
+    Then the command succeeds
+    And stdout contains "<redacted>"
+    And stdout does not contain "top-secret-token"
+
+  Scenario: Get fails when the key does not exist
+    Given a file "morphir.toml" containing:
+      """
+      [project]
+      name = "acceptance-project"
+      version = "1.0.0"
+      """
+    When I run "morphir config get project.missing --isolated"
+    Then the command fails
+    And stderr contains "Configuration key not found: project.missing"
 
   Scenario: Show a discovered project configuration
     Given a file "morphir.toml" containing:

--- a/crates/morphir/tests/features/config.feature
+++ b/crates/morphir/tests/features/config.feature
@@ -23,9 +23,9 @@ Feature: Inspect Morphir configuration
       format_version = 3
       """
     And the working directory is "src/nested"
-    When I run "morphir config show"
+    When I run "morphir config show --isolated"
     Then the command succeeds
-    And stdout contains "name = \"acceptance-project\""
+    And stdout contains "acceptance-project"
     And stdout contains "format_version = 3"
 
   Scenario: Show an explicitly selected configuration as JSON
@@ -36,7 +36,7 @@ Feature: Inspect Morphir configuration
         version: 2.0.0
       """
     And the working directory is "elsewhere"
-    When I run "morphir config show --config ../configs/project.yaml --json"
+    When I run "morphir config show --config ../configs/project.yaml --json --isolated"
     Then the command succeeds
     And stdout is valid JSON
     And the JSON project name is "explicit-project"
@@ -49,7 +49,7 @@ Feature: Inspect Morphir configuration
       format_version = 3
       """
     And the environment variable "MORPHIR_IR__FORMAT_VERSION" is "4"
-    When I run "morphir config show --json"
+    When I run "morphir config show --json --isolated"
     Then the command succeeds
     And the JSON config value at "/ir/format_version" is 4
 
@@ -60,7 +60,7 @@ Feature: Inspect Morphir configuration
       token = "top-secret-token"
       endpoint = "https://registry.example.test"
       """
-    When I run "morphir config show --json"
+    When I run "morphir config show --json --isolated"
     Then the command succeeds
     And stdout contains "<redacted>"
     And stdout contains "https://registry.example.test"
@@ -73,7 +73,7 @@ Feature: Inspect Morphir configuration
       name = "source-project"
       version = "1.0.0"
       """
-    When I run "morphir config path"
+    When I run "morphir config path --isolated"
     Then the command succeeds
     And stdout contains "Configuration sources (in priority order):"
     And stdout contains "[✓] project"
@@ -88,7 +88,7 @@ Feature: Inspect Morphir configuration
       version = "1.0.0"
       """
     And the environment variable "MORPHIR_UI__COLOR" is "false"
-    When I run "morphir config path --json"
+    When I run "morphir config path --json --isolated"
     Then the command succeeds
     And stdout is valid JSON
     And the JSON source "project" has status "loaded"
@@ -101,7 +101,7 @@ Feature: Inspect Morphir configuration
       [project
       name = "broken"
       """
-    When I run "morphir config show"
+    When I run "morphir config show --isolated"
     Then the command fails
     And stderr contains "Configuration error"
 
@@ -118,6 +118,6 @@ Feature: Inspect Morphir configuration
         name: yaml-project
         version: 1.0.0
       """
-    When I run "morphir config path"
+    When I run "morphir config path --isolated"
     Then the command fails
     And stderr contains "Ambiguous Morphir configuration"


### PR DESCRIPTION
## Summary

- add a Cucumber test target for the `morphir config` command family
- add `morphir config get <dotted.key>` with plain and typed JSON output
- return the effective last-wins value and fail when the key is absent, following the core behavior of `git config get`
- redact secrets before `get` lookup so both secret leaves and containing objects are safe
- cover `config --help`, `config get`, `config show`, and `config path` in human and JSON modes
- verify discovery, explicit paths, environment precedence, redaction, source ordering, and errors
- inject `ConfigLoadOptions` into config runners and use an isolated source policy for hermetic acceptance scenarios
- fix Starbase dispatch so CLI commands execute once

## Testing

- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 check -p morphir --test config_acceptance` on native Windows ARM64
- `cargo +1.98.0-x86_64-pc-windows-msvc check -p morphir --all-targets`
- `cargo +1.98.0-x86_64-pc-windows-msvc clippy -p morphir --all-targets --no-deps -- -D warnings`

Native ARM64 compilation now passes with LLVM 22.1.8. Windows executable tests reach the linker and fail on existing unresolved Extism PDK host symbols. Linux CI runs the full Cucumber suite.