### PR TITLE
feat(home): relocatable Morphir home directory via MORPHIR_HOME

### DIFF
--- a/crates/morphir/src/commands/dist.rs
+++ b/crates/morphir/src/commands/dist.rs
@@ -3,7 +3,7 @@
 //! This module provides functionality for installing, updating, listing, and
 //! uninstalling Morphir distributions.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use starbase::AppResult;
 use std::collections::HashMap;
@@ -70,8 +70,7 @@ impl DistRegistry {
 
     /// Get the path to the distribution registry configuration file
     fn config_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow!("Could not determine home directory"))?;
-        Ok(home.join(".morphir").join("distributions.json"))
+        Ok(crate::home::MorphirHome::resolve()?.distributions_file())
     }
 
     /// Add or update a distribution in the registry

--- a/crates/morphir/src/commands/extension.rs
+++ b/crates/morphir/src/commands/extension.rs
@@ -3,7 +3,7 @@
 //! This module provides functionality for installing, updating, listing, and
 //! uninstalling Morphir extensions.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use starbase::AppResult;
 use std::collections::HashMap;
@@ -70,8 +70,7 @@ impl ExtensionRegistry {
 
     /// Get the path to the extension registry configuration file
     fn config_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow!("Could not determine home directory"))?;
-        Ok(home.join(".morphir").join("extensions.json"))
+        Ok(crate::home::MorphirHome::resolve()?.extensions_file())
     }
 
     /// Add or update an extension in the registry

--- a/crates/morphir/src/commands/tool.rs
+++ b/crates/morphir/src/commands/tool.rs
@@ -3,7 +3,7 @@
 //! This module provides functionality for installing, updating, listing, and
 //! uninstalling Morphir tools and extensions, similar to npm or dotnet tool.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use starbase::AppResult;
 use std::collections::HashMap;
@@ -69,8 +69,7 @@ impl ToolRegistry {
 
     /// Get the path to the tool registry configuration file
     fn config_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow!("Could not determine home directory"))?;
-        Ok(home.join(".morphir").join("tools.json"))
+        Ok(crate::home::MorphirHome::resolve()?.tools_file())
     }
 
     /// Add or update a tool in the registry

--- a/crates/morphir/src/home.rs
+++ b/crates/morphir/src/home.rs
@@ -1,0 +1,8 @@
+//! Resolution of the user-level Morphir home directory.
+//!
+//! The canonical implementation lives in `morphir-common` so the whole
+//! Morphir Rust ecosystem shares one definition; see
+//! [`morphir_common::home`] for the resolution rules (`MORPHIR_HOME`
+//! environment variable, falling back to the OS-specific `~/.morphir`).
+
+pub use morphir_common::home::{MORPHIR_HOME_ENV, MorphirHome};

--- a/crates/morphir/src/lib.rs
+++ b/crates/morphir/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod commands;
 pub mod error;
+pub mod home;
 pub mod output;
 pub mod tui;
 

--- a/crates/morphir/src/logging.rs
+++ b/crates/morphir/src/logging.rs
@@ -61,7 +61,7 @@ impl Default for LogConfig {
 /// Priority:
 /// 1. MORPHIR_LOG_DIR environment variable
 /// 2. `.morphir/logs/` in current or parent directory (workspace)
-/// 3. `~/.morphir/logs/` (global fallback)
+/// 3. `logs/` under the Morphir home directory (global fallback, honors MORPHIR_HOME)
 fn default_log_dir() -> PathBuf {
     // Check environment variable
     if let Ok(dir) = std::env::var("MORPHIR_LOG_DIR") {
@@ -74,10 +74,9 @@ fn default_log_dir() -> PathBuf {
     }
 
     // Global fallback
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".morphir")
-        .join("logs")
+    crate::home::MorphirHome::resolve()
+        .map(|home| home.logs_dir())
+        .unwrap_or_else(|_| PathBuf::from(".morphir").join("logs"))
 }
 
 /// Find the workspace root by looking for morphir.toml or .morphir directory.

--- a/crates/morphir/src/main.rs
+++ b/crates/morphir/src/main.rs
@@ -4,6 +4,7 @@ use starbase::{App, AppResult, AppSession};
 pub mod commands;
 pub mod error;
 mod help;
+pub mod home;
 mod logging;
 pub mod output;
 mod tui;

--- a/crates/morphir/tests/cli_integration.rs
+++ b/crates/morphir/tests/cli_integration.rs
@@ -146,3 +146,28 @@ fn test_output_format() {
         OutputFormat::JsonLines // json_lines takes precedence
     );
 }
+
+#[test]
+fn test_morphir_home_env_var_relocates_home_directory() {
+    let temp_dir = TempDir::new().unwrap();
+    let morphir_home = temp_dir.path().join("relocated-home");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_morphir"))
+        .args(["tool", "install", "example-tool"])
+        .env("MORPHIR_HOME", &morphir_home)
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("failed to run morphir binary");
+
+    assert!(
+        output.status.success(),
+        "tool install failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        morphir_home.join("tools.json").exists(),
+        "expected tool registry at MORPHIR_HOME ({})",
+        morphir_home.display()
+    );
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,8 @@ On Windows, Morphir checks:
 
 The paths are alternatives at the same precedence. If more than one candidate exists, Morphir reports an ambiguity error.
 
+When the [`MORPHIR_HOME` environment variable](#special-environment-variables) is set, the user-home candidate on every platform becomes `$MORPHIR_HOME/morphir.toml` or `morphir.yaml` instead of the `.morphir` directory under the user home. The platform config-directory candidates are unaffected.
+
 TOML example:
 
 ```toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,6 +234,23 @@ Mapping examples:
 
 Values are typed mechanically: `true` and `false` become booleans, integers become numbers, values that start with `[` or `{` and parse as JSON become arrays or objects, and anything else stays a string. Key segments are lower-cased.
 
+### Special Environment Variables
+
+Some environment variables control Morphir directly rather than overriding a configuration key:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `MORPHIR_HOME` | Relocates the Morphir home directory, which holds user-global state such as the tool, distribution, and extension registries and fallback log output; when set, caches also relocate under `$MORPHIR_HOME/cache` | `$HOME/.morphir` on Linux/macOS, `%USERPROFILE%\.morphir` on Windows |
+| `MORPHIR_LOG_DIR` | Overrides the log output directory | `.morphir/logs/` in the workspace, or `logs/` under the Morphir home directory |
+
+Relocating the home directory is useful for testing, CI, or sandboxed environments where the real user home is unavailable or should stay untouched:
+
+```sh
+export MORPHIR_HOME=/tmp/morphir-test-home
+```
+
+An empty value is treated as unset.
+
 ## CLI Commands
 
 ### View Configuration

--- a/docs/design/draft/daemon/environment.md
+++ b/docs/design/draft/daemon/environment.md
@@ -27,9 +27,12 @@ The Morphir home directory for user-level data.
 
 | Aspect | Value |
 |--------|-------|
-| Default (Linux/macOS) | `$XDG_DATA_HOME/morphir` or `~/.local/share/morphir` |
-| Default (Windows) | `%LOCALAPPDATA%\morphir` |
+| Default (Linux/macOS) | `~/.morphir` |
+| Default (Windows) | `%USERPROFILE%\.morphir` |
 | Contains | User extensions, cache, global config |
+
+When set, caches also relocate under `$MORPHIR_HOME/cache` so sandboxed and
+hermetic environments never touch the real user directories.
 
 ```bash
 export MORPHIR_HOME="/opt/morphir"
@@ -464,7 +467,7 @@ export MORPHIR_ENV="production"
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `MORPHIR_HOME` | path | XDG default | Morphir data directory |
+| `MORPHIR_HOME` | path | `~/.morphir` | Morphir home directory |
 | `MORPHIR_CONFIG_HOME` | path | XDG default | Configuration directory |
 | `MORPHIR_CACHE_HOME` | path | XDG default | Cache directory |
 | `MORPHIR_DAEMON_URL` | url | None | Daemon connection URL |

--- a/docs/spec/morphir-toml/morphir-toml-merge-rules.md
+++ b/docs/spec/morphir-toml/morphir-toml-merge-rules.md
@@ -80,6 +80,8 @@ The user-home alternatives are:
 - `$HOME/.morphir/morphir.toml` and `$HOME/.morphir/morphir.yaml` on Unix-like systems
 - `%USERPROFILE%\.morphir\morphir.toml` and `%USERPROFILE%\.morphir\morphir.yaml` on Windows, where the implementation resolves the profile through `FOLDERID_Profile`
 
+When the `MORPHIR_HOME` environment variable is set to a non-empty value, the user-home alternatives become `$MORPHIR_HOME/morphir.toml` and `$MORPHIR_HOME/morphir.yaml` on every platform, replacing the `.morphir` directory under the user home. The platform config-directory candidates are unaffected. `MORPHIR_HOME` is an operational variable and MUST NOT be interpreted as a configuration key by the environment source.
+
 These paths are alternate locations at the same precedence. A loader accepts at most one global user configuration across all candidates. If it finds more than one, it reports an ambiguity error that names every candidate. It MUST NOT merge the files or choose one by path or extension.
 
 ## Merge algorithm (normative)


### PR DESCRIPTION
## Summary

Adds an OS-specific, relocatable Morphir home directory: `MORPHIR_HOME` (empty value treated as unset) relocates the directory holding user-global state - the tool, distribution, and extension registries and fallback log output - which defaults to `~/.morphir` on Linux/macOS and `%USERPROFILE%\.morphir` on Windows. Useful for testing, CI, and restricted/hermetic sandbox environments.

- The canonical implementation lives in `morphir_common::home` (finos/morphir-rust#87, pulled in via the submodule bump); this repo's `crates/morphir/src/home.rs` re-exports it so both CLIs share one definition.
- The registry (`tool.rs`/`dist.rs`/`extension.rs`) and logging call sites route through `MorphirHome` instead of hardcoding `~/.morphir`.
- Through the submodule, config discovery replaces the `~/.morphir` global-config candidate with `$MORPHIR_HOME` when relocated, and caches move under `$MORPHIR_HOME/cache` so relocated environments stay hermetic; all defaults are unchanged.
- Docs: the configuration guide documents `MORPHIR_HOME`/`MORPHIR_LOG_DIR`; the daemon environment draft is aligned with the implemented `~/.morphir` defaults (XDG-split rejected in favor of the CARGO_HOME/RUSTUP_HOME dev-CLI pattern and backward compatibility).

Depends on finos/morphir-rust#87 (submodule pointer references its head commit).

## Testing

- End-to-end integration test spawning the real `morphir` binary with `MORPHIR_HOME` pointed at a temp dir and asserting the tool registry lands there
- Canonical resolver unit tests live in `morphir-common` (pure resolution core, no process-state mutation)
- `cargo test -p morphir`, clippy, and rustfmt all clean