### PR TITLE
fix: install Dioxus CLI with locked dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           key: morphir-live-release
 
       - name: Install dioxus-cli
-        run: cargo install dioxus-cli
+        run: cargo install dioxus-cli --locked
 
       - name: Build WASM release
         working-directory: crates/morphir-live

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -88,6 +88,9 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("overwrite: true", self.workflow)
         self.assertIn("retention-days: 7", self.workflow)
 
+    def test_dioxus_cli_install_uses_published_lockfile(self) -> None:
+        self.assertIn("cargo install dioxus-cli --locked", self.workflow)
+
     def test_cli_checksum_uses_archive_basename(self) -> None:
         self.assertIn("cd release-assets", self.workflow)
         self.assertIn(


### PR DESCRIPTION
## Summary

- install dioxus-cli with its published Cargo.lock during releases
- add regression coverage for the locked install

## Context

The v0.2.0-alpha-01 release run failed because an unlocked cargo install resolved auth-git2 0.5.8 against an incompatible git2 feature set.

## Validation

- python -B -m unittest discover -s tests/ci
- git diff --check