### PR TITLE
fix: exclude Pages from release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: release-assets
+          pattern: morphir-*
           merge-multiple: true
 
       - name: Read published checksums

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -103,6 +103,10 @@ class ReleaseWorkflowTests(unittest.TestCase):
             self.workflow,
         )
 
+    def test_release_download_excludes_pages_artifact(self) -> None:
+        publish_job = self.workflow.split("  publish-release:\n", maxsplit=1)[1]
+        self.assertIn("pattern: morphir-*", publish_job)
+
     def test_cli_checksum_uses_archive_basename(self) -> None:
         self.assertIn("cd release-assets", self.workflow)
         self.assertIn(


### PR DESCRIPTION
## Summary
- download only Morphir release artifacts in the publish job
- exclude the GitHub Pages artifact from checksum validation
- add regression coverage for the artifact filter

## Verification
- python -B -m unittest discover -s tests/ci