### PR TITLE
chore: prepare v0.4.0-alpha.5 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to release (for example, v0.2.0-alpha-01)'
+        description: 'Existing tag to release (for example, v0.4.0-alpha.5)'
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,7 +5042,7 @@ dependencies = [
 
 [[package]]
 name = "morphir"
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-common"
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-core"
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-daemon"
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-devkit"
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-extension-sdk"
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 dependencies = [
  "extism-pdk",
  "serde",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "morphir-live"
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 dependencies = [
  "clap",
  "dioxus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/morphir-live", "crates/morphir"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0-alpha-01"
+version = "0.4.0-alpha.5"
 edition = "2024"
 rust-version = "1.93"
 authors = [

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -23,7 +23,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
 
     def test_workspace_uses_release_prerelease_version(self) -> None:
         workspace = tomllib.loads(WORKSPACE_TOML_PATH.read_text(encoding="utf-8"))
-        self.assertEqual("0.2.0-alpha-01", workspace["workspace"]["package"]["version"])
+        self.assertEqual("0.4.0-alpha.5", workspace["workspace"]["package"]["version"])
 
         lockfile = tomllib.loads(CARGO_LOCK_PATH.read_text(encoding="utf-8"))
         workspace_packages = {
@@ -33,8 +33,8 @@ class ReleaseWorkflowTests(unittest.TestCase):
         }
         self.assertEqual(
             {
-                "morphir": "0.2.0-alpha-01",
-                "morphir-live": "0.2.0-alpha-01",
+                "morphir": "0.4.0-alpha.5",
+                "morphir-live": "0.4.0-alpha.5",
             },
             workspace_packages,
         )


### PR DESCRIPTION
## Summary
- bump the Rust workspace version to 0.4.0-alpha.5
- update all local workspace entries in Cargo.lock
- update release regression expectations and the manual-release example

## Verification
- python -B -m unittest discover -s tests/ci (19 passed)
- git diff --check
- cargo check --workspace --locked reaches dependency validation but the existing kdl 6.7.1 and usage-lib 6.1.1 packages require Rust 1.95; this checkout uses Rust 1.93.1