### PR TITLE
chore: add finos/morphir-ui as ecosystem submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "ecosystem/morphir-scala"]
 	path = ecosystem/morphir-scala
 	url = https://github.com/finos/morphir-scala.git
+[submodule "ecosystem/morphir-ui"]
+	path = ecosystem/morphir-ui
+	url = https://github.com/finos/morphir-ui.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This repository contains:
 - **[finos/morphir-rust](https://github.com/finos/morphir-rust)** - Rust tooling
 - **[finos/morphir-python](https://github.com/finos/morphir-python)** - Python tooling
 - **[finos/morphir-moonbit](https://github.com/finos/morphir-moonbit)** - MoonBit implementation of Morphir tooling
+- **[finos/morphir-ui](https://github.com/finos/morphir-ui)** - User-interface work for the Morphir project
 
 ### Morphir IR Specification
 

--- a/ecosystem/AGENTS.md
+++ b/ecosystem/AGENTS.md
@@ -10,6 +10,7 @@ This directory holds **git submodules** for Morphir ecosystem repositories. Use 
 - **morphir-moonbit** – MoonBit implementation of Morphir tooling.
 - **morphir-python** – Python implementation of Morphir tooling.
 - **morphir-scala** – Scala implementation of Morphir tooling. Mill build, cross-compiled to JVM, JS, and Scala Native.
+- **morphir-ui** – User-interface work for the Morphir project (scoping stage; no implementation yet).
 
 Do not edit submodule content in-place for long-term changes. Prefer contributing in the submodule's own repo and then updating the submodule ref in finos/morphir when intentional.
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -12,6 +12,7 @@ This directory contains [git submodules](https://git-scm.com/book/en/v2/Git-Tool
 | **morphir-moonbit** | [finos/morphir-moonbit](https://github.com/finos/morphir-moonbit) | main | MoonBit implementation of Morphir tooling |
 | **morphir-python** | [finos/morphir-python](https://github.com/finos/morphir-python) | main | Python implementation of Morphir tooling |
 | **morphir-scala** | [finos/morphir-scala](https://github.com/finos/morphir-scala) | main | Scala implementation of Morphir tooling; Mill build cross-compiled to JVM, JS, and Scala Native |
+| **morphir-ui** | [finos/morphir-ui](https://github.com/finos/morphir-ui) | main | User-interface work for the Morphir project (scoping stage; no implementation yet) |
 
 ## First-time clone
 
@@ -67,6 +68,7 @@ mise run submodules:status
 - **morphir-moonbit**: MoonBit implementation with packages for SDK, core types, and WASM bindings. See below for build commands.
 - **morphir-python**: Python implementation of Morphir tooling. See the submodule's own README for build and usage.
 - **morphir-scala**: Scala implementation of Morphir tooling, built with Mill. See below for build commands.
+- **morphir-ui**: User-interface work for the Morphir project. Currently in the scoping stage with no implementation; discuss proposed work in the repo's GitHub issues.
 
 ## Building and testing morphir-moonbit
 


### PR DESCRIPTION
## Summary

Adds [finos/morphir-ui](https://github.com/finos/morphir-ui) as a git submodule under `ecosystem/`, following the same pattern as the other ecosystem submodules.

The submodule is pinned to the current `main` head (`81ab858`). morphir-ui is the FINOS repository for user-interface work in Morphir; it is currently in the scoping stage and contains governance files and a README but no implementation yet, so no build-task wiring was needed.

## Changes

- `.gitmodules` / `ecosystem/morphir-ui` — add the submodule (equivalent to `mise run submodules:add -- morphir-ui`)
- `ecosystem/README.md` — add morphir-ui to the submodule table and description list
- `ecosystem/AGENTS.md` — add morphir-ui to the submodule list
- `AGENTS.md` — add morphir-ui to the Morphir ecosystem repos list

## Test plan

- [x] `git submodule status` shows `ecosystem/morphir-ui` at `81ab858` on `main`
- [x] Submodule clones cleanly from the public URL