### PR TITLE
docs(ecosystem): reflect the bootstrapped morphir-ui implementation

### DIFF
--- a/ecosystem/AGENTS.md
+++ b/ecosystem/AGENTS.md
@@ -10,7 +10,7 @@ This directory holds **git submodules** for Morphir ecosystem repositories. Use 
 - **morphir-moonbit** – MoonBit implementation of Morphir tooling.
 - **morphir-python** – Python implementation of Morphir tooling.
 - **morphir-scala** – Scala implementation of Morphir tooling. Mill build, cross-compiled to JVM, JS, and Scala Native.
-- **morphir-ui** – User-interface work for the Morphir project (scoping stage; no implementation yet).
+- **morphir-ui** – Morphir's UI monorepo: the morphir-desktop (Electron) and morphir-web apps sharing one Svelte + Effect application (moonrepo + mise + bun toolchain).
 
 Do not edit submodule content in-place for long-term changes. Prefer contributing in the submodule's own repo and then updating the submodule ref in finos/morphir when intentional.
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -12,7 +12,7 @@ This directory contains [git submodules](https://git-scm.com/book/en/v2/Git-Tool
 | **morphir-moonbit** | [finos/morphir-moonbit](https://github.com/finos/morphir-moonbit) | main | MoonBit implementation of Morphir tooling |
 | **morphir-python** | [finos/morphir-python](https://github.com/finos/morphir-python) | main | Python implementation of Morphir tooling |
 | **morphir-scala** | [finos/morphir-scala](https://github.com/finos/morphir-scala) | main | Scala implementation of Morphir tooling; Mill build cross-compiled to JVM, JS, and Scala Native |
-| **morphir-ui** | [finos/morphir-ui](https://github.com/finos/morphir-ui) | main | User-interface work for the Morphir project (scoping stage; no implementation yet) |
+| **morphir-ui** | [finos/morphir-ui](https://github.com/finos/morphir-ui) | main | Morphir's UI monorepo: the morphir-desktop (Electron) and morphir-web apps sharing one Svelte + Effect application |
 
 ## First-time clone
 
@@ -68,7 +68,7 @@ mise run submodules:status
 - **morphir-moonbit**: MoonBit implementation with packages for SDK, core types, and WASM bindings. See below for build commands.
 - **morphir-python**: Python implementation of Morphir tooling. See the submodule's own README for build and usage.
 - **morphir-scala**: Scala implementation of Morphir tooling, built with Mill. See below for build commands.
-- **morphir-ui**: User-interface work for the Morphir project. Currently in the scoping stage with no implementation; discuss proposed work in the repo's GitHub issues.
+- **morphir-ui**: Morphir's UI monorepo — the morphir-desktop (Electron) and morphir-web apps sharing one Svelte + Effect application, with `morphir-ir.json` browsing, MORPHIR_HOME-backed configuration, and GitHub token capture. Build with mise + bun + moon: `mise install && bun install && moon run :build` (see the repo's README for the full getting-started guide).
 
 ## Building and testing morphir-moonbit
 

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -68,7 +68,7 @@ mise run submodules:status
 - **morphir-moonbit**: MoonBit implementation with packages for SDK, core types, and WASM bindings. See below for build commands.
 - **morphir-python**: Python implementation of Morphir tooling. See the submodule's own README for build and usage.
 - **morphir-scala**: Scala implementation of Morphir tooling, built with Mill. See below for build commands.
-- **morphir-ui**: Morphir's UI monorepo — the morphir-desktop (Electron) and morphir-web apps sharing one Svelte + Effect application, with `morphir-ir.json` browsing, MORPHIR_HOME-backed configuration, and GitHub token capture. Build with mise + bun + moon: `mise install && bun install && moon run :build` (see the repo's README for the full getting-started guide).
+- **morphir-ui**: Morphir's UI monorepo — the morphir-desktop (Electron) and morphir-web apps sharing one Svelte + Effect application, with `morphir-ir.json` browsing, MORPHIR_HOME-backed configuration, and GitHub token capture. Build from within the submodule (it has its own mise toolchain): `cd ecosystem/morphir-ui && mise install && bun install && moon run :build` (see that repo's README for the full getting-started guide).
 
 ## Building and testing morphir-moonbit
 


### PR DESCRIPTION
Follow-up to #718's review comment: `ecosystem/README.md` still described morphir-ui as scoping-stage with no implementation. Updates both entries to describe the bootstrapped monorepo (morphir-desktop + morphir-web over one Svelte + Effect app) and adds the mise/bun/moon build one-liner.