### PR TITLE
docs: restore stage and commit steps in the team-maintainer close workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,9 @@ apply to every session; step 4 depends on the active profile.
      part of session close — work is then not complete until `git push`
      succeeds:
      ```bash
+     git status              # review what changed
+     git add <files>         # stage code changes
+     git commit -m "..."     # commit code (beads changes go via bd sync)
      git pull --rebase
      bd sync
      git push


### PR DESCRIPTION
Addresses the post-merge review comment on #723: the profile-scoped rewrite dropped the `git add`/`git commit` steps from the team-maintainer session-close workflow, leaving `git pull --rebase` → `bd sync` → `git push` with no way to carry code changes (and a dirty-worktree rebase failure). Restores the stage/commit steps ahead of the pull/push sequence.