### PR TITLE
fix: select Morphir Live in Dioxus build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build WASM release
         working-directory: crates/morphir-live
-        run: dx build --release
+        run: dx build --release --package morphir-live
 
       - name: Create release archive
         shell: bash

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -91,6 +91,12 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def test_dioxus_cli_install_uses_published_lockfile(self) -> None:
         self.assertIn("cargo install dioxus-cli --locked", self.workflow)
 
+    def test_dioxus_build_selects_package_in_workspace(self) -> None:
+        self.assertIn(
+            "dx build --release --package morphir-live",
+            self.workflow,
+        )
+
     def test_cli_checksum_uses_archive_basename(self) -> None:
         self.assertIn("cd release-assets", self.workflow)
         self.assertIn(


### PR DESCRIPTION
## Summary

- pass the Morphir Live package explicitly to the Dioxus release build
- add regression coverage for workspace package selection

## Context

Dioxus CLI 0.7.10 resolves workspace default members relative to the current crate directory and panics while canonicalizing the resulting nonexistent path. Explicit package selection bypasses that code path.

## Validation

- python -B -m unittest discover -s tests/ci
- git diff --check