### PR TITLE
fix: deploy release Pages from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
               - '.github/workflows/ci.yml'
             release:
               - '.github/workflows/release.yml'
+              - '.github/workflows/deploy-release-pages.yml'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'crates/morphir/Cargo.toml'

--- a/.github/workflows/deploy-release-pages.yml
+++ b/.github/workflows/deploy-release-pages.yml
@@ -1,0 +1,60 @@
+name: Deploy Release to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Release workflow run ID containing the Morphir Live artifact
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy-pages:
+    name: Deploy release to GitHub Pages
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download Morphir Live artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: morphir-live-wasm
+          run-id: ${{ inputs.run_id || github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Morphir Live artifact
+        run: |
+          mkdir pages-dist
+          tar -xzf morphir-live-*.tar.gz -C pages-dist
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: pages-dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,37 +236,3 @@ jobs:
             exit 0
           fi
           gh release upload "$TAG" "${ASSETS[@]}" --clobber
-
-  deploy-pages:
-    name: Deploy to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: [release-info, package-live]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Download Morphir Live artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: morphir-live-wasm
-
-      - name: Extract Morphir Live artifact
-        run: |
-          mkdir pages-dist
-          tar -xzf morphir-live-*.tar.gz -C pages-dist
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: pages-dist
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+PAGES_WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "deploy-release-pages.yml"
+)
 CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 CARGO_TOML_PATH = REPO_ROOT / "crates" / "morphir" / "Cargo.toml"
 WORKSPACE_TOML_PATH = REPO_ROOT / "Cargo.toml"
@@ -121,6 +124,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
     def test_workspace_version_files_trigger_release_validation(self) -> None:
         release_filter = self.ci_workflow.split("            release:\n", maxsplit=1)[1]
         release_filter = release_filter.split("\n\n", maxsplit=1)[0]
+        self.assertIn("- '.github/workflows/deploy-release-pages.yml'", release_filter)
         self.assertIn("- 'Cargo.toml'", release_filter)
         self.assertIn("- 'Cargo.lock'", release_filter)
 
@@ -149,11 +153,30 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("--clobber", publish_job)
         self.assertNotIn("softprops/action-gh-release", publish_job)
 
-    def test_pages_deployment_reuses_packaged_live_artifact(self) -> None:
-        pages_job = self.workflow.split("  deploy-pages:\n", maxsplit=1)[1]
-        self.assertIn("name: morphir-live-wasm", pages_job)
-        self.assertIn("tar -xzf morphir-live-*.tar.gz -C pages-dist", pages_job)
-        self.assertNotIn("dx build", pages_job)
+    def test_pages_deployment_runs_from_default_branch_after_release(self) -> None:
+        pages_workflow = PAGES_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        self.assertNotIn("\n  deploy-pages:\n", self.workflow)
+        self.assertIn("workflows: [Release]", pages_workflow)
+        self.assertIn("types: [completed]", pages_workflow)
+        self.assertIn("workflow_dispatch:", pages_workflow)
+        self.assertIn("run_id:", pages_workflow)
+        self.assertIn(
+            "github.event.workflow_run.conclusion == 'success'",
+            pages_workflow,
+        )
+        self.assertIn(
+            "startsWith(github.event.workflow_run.head_branch, 'v')",
+            pages_workflow,
+        )
+        self.assertIn("name: morphir-live-wasm", pages_workflow)
+        self.assertIn("inputs.run_id || github.event.workflow_run.id", pages_workflow)
+        self.assertIn("github-token: ${{ secrets.GITHUB_TOKEN }}", pages_workflow)
+        self.assertIn(
+            "tar -xzf morphir-live-*.tar.gz -C pages-dist",
+            pages_workflow,
+        )
+        self.assertNotIn("dx build", pages_workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #702.

## Summary
- move release Pages deployment to a workflow_run workflow that executes from main
- download Morphir Live from the completed release run
- keep the github-pages environment protection unchanged
- add a manual run ID input for recovery and verification
- validate the new workflow through the release CI path

## Verification
- python -B -m unittest discover -s tests/ci