### PR TITLE
feat(tests): adopt the CLI integration test crate from morphir-rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,16 +134,20 @@ jobs:
           key: morphir-cli
 
       - name: Check formatting
-        run: cargo fmt --package morphir --check
+        run: cargo fmt --package morphir --package integration-tests --check
 
       - name: Run clippy
-        run: cargo clippy --locked --package morphir --all-targets -- -D warnings
+        run: cargo clippy --locked --package morphir --package integration-tests --all-targets -- -D warnings
 
       - name: Run tests
         run: cargo test --locked --package morphir
 
       - name: Build
         run: cargo build --locked --release --package morphir
+
+      - name: Run CLI integration tests
+        # integration-tests finds the CLI binary in target/release/morphir
+        run: cargo test --locked --package integration-tests
 
       - name: Generate CLI docs
         run: mise run docs:cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "addr2line"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +711,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,7 +908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -1769,7 +1784,9 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cbb27bc2064274afa3a3d8bc9a0e71333589850573aa632ec4520e4af14d94"
 dependencies = [
+ "Inflector",
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "console",
  "cucumber-codegen",
@@ -1783,10 +1800,14 @@ dependencies = [
  "inventory",
  "itertools 0.14.0",
  "linked-hash-map",
+ "mime",
  "pin-project",
  "ref-cast",
  "regex",
  "sealed",
+ "serde",
+ "serde_json",
+ "serde_with",
  "smart-default",
 ]
 
@@ -1832,6 +1853,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
@@ -1855,6 +1886,19 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_core"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
@@ -1873,6 +1917,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -1924,6 +1979,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,6 +2020,9 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "derive_more"
@@ -3461,7 +3550,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -3724,7 +3813,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3741,6 +3830,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -4197,6 +4292,17 @@ checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -4281,6 +4387,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "integration-tests"
+version = "0.4.0-alpha.5"
+dependencies = [
+ "anyhow",
+ "cucumber",
+ "morphir-common",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -4402,6 +4520,59 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -4785,7 +4956,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser",
  "html5ever",
- "indexmap",
+ "indexmap 2.14.0",
  "selectors",
 ]
 
@@ -5359,7 +5530,7 @@ dependencies = [
  "crossterm",
  "cucumber",
  "dirs",
- "indexmap",
+ "indexmap 2.14.0",
  "miette",
  "morphir-common",
  "morphir-core",
@@ -5368,7 +5539,7 @@ dependencies = [
  "morphir-extension-sdk",
  "owo-colors",
  "ratatui",
- "schemars",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "starbase",
@@ -5396,7 +5567,7 @@ dependencies = [
  "dirs",
  "flate2",
  "glob",
- "indexmap",
+ "indexmap 2.14.0",
  "morphir-core",
  "nbformat",
  "reqwest 0.13.4",
@@ -5418,10 +5589,10 @@ name = "morphir-core"
 version = "0.4.0-alpha.5"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "lasso",
  "rstest",
- "schemars",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -5962,7 +6133,7 @@ checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -6265,7 +6436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -6452,7 +6623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
- "indexmap",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -6509,6 +6680,15 @@ name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -7684,12 +7864,24 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
- "indexmap",
+ "indexmap 2.14.0",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -7942,12 +8134,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "jiff",
+ "schemars 0.9.0",
+ "schemars 1.2.2",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -8976,7 +9201,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -8991,7 +9216,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -9033,7 +9258,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -9044,7 +9269,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -9057,7 +9282,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -9521,7 +9746,7 @@ checksum = "63acaba57f5b4fa84a5291e3d69dce8b25d46a36f0130b32fdfbaf3de864329d"
 dependencies = [
  "clap",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.15.0",
  "kdl",
  "log",
@@ -9780,7 +10005,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "im-rc",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "petgraph",
  "serde",
@@ -9833,7 +10058,7 @@ checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -9845,7 +10070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
 dependencies = [
  "bitflags 2.13.1",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -9926,7 +10151,7 @@ dependencies = [
  "cranelift-entity",
  "gimli 0.33.0",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "object 0.38.1",
  "postcard",
@@ -10113,7 +10338,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.13.1",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "wit-parser",
 ]
 
@@ -10913,7 +11138,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -11257,7 +11482,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.3",
  "hmac 0.13.0",
- "indexmap",
+ "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "integration-tests"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+publish = false
+description = "Integration tests for the Morphir CLI and cross-crate functionality"
+
+# This crate is test-only - no lib target
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+tempfile = "3.24"
+serde_json = "1.0"
+morphir-common = { path = "../../ecosystem/morphir-rust/crates/morphir-common" }
+
+[dev-dependencies]
+cucumber = { version = "0.22", features = ["output-json"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[[test]]
+name = "cli"
+harness = false

--- a/crates/integration-tests/fixtures/ir/v4/hole-reason-examples.json
+++ b/crates/integration-tests/fixtures/ir/v4/hole-reason-examples.json
@@ -1,0 +1,34 @@
+{
+  "description": "V4 HoleReason examples for testing morphir-rust compliance",
+  "examples": {
+    "unresolvedReference": {
+      "HoleReason": {
+        "UnresolvedReference": {
+          "target": "my-org/my-package:domain/users#get-user"
+        }
+      }
+    },
+    "deletedDuringRefactor": {
+      "HoleReason": {
+        "DeletedDuringRefactor": {
+          "tx-id": "refactor-2026-01-30-001"
+        }
+      }
+    },
+    "typeMismatch": {
+      "HoleReason": {
+        "TypeMismatch": {
+          "expected": "morphir/sdk:basics#int",
+          "found": "morphir/sdk:string#string"
+        }
+      }
+    }
+  },
+  "legacyStringFormats": {
+    "comment": "These string formats should be accepted for backward compatibility",
+    "examples": [
+      "DeletedDuringRefactor",
+      "TypeMismatch"
+    ]
+  }
+}

--- a/crates/integration-tests/fixtures/ir/v4/incomplete-type-definition-example.json
+++ b/crates/integration-tests/fixtures/ir/v4/incomplete-type-definition-example.json
@@ -1,0 +1,50 @@
+{
+  "description": "V4 IncompleteTypeDefinition examples for testing morphir-rust compliance",
+  "examples": {
+    "holeWithUnresolvedReference": {
+      "IncompleteTypeDefinition": {
+        "typeParams": ["a"],
+        "incompleteness": {
+          "Hole": {
+            "reason": {
+              "UnresolvedReference": {
+                "target": "acme/finance:domain#missing-type"
+              }
+            }
+          }
+        },
+        "partialTypeExp": null
+      }
+    },
+    "draftWithPartialBody": {
+      "IncompleteTypeDefinition": {
+        "typeParams": [],
+        "incompleteness": {
+          "Draft": {}
+        },
+        "partialTypeExp": {
+          "Record": {
+            "id": "morphir/sdk:string#string",
+            "name": "morphir/sdk:string#string"
+          }
+        }
+      }
+    },
+    "holeWithTypeMismatch": {
+      "IncompleteTypeDefinition": {
+        "typeParams": ["a", "b"],
+        "incompleteness": {
+          "Hole": {
+            "reason": {
+              "TypeMismatch": {
+                "expected": "Function",
+                "found": "Record"
+              }
+            }
+          }
+        },
+        "partialTypeExp": null
+      }
+    }
+  }
+}

--- a/crates/integration-tests/fixtures/ir/v4/incompleteness-examples.json
+++ b/crates/integration-tests/fixtures/ir/v4/incompleteness-examples.json
@@ -1,0 +1,33 @@
+{
+  "description": "V4 Incompleteness examples for testing morphir-rust compliance",
+  "examples": {
+    "holeWithUnresolvedReference": {
+      "Incompleteness": {
+        "Hole": {
+          "reason": {
+            "UnresolvedReference": {
+              "target": "acme/finance:ledger#calculate-balance"
+            }
+          }
+        }
+      }
+    },
+    "holeWithTypeMismatch": {
+      "Incompleteness": {
+        "Hole": {
+          "reason": {
+            "TypeMismatch": {
+              "expected": "Int",
+              "found": "String"
+            }
+          }
+        }
+      }
+    },
+    "draft": {
+      "Incompleteness": {
+        "Draft": {}
+      }
+    }
+  }
+}

--- a/crates/integration-tests/fixtures/ir/v4/literal-examples.json
+++ b/crates/integration-tests/fixtures/ir/v4/literal-examples.json
@@ -1,0 +1,36 @@
+{
+  "description": "V4 Literal examples demonstrating IntegerLiteral (replacing WholeNumberLiteral)",
+  "v4CanonicalFormat": {
+    "comment": "V4 canonical format uses IntegerLiteral",
+    "examples": {
+      "positiveInteger": { "IntegerLiteral": 42 },
+      "negativeInteger": { "IntegerLiteral": -100 },
+      "zero": { "IntegerLiteral": 0 },
+      "largeInteger": { "IntegerLiteral": 9223372036854775807 },
+      "bool": { "BoolLiteral": true },
+      "char": { "CharLiteral": "A" },
+      "string": { "StringLiteral": "Hello, Morphir!" },
+      "float": { "FloatLiteral": 3.14159 },
+      "decimal": { "DecimalLiteral": "123456789.987654321" }
+    }
+  },
+  "v3LegacyFormat": {
+    "comment": "V3 format used WholeNumberLiteral - V4 decoders should accept this",
+    "examples": {
+      "wholeNumber": ["WholeNumberLiteral", 42],
+      "negativeWholeNumber": ["WholeNumberLiteral", -100]
+    }
+  },
+  "backwardCompatibility": {
+    "comment": "V4 decoders MUST accept WholeNumberLiteral for backward compatibility",
+    "decoderRequirements": [
+      "Accept { \"IntegerLiteral\": n } (V4 canonical)",
+      "Accept { \"WholeNumberLiteral\": n } (V4 legacy compat)",
+      "Accept [\"WholeNumberLiteral\", n] (V3 tagged array)"
+    ],
+    "encoderRequirements": [
+      "Output { \"IntegerLiteral\": n } for V4 format",
+      "Output [\"WholeNumberLiteral\", n] for V3 format"
+    ]
+  }
+}

--- a/crates/integration-tests/fixtures/ir/v4/native-hint-examples.json
+++ b/crates/integration-tests/fixtures/ir/v4/native-hint-examples.json
@@ -1,0 +1,49 @@
+{
+  "description": "V4 NativeHint examples for testing morphir-rust compliance",
+  "examples": {
+    "arithmetic": {
+      "NativeHint": {
+        "Arithmetic": {}
+      }
+    },
+    "comparison": {
+      "NativeHint": {
+        "Comparison": {}
+      }
+    },
+    "stringOp": {
+      "NativeHint": {
+        "StringOp": {}
+      }
+    },
+    "collectionOp": {
+      "NativeHint": {
+        "CollectionOp": {}
+      }
+    },
+    "platformSpecificWasm": {
+      "NativeHint": {
+        "PlatformSpecific": {
+          "platform": "wasm"
+        }
+      }
+    },
+    "platformSpecificJavaScript": {
+      "NativeHint": {
+        "PlatformSpecific": {
+          "platform": "javascript"
+        }
+      }
+    }
+  },
+  "legacyStringFormats": {
+    "comment": "These string formats should be accepted for backward compatibility",
+    "examples": [
+      "Arithmetic",
+      "Comparison",
+      "StringOp",
+      "CollectionOp",
+      "PlatformSpecific"
+    ]
+  }
+}

--- a/crates/integration-tests/fixtures/ir/v4/v4-library-distribution.json
+++ b/crates/integration-tests/fixtures/ir/v4/v4-library-distribution.json
@@ -1,0 +1,93 @@
+{
+  "formatVersion": 4,
+  "distribution": {
+    "Library": {
+      "packageName": "example/v4-test",
+      "dependencies": {},
+      "def": {
+        "modules": {
+          "domain": {
+            "access": "Public",
+            "value": {
+              "types": {
+                "user-id": {
+                  "access": "Public",
+                  "value": {
+                    "TypeAliasDefinition": {
+                      "typeParams": [],
+                      "typeExp": "morphir/sdk:string#string"
+                    }
+                  }
+                },
+                "incomplete-user": {
+                  "access": "Private",
+                  "value": {
+                    "IncompleteTypeDefinition": {
+                      "typeParams": [],
+                      "incompleteness": {
+                        "Draft": {}
+                      },
+                      "partialTypeExp": {
+                        "Record": {
+                          "id": "morphir/sdk:string#string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "values": {
+                "get-user-name": {
+                  "access": "Public",
+                  "value": {
+                    "inputTypes": {
+                      "user": {
+                        "type": "example/v4-test:domain#user-id"
+                      }
+                    },
+                    "outputType": "morphir/sdk:string#string",
+                    "body": {
+                      "ExpressionBody": {
+                        "body": {
+                          "Hole": {
+                            "attributes": {},
+                            "reason": {
+                              "UnresolvedReference": {
+                                "target": "example/v4-test:domain#user-name-lookup"
+                              }
+                            },
+                            "expectedType": "morphir/sdk:string#string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "native-add": {
+                  "access": "Public",
+                  "value": {
+                    "inputTypes": {
+                      "a": {
+                        "type": "morphir/sdk:basics#int"
+                      },
+                      "b": {
+                        "type": "morphir/sdk:basics#int"
+                      }
+                    },
+                    "outputType": "morphir/sdk:basics#int",
+                    "body": {
+                      "NativeBody": {
+                        "hint": { "Arithmetic": {} },
+                        "description": "Native integer addition"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -140,23 +140,23 @@ impl CliTestContext {
             }
         }
 
-        // Fall back to target directory locations
+        // Fall back to target directory locations, resolved to absolute
+        // paths so the binary stays reachable after the child process
+        // changes its working directory to the test project.
+        let workspace_root = Self::find_workspace_root()?;
+        let target_dir = std::env::var("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("target"));
+        let target_dir = if target_dir.is_absolute() {
+            target_dir
+        } else {
+            workspace_root.join(target_dir)
+        };
         let possible_paths = vec![
             // Release binary (preferred)
-            {
-                let target_dir =
-                    std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
-                PathBuf::from(target_dir).join("release").join("morphir")
-            },
+            target_dir.join("release").join("morphir"),
             // Debug binary
-            {
-                let target_dir =
-                    std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
-                PathBuf::from(target_dir).join("debug").join("morphir")
-            },
-            // In workspace root target
-            PathBuf::from("../../target/release/morphir"),
-            PathBuf::from("../../target/debug/morphir"),
+            target_dir.join("debug").join("morphir"),
         ];
 
         possible_paths.into_iter().find(|path| path.exists())

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -1,0 +1,342 @@
+//! Integration test utilities for Morphir CLI testing
+//!
+//! This crate provides helpers for running CLI integration tests that require
+//! the morphir binary to be pre-built and available.
+//!
+//! # Binary Location
+//!
+//! The CLI tests look for the morphir binary in these locations (in order):
+//! 1. `.morphir/build/bin/morphir` (staged release binary - preferred for CI)
+//! 2. `.morphir/build/bin/morphir-debug` (staged debug binary)
+//! 3. `target/release/morphir`
+//! 4. `target/debug/morphir`
+//!
+//! # Usage
+//!
+//! Build the binary first:
+//! ```sh
+//! mise run build:release
+//! ```
+//!
+//! Then run integration tests:
+//! ```sh
+//! mise run test:integration
+//! ```
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+#[allow(unused_imports)]
+use morphir_common::vfs::Vfs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+/// Check if CLI tests can run (morphir binary available or cargo run works)
+pub fn cli_tests_available() -> bool {
+    // Check if staged binary exists (preferred for CI)
+    if CliTestContext::find_workspace_root()
+        .is_some_and(|root| root.join(".morphir/build/bin/morphir").exists())
+    {
+        return true;
+    }
+    // Check if morphir binary exists in target
+    if CliTestContext::get_morphir_binary().is_some() {
+        return true;
+    }
+    // Check if we can find the workspace root (needed for cargo run)
+    if CliTestContext::find_workspace_root().is_some() {
+        // Try to verify cargo is available
+        return Command::new("cargo").arg("--version").output().is_ok();
+    }
+    false
+}
+
+/// CLI test context for managing test environments
+#[derive(Debug)]
+pub struct CliTestContext {
+    pub temp_dir: TempDir,
+    pub project_root: PathBuf,
+    pub morphir_dir: PathBuf,
+}
+
+impl CliTestContext {
+    /// Create a new test context with temporary directory
+    pub fn new() -> Result<Self> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().to_path_buf();
+        let morphir_dir = project_root.join(".morphir");
+
+        Ok(Self {
+            temp_dir,
+            project_root,
+            morphir_dir,
+        })
+    }
+
+    /// Create a test project structure
+    pub fn create_test_project(&self) -> Result<()> {
+        std::fs::create_dir_all(self.project_root.join("src"))?;
+        Ok(())
+    }
+
+    /// Create a test workspace structure
+    pub fn create_test_workspace(&self, members: &[&str]) -> Result<()> {
+        for member in members {
+            let member_path = self.project_root.join(member);
+            std::fs::create_dir_all(member_path.join("src"))?;
+        }
+        Ok(())
+    }
+
+    /// Write a morphir.toml configuration file
+    pub fn write_test_config(&self, config_content: &str) -> Result<()> {
+        std::fs::write(self.project_root.join("morphir.toml"), config_content)?;
+        Ok(())
+    }
+
+    /// Write a test source file
+    pub fn write_source_file(&self, path: &str, content: &str) -> Result<()> {
+        let file_path = self.project_root.join(path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&file_path, content)?;
+        Ok(())
+    }
+
+    /// Find the workspace root by looking for Cargo.toml with [workspace]
+    pub fn find_workspace_root() -> Option<PathBuf> {
+        // Start from CARGO_MANIFEST_DIR if available
+        let start_dir = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| std::env::current_dir().unwrap());
+
+        let mut current = start_dir.as_path();
+        loop {
+            let cargo_toml = current.join("Cargo.toml");
+            if cargo_toml.exists()
+                && let Ok(content) = std::fs::read_to_string(&cargo_toml)
+                && content.contains("[workspace]")
+            {
+                return Some(current.to_path_buf());
+            }
+            current = current.parent()?;
+        }
+    }
+
+    /// Get the path to the morphir CLI binary
+    pub fn get_morphir_binary() -> Option<PathBuf> {
+        // First check for staged binary in .morphir/build/bin/
+        // This is the preferred location for CI and pre-built binaries
+        if let Some(workspace_root) = Self::find_workspace_root() {
+            let staged_release = workspace_root.join(".morphir/build/bin/morphir");
+            if staged_release.exists() {
+                return Some(staged_release);
+            }
+            let staged_debug = workspace_root.join(".morphir/build/bin/morphir-debug");
+            if staged_debug.exists() {
+                return Some(staged_debug);
+            }
+        }
+
+        // Fall back to target directory locations
+        let possible_paths = vec![
+            // Release binary (preferred)
+            {
+                let target_dir =
+                    std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+                PathBuf::from(target_dir).join("release").join("morphir")
+            },
+            // Debug binary
+            {
+                let target_dir =
+                    std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".to_string());
+                PathBuf::from(target_dir).join("debug").join("morphir")
+            },
+            // In workspace root target
+            PathBuf::from("../../target/release/morphir"),
+            PathBuf::from("../../target/debug/morphir"),
+        ];
+
+        possible_paths.into_iter().find(|path| path.exists())
+    }
+
+    /// Execute a morphir CLI command
+    pub fn execute_cli_command(&self, args: &[&str]) -> Result<CommandResult> {
+        // Find workspace root by looking for Cargo.toml with [workspace]
+        let workspace_root = Self::find_workspace_root()
+            .ok_or_else(|| anyhow::anyhow!("Could not find workspace root"))?;
+
+        let mut cmd = if let Some(binary) = Self::get_morphir_binary() {
+            // Use built binary
+            Command::new(&binary)
+        } else {
+            // Fall back to cargo run with absolute path to workspace Cargo.toml
+            let manifest_path = workspace_root.join("Cargo.toml");
+            let mut cargo_cmd = Command::new("cargo");
+            cargo_cmd.args([
+                "run",
+                "--bin",
+                "morphir",
+                "--manifest-path",
+                manifest_path.to_str().unwrap(),
+                "--",
+            ]);
+            cargo_cmd
+        };
+
+        cmd.args(args);
+        cmd.current_dir(&self.project_root);
+        cmd.env("RUST_BACKTRACE", "1");
+        cmd.env("RUST_LOG", "error"); // Reduce noise in test output
+
+        let output = cmd.output()?;
+
+        Ok(CommandResult {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            exit_code: output.status.code().unwrap_or(-1),
+            success: output.status.success(),
+        })
+    }
+
+    /// Load a test fixture from .morphir/test/fixtures/
+    pub fn load_test_fixture(&self, name: &str) -> Result<PathBuf> {
+        let fixture_path = self.morphir_dir.join("test").join("fixtures").join(name);
+
+        if fixture_path.exists() {
+            Ok(fixture_path)
+        } else {
+            // Try in workspace root
+            let workspace_fixture = self
+                .project_root
+                .parent()
+                .unwrap_or(&self.project_root)
+                .join(".morphir")
+                .join("test")
+                .join("fixtures")
+                .join(name);
+
+            if workspace_fixture.exists() {
+                Ok(workspace_fixture)
+            } else {
+                Err(anyhow::anyhow!("Test fixture not found: {}", name))
+            }
+        }
+    }
+
+    /// Load a test scenario from .morphir/test/scenarios/
+    pub fn load_test_scenario(&self, name: &str) -> Result<PathBuf> {
+        let scenario_path = self.morphir_dir.join("test").join("scenarios").join(name);
+
+        if scenario_path.exists() {
+            Ok(scenario_path)
+        } else {
+            // Try in workspace root
+            let workspace_scenario = self
+                .project_root
+                .parent()
+                .unwrap_or(&self.project_root)
+                .join(".morphir")
+                .join("test")
+                .join("scenarios")
+                .join(name);
+
+            if workspace_scenario.exists() {
+                Ok(workspace_scenario)
+            } else {
+                Err(anyhow::anyhow!("Test scenario not found: {}", name))
+            }
+        }
+    }
+}
+
+/// Result of a CLI command execution
+#[derive(Debug, Clone)]
+pub struct CommandResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub success: bool,
+}
+
+impl CommandResult {
+    /// Assert that the command succeeded
+    pub fn assert_success(&self) {
+        assert!(
+            self.success,
+            "Command failed with exit code {}\nSTDOUT:\n{}\nSTDERR:\n{}",
+            self.exit_code, self.stdout, self.stderr
+        );
+    }
+
+    /// Assert that the command failed
+    pub fn assert_failure(&self) {
+        assert!(
+            !self.success,
+            "Command unexpectedly succeeded\nSTDOUT:\n{}\nSTDERR:\n{}",
+            self.stdout, self.stderr
+        );
+    }
+
+    /// Assert that output contains text
+    pub fn assert_output_contains(&self, text: &str) {
+        assert!(
+            self.stdout.contains(text) || self.stderr.contains(text),
+            "Output does not contain '{}'\nSTDOUT:\n{}\nSTDERR:\n{}",
+            text,
+            self.stdout,
+            self.stderr
+        );
+    }
+
+    /// Assert JSON output structure
+    pub fn assert_json_output(&self) -> Result<serde_json::Value> {
+        let json: serde_json::Value = serde_json::from_str(&self.stdout)?;
+        Ok(json)
+    }
+}
+
+/// Assert that files exist
+pub fn assert_files_exist(root: &Path, files: &[&str]) {
+    for file in files {
+        let path = root.join(file);
+        assert!(path.exists(), "File does not exist: {:?}", path);
+    }
+}
+
+/// Assert .morphir/ folder structure
+pub fn assert_morphir_structure(morphir_dir: &Path, project: &str) {
+    assert!(
+        morphir_dir.exists(),
+        ".morphir/ directory does not exist: {:?}",
+        morphir_dir
+    );
+
+    let out_dir = morphir_dir.join("out").join(project);
+    assert!(
+        out_dir.exists(),
+        ".morphir/out/{} directory does not exist: {:?}",
+        project,
+        out_dir
+    );
+}
+
+/// Create a NotebookVfs from a test notebook file
+pub fn create_notebook_vfs(notebook_path: &Path) -> Result<morphir_common::vfs::NotebookVfs> {
+    Ok(morphir_common::vfs::NotebookVfs::from_file(notebook_path)?)
+}
+
+/// Assert that a notebook contains a file with the given path
+pub fn assert_notebook_contains_file(
+    notebook: &morphir_common::vfs::NotebookVfs,
+    file_path: &Path,
+) -> Result<()> {
+    assert!(
+        notebook.exists(file_path),
+        "Notebook does not contain file: {:?}",
+        file_path
+    );
+    Ok(())
+}

--- a/crates/integration-tests/tests/cli.rs
+++ b/crates/integration-tests/tests/cli.rs
@@ -1,0 +1,98 @@
+//! CLI integration tests for Morphir
+//!
+//! These tests require the morphir binary to be pre-built and available.
+//! Run `mise run build:release` before running these tests.
+
+use cucumber::{World, given, then, when};
+use integration_tests::{CliTestContext, cli_tests_available};
+
+/// World state for CLI cucumber tests
+#[derive(Debug, Default, World)]
+pub struct CliWorld {
+    context: Option<CliTestContext>,
+    last_result: Option<integration_tests::CommandResult>,
+}
+
+// Background step
+#[given("I have a temporary test project")]
+fn given_temp_project(world: &mut CliWorld) {
+    if !cli_tests_available() {
+        // Skip test if CLI binary not available
+        return;
+    }
+
+    let context = CliTestContext::new().expect("Failed to create test context");
+    context
+        .create_test_project()
+        .expect("Failed to create test project");
+    world.context = Some(context);
+}
+
+// Source file step
+#[given(regex = r#"I have a Gleam source file "([^"]+)" with:"#)]
+fn given_gleam_source_file(world: &mut CliWorld, path: String, step: &cucumber::gherkin::Step) {
+    if let Some(context) = &world.context {
+        let content = step
+            .docstring()
+            .expect("Expected docstring with file content");
+        context
+            .write_source_file(&path, content)
+            .expect("Failed to write source file");
+    }
+}
+
+// CLI command step
+#[when(regex = r#"I run CLI command "([^"]+)""#)]
+fn when_run_cli_command(world: &mut CliWorld, command: String) {
+    if let Some(context) = &world.context {
+        // Parse the command string into args
+        let args: Vec<&str> = command.split_whitespace().collect();
+        // Skip the "morphir" part if present
+        let args = if args.first() == Some(&"morphir") {
+            &args[1..]
+        } else {
+            &args[..]
+        };
+
+        match context.execute_cli_command(args) {
+            Ok(result) => world.last_result = Some(result),
+            Err(e) => panic!("Failed to execute CLI command: {}", e),
+        }
+    }
+}
+
+// Success assertion
+#[then("the CLI command should succeed")]
+fn then_cli_should_succeed(world: &mut CliWorld) {
+    if let Some(result) = &world.last_result {
+        result.assert_success();
+    }
+}
+
+// Failure assertion
+#[then("the CLI command should fail")]
+fn then_cli_should_fail(world: &mut CliWorld) {
+    if let Some(result) = &world.last_result {
+        result.assert_failure();
+    }
+}
+
+// Output contains assertion
+#[then(regex = r#"the output should contain "([^"]+)""#)]
+fn then_output_contains(world: &mut CliWorld, text: String) {
+    if let Some(result) = &world.last_result {
+        result.assert_output_contains(&text);
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // All CLI tests are currently @wip - skip them
+    CliWorld::cucumber()
+        .filter_run("tests/features", |feature, _rule, _scenario| {
+            // Skip features with @wip tag
+            let feature_has_wip = feature.tags.iter().any(|t| t == "wip");
+            !feature_has_wip
+        })
+        .await;
+}

--- a/crates/integration-tests/tests/features/cli.feature
+++ b/crates/integration-tests/tests/features/cli.feature
@@ -1,0 +1,134 @@
+# WIP: CLI integration tests require full CLI functionality
+# See: https://github.com/finos/morphir-rust/issues/40
+@wip
+Feature: CLI Integration
+  As a developer
+  I want to use the Morphir CLI to compile and generate Gleam code
+  So that I can integrate Morphir into my build process
+
+  Background:
+    Given I have a temporary test project
+
+  @cli @e2e
+  Scenario: Compile single Gleam file via CLI
+    Given I have a Gleam source file "src/main.gleam" with:
+      """
+      pub fn hello() {
+        "world"
+      }
+      """
+    When I run CLI command "morphir gleam compile --input src/"
+    Then the CLI command should succeed
+    And the CLI should create .morphir/out/ structure
+    And the output should contain "Compilation successful"
+
+  @cli @e2e
+  Scenario: Compile Gleam project via CLI
+    Given I have a Gleam project structure:
+      | path              | content                    |
+      | src/main.gleam    | pub fn main() { "hello" } |
+      | src/utils.gleam   | pub fn util() { 42 }      |
+      | morphir.toml      | [project]\nname = "test"  |
+    When I run CLI command "morphir gleam compile"
+    Then the CLI command should succeed
+    And the CLI should create .morphir/out/test/compile/gleam/ structure
+
+  @cli @e2e
+  Scenario: Generate Gleam code from IR via CLI
+    Given I have compiled IR at ".morphir/out/test/compile/gleam/"
+    When I run CLI command "morphir gleam generate --input .morphir/out/test/compile/gleam/"
+    Then the CLI command should succeed
+    And the CLI should create .morphir/out/test/generate/gleam/ structure
+
+  @cli @e2e
+  Scenario: Roundtrip via CLI (compile then generate)
+    Given I have a Gleam source file "src/main.gleam" with:
+      """
+      pub fn hello() {
+        "world"
+      }
+      """
+    When I run CLI command "morphir gleam roundtrip --input src/"
+    Then the CLI command should succeed
+    And the CLI should create both compile and generate output structures
+
+  @cli @e2e @config
+  Scenario: CLI with morphir.toml configuration
+    Given I have a morphir.toml file:
+      """
+      [project]
+      name = "my-package"
+      source_directory = "src"
+
+      [frontend]
+      language = "gleam"
+      """
+    And I have a Gleam source file "src/main.gleam" with:
+      """
+      pub fn main() {
+        "hello"
+      }
+      """
+    When I run CLI command "morphir compile"
+    Then the CLI command should succeed
+    And the CLI should use configuration from morphir.toml
+
+  @cli @json
+  Scenario: CLI with JSON output
+    Given I have a Gleam source file "src/main.gleam" with:
+      """
+      pub fn main() {
+        "hello"
+      }
+      """
+    When I run CLI command "morphir gleam compile --input src/ --json"
+    Then the CLI command should succeed
+    And the JSON output should be valid
+    And the JSON output should contain "success"
+
+  @cli @json
+  Scenario: CLI with JSON Lines output
+    Given I have a Gleam source file "src/main.gleam" with:
+      """
+      pub fn main() {
+        "hello"
+      }
+      """
+    When I run CLI command "morphir gleam compile --input src/ --json-lines"
+    Then the CLI command should succeed
+    And the JSON Lines output should be valid
+
+  @cli @error-handling
+  Scenario: CLI error handling (missing files)
+    When I run CLI command "morphir gleam compile --input nonexistent/"
+    Then the CLI command should fail
+    And the error output should contain "not found" or "does not exist"
+
+  @cli @error-handling
+  Scenario: CLI error handling (invalid config)
+    Given I have an invalid morphir.toml file:
+      """
+      [project]
+      name = invalid syntax
+      """
+    When I run CLI command "morphir compile"
+    Then the CLI command should fail
+    And the error output should contain "config" or "parse"
+
+  @cli
+  Scenario Outline: CLI commands with various flags and options
+    Given I have a Gleam source file "src/main.gleam" with:
+      """
+      pub fn main() {
+        "hello"
+      }
+      """
+    When I run CLI command "<command>"
+    Then the CLI command should <result>
+
+    Examples:
+      | command                                          | result  |
+      | morphir gleam compile --input src/              | succeed |
+      | morphir compile --language gleam --input src/   | succeed |
+      | morphir gleam compile --input src/ --json       | succeed |
+      | morphir gleam roundtrip --input src/            | succeed |

--- a/crates/integration-tests/tests/features/steel-thread.feature
+++ b/crates/integration-tests/tests/features/steel-thread.feature
@@ -1,0 +1,359 @@
+@steel-thread
+Feature: Steel Thread - Migrate Command via Extension Architecture
+  As a Morphir developer
+  I want to validate the extension architecture end-to-end
+  Using the migrate command as the steel thread
+
+  Background:
+    Given the morphir CLI is built and available
+    And I have a temporary test directory
+
+  # ========================================================================
+  # Native Mode Tests (P0 - Steel Thread MVP)
+  # ========================================================================
+
+  @native @p0
+  Scenario Outline: Migrate Classic IR to V4 format (native mode)
+    Given I have a Classic IR file from fixture "<fixture>"
+    When I run "morphir migrate <fixture> output.json --target v4"
+    Then the command should succeed
+    And the file "output.json" should exist
+    And the file "output.json" should be valid JSON
+    And the file "output.json" should have V4 wrapper format
+    And the file "output.json" should contain package "<package>"
+    And the stderr should contain "Migration complete"
+
+    Examples:
+      | fixture                          | package           |
+      | classic-simple.json              | com.example.test  |
+      | classic-with-modules.json        | com.example.multi |
+      | classic-with-types.json          | com.example.types |
+      | classic-with-values.json         | com.example.funcs |
+      | classic-empty-package.json       | com.example.empty |
+
+  @native @p0
+  Scenario Outline: Migrate V4 IR to Classic format (native mode)
+    Given I have a V4 IR file from fixture "<fixture>"
+    When I run "morphir migrate <fixture> output.json --target classic"
+    Then the command should succeed
+    And the file "output.json" should exist
+    And the file "output.json" should be valid JSON
+    And the file "output.json" should have Classic tuple format
+    And the file "output.json" should contain '"formatVersion": 1'
+    And the stderr should contain "Migration complete"
+
+    Examples:
+      | fixture                        |
+      | v4-simple.json                 |
+      | v4-with-modules.json           |
+      | v4-with-types.json             |
+      | v4-with-values.json            |
+      | v4-empty-package.json          |
+
+  @native @p0
+  Scenario: Migrate same format (Classic to Classic) is a no-op
+    Given I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json output.json --target classic"
+    Then the command should succeed
+    And the file "output.json" should exist
+    And the stderr should contain "Copying"
+
+  @native @p0
+  Scenario: Migrate same format (V4 to V4) is a no-op
+    Given I have a V4 IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json output.json --target v4"
+    Then the command should succeed
+    And the file "output.json" should exist
+    And the stderr should contain "Copying"
+
+  @native @p0 @error-handling
+  Scenario: Handle invalid target version
+    Given I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json output.json --target invalid"
+    Then the command should fail
+    And the stderr should contain "Invalid target version"
+
+  @native @p0 @error-handling
+  Scenario: Handle missing input file
+    When I run "morphir migrate nonexistent.json output.json --target v4"
+    Then the command should fail
+    And the stderr should contain "Failed to load input"
+
+  @native @p0 @error-handling
+  Scenario: Handle malformed IR
+    Given I have a file "invalid-ir.json" with:
+      """
+      { "this": "is not valid IR" }
+      """
+    When I run "morphir migrate invalid-ir.json output.json --target v4"
+    Then the command should fail
+    And the stderr should contain "Failed to load input"
+
+  @native @p0
+  Scenario: Migrate to stdout with JSON mode
+    Given I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json --target v4 --json"
+    Then the command should succeed
+    And stdout should contain valid JSON
+    And stdout should contain "formatVersion"
+
+  @native @p0
+  Scenario: Migrate with dependency warning (Classic to V4)
+    Given I have a Classic IR file "morphir-ir.json" with:
+      """
+      {
+        "formatVersion": 1,
+        "distribution": [
+          "Library",
+          "Library",
+          ["com", "example", "test"],
+          [
+            {
+              "packageName": ["com", "example", "dependency"],
+              "packagePath": "/some/path"
+            }
+          ],
+          {
+            "modules": {}
+          }
+        ]
+      }
+      """
+    When I run "morphir migrate morphir-ir.json output.json --target v4"
+    Then the command should succeed
+    And the stderr should contain "Warning"
+    And the stderr should contain "dependencies"
+
+  @native @p0
+  Scenario: Migrate with expanded format option
+    Given I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json output.json --target v4 --expanded"
+    Then the command should succeed
+    And the file "output.json" should exist
+    # Note: Expanded format means non-compact JSON (more readable, more bytes)
+
+  # ========================================================================
+  # Remote Source Tests (P1)
+  # ========================================================================
+
+  @native @p1 @remote
+  Scenario: Migrate from HTTP URL
+    Given I have internet connectivity
+    When I run "morphir migrate https://example.com/morphir-ir.json output.json --target v4"
+    Then the command should succeed or fail gracefully
+    # Note: May fail if URL not available, that's ok for test
+
+  @native @p1 @remote
+  Scenario: Migrate with force refresh
+    Given I have a cached remote IR
+    When I run "morphir migrate https://example.com/morphir-ir.json output.json --target v4 --force-refresh"
+    Then the command should succeed or fail gracefully
+
+  @native @p1 @remote
+  Scenario: Migrate with no cache
+    When I run "morphir migrate https://example.com/morphir-ir.json output.json --target v4 --no-cache"
+    Then the command should succeed or fail gracefully
+
+  # ========================================================================
+  # WASM Mode Tests (P2 - Future)
+  # ========================================================================
+
+  @wasm @p2 @wip
+  Scenario: Migrate Classic to V4 via WASM extension
+    Given I have morphir-builtins compiled to WASM
+    And I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json output.json --target v4 --mode wasm"
+    Then the command should succeed
+    And the file "output.json" should exist
+    And the file "output.json" should match native mode output
+
+  @wasm @p2 @wip
+  Scenario: WASM mode produces identical results to native mode
+    Given I have morphir-builtins compiled to WASM
+    And I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json native-output.json --target v4"
+    And I run "morphir migrate morphir-ir.json wasm-output.json --target v4 --mode wasm"
+    Then both commands should succeed
+    And the files "native-output.json" and "wasm-output.json" should be identical
+
+  @wasm @p2 @wip @performance
+  Scenario: Compare native vs WASM performance
+    Given I have morphir-builtins compiled to WASM
+    And I have a large Classic IR file "large-ir.json"
+    When I measure time for "morphir migrate large-ir.json native.json --target v4"
+    And I measure time for "morphir migrate large-ir.json wasm.json --target v4 --mode wasm"
+    Then WASM mode should be within 50% of native mode performance
+    # Note: WASM has overhead, but should be reasonable
+
+  # ========================================================================
+  # Envelope Protocol Validation (P0 - Architecture Proof)
+  # ========================================================================
+
+  @envelope @p0
+  Scenario: Verify envelope protocol is used throughout
+    Given I have debugging enabled for morphir-builtins
+    And I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json output.json --target v4"
+    Then the debug logs should show envelope creation
+    And the debug logs should show envelope serialization
+    And the debug logs should show envelope deserialization
+    And the command should succeed
+
+  @envelope @p0
+  Scenario: Envelope contains proper metadata
+    Given I have JSON output mode enabled
+    And I have a Classic IR file "morphir-ir.json"
+    When I run "morphir migrate morphir-ir.json output.json --target v4 --json"
+    Then the JSON output should contain:
+      | field          | type    |
+      | success        | boolean |
+      | source_format  | string  |
+      | target_format  | string  |
+      | warnings       | array   |
+
+  # ========================================================================
+  # Regression Tests (P1)
+  # ========================================================================
+
+  @regression @p1
+  Scenario: Migrate preserves module structure
+    Given I have a Classic IR with multiple modules
+    When I run "morphir migrate morphir-ir.json output.json --target v4"
+    Then the command should succeed
+    And all modules should be present in output
+
+  @regression @p1
+  Scenario: Migrate preserves type definitions
+    Given I have a Classic IR with type definitions
+    When I run "morphir migrate morphir-ir.json output.json --target v4"
+    Then the command should succeed
+    And all type definitions should be present in output
+
+  @regression @p1
+  Scenario: Migrate preserves value definitions
+    Given I have a Classic IR with value definitions
+    When I run "morphir migrate morphir-ir.json output.json --target v4"
+    Then the command should succeed
+    And all value definitions should be present in output
+
+  # ========================================================================
+  # V4 Format Validation (Correctness Check)
+  # ========================================================================
+
+  @native @p0 @format-validation
+  Scenario: V4 output uses correct wrapper object format
+    Given I have a Classic IR file "classic-simple.json" with:
+      """
+      {
+        "formatVersion": 1,
+        "distribution": [
+          "Library",
+          "Library",
+          ["com", "example", "test"],
+          [],
+          {
+            "modules": {
+              "Main": {
+                "types": {},
+                "values": {}
+              }
+            }
+          }
+        ]
+      }
+      """
+    When I run "morphir migrate classic-simple.json output.json --target v4"
+    Then the command should succeed
+    And the file "output.json" should contain:
+      """
+      {
+        "formatVersion": "4.0.0",
+        "distribution": {
+          "Library": {
+            "packageName": "com/example/test",
+            "dependencies": {},
+            "def": {
+              "modules": {
+                "main": {
+                  "types": {},
+                  "values": {}
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    # Note: V4 canonical format uses:
+    # - Wrapper objects: {"Library": {...}} not tuple arrays ["Library", ...]
+    # - Canonical strings: "com/example/test" not ["com", "example", "test"]
+    # - Kebab-case names: "main" not "Main" for module names
+
+  @native @p0 @format-validation
+  Scenario Outline: Verify V4 distribution variants use wrapper objects
+    Given I have a V4 IR file with <variant> distribution
+    When I parse the JSON structure
+    Then the "distribution" field should be an object
+    And the "distribution" object should have key "<wrapper>"
+    And the "<wrapper>" value should be an object (not an array)
+
+    Examples:
+      | variant     | wrapper      |
+      | Library     | Library      |
+      | Specs       | Specs        |
+      | Application | Application  |
+
+  # ========================================================================
+  # JSONL Format Tests (P1 - Fast Follower)
+  # ========================================================================
+
+  @native @p1 @jsonl @fast-follower @wip
+  Scenario Outline: Migrate to JSONL format
+    Given I have a <format> IR file from fixture "<fixture>"
+    When I run "morphir migrate <fixture> output.jsonl --target v4 --format jsonl"
+    Then the command should succeed
+    And the file "output.jsonl" should exist
+    And each line in "output.jsonl" should be valid JSON
+    And line 1 should contain package metadata
+    And subsequent lines should contain module definitions
+
+    Examples:
+      | format  | fixture                     |
+      | Classic | classic-simple.json         |
+      | Classic | classic-with-modules.json   |
+      | V4      | v4-simple.json              |
+      | V4      | v4-with-modules.json        |
+
+  @native @p1 @jsonl @fast-follower @wip
+  Scenario: JSONL format enables directory tree reconstruction
+    Given I have a Classic IR file "classic-with-modules.json"
+    When I run "morphir migrate classic-with-modules.json output.jsonl --target v4 --format jsonl"
+    Then the command should succeed
+    And I can reconstruct directory tree from "output.jsonl"
+    And each JSONL line maps to a file path
+    # Note: Line 1 = package.json, Line N = modules/path/to/module.json
+
+  @native @p1 @jsonl @fast-follower @wip
+  Scenario: JSONL line structure validation
+    Given I have a Classic IR file "classic-simple.json"
+    When I run "morphir migrate classic-simple.json output.jsonl --target v4 --format jsonl"
+    Then the command should succeed
+    And line 1 should match JSONL package schema:
+      | field         | type   | required |
+      | packageName   | string | true     |
+      | dependencies  | object | true     |
+      | formatVersion | string | true     |
+    And subsequent lines should match JSONL module schema:
+      | field      | type   | required |
+      | modulePath | string | true     |
+      | types      | object | false    |
+      | values     | object | false    |
+
+  @native @p1 @jsonl @fast-follower @wip @roundtrip
+  Scenario: JSONL roundtrip produces equivalent IR
+    Given I have a Classic IR file "classic-with-modules.json"
+    When I run "morphir migrate classic-with-modules.json v4-standard.json --target v4"
+    And I run "morphir migrate classic-with-modules.json v4-jsonl.jsonl --target v4 --format jsonl"
+    And I reconstruct "v4-reconstructed.json" from "v4-jsonl.jsonl"
+    Then both commands should succeed
+    And "v4-standard.json" and "v4-reconstructed.json" should be semantically equivalent


### PR DESCRIPTION
## What

Moves the Morphir CLI integration test crate from finos/morphir-rust into this repository, ahead of removing the CLI crate from morphir-rust (companion PR there follows). The canonical `morphir` CLI lives here, so its integration tests belong here too.

## Changes

- Add `crates/integration-tests`: cucumber CLI features (`cli.feature`, `steel-thread.feature`), the CLI test harness helpers, and IR fixtures, unchanged from morphir-rust apart from resolving `morphir-common` through the `ecosystem/morphir-rust` submodule
- Run `cargo test -p integration-tests` in the morphir-cli CI job after the release build, which places the binary at `target/release/morphir` where the harness looks for it
- Extend the CI fmt and clippy steps to cover the new crate

## Behavior

Test behavior is unchanged from morphir-rust: `cli.feature` is tagged `@wip` and filtered out, and the steel-thread scenarios skip until their step definitions are implemented. Locally: check, fmt, clippy (`-D warnings`), and `cargo test -p integration-tests` all pass.