### PR TITLE
fix: archive Dioxus workspace output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         shell: bash
         run: |
           ARCHIVE="morphir-live-${{ needs.release-info.outputs.version }}.tar.gz"
-          tar -C crates/morphir-live/dist -czf "$ARCHIVE" .
+          tar -C target/dx/morphir-live/release/web/public -czf "$ARCHIVE" .
           shasum -a 256 "$ARCHIVE" > "$ARCHIVE.sha256"
 
       - name: Upload build artifact

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -97,6 +97,12 @@ class ReleaseWorkflowTests(unittest.TestCase):
             self.workflow,
         )
 
+    def test_live_archive_uses_dioxus_workspace_output(self) -> None:
+        self.assertIn(
+            "tar -C target/dx/morphir-live/release/web/public",
+            self.workflow,
+        )
+
     def test_cli_checksum_uses_archive_basename(self) -> None:
         self.assertIn("cd release-assets", self.workflow)
         self.assertIn(


### PR DESCRIPTION
## Summary
- archive Morphir Live from Dioxus's workspace-level release output
- add regression coverage for the release archive path

## Verification
- python -B -m unittest discover -s tests/ci