### PR TITLE
docs: add commit step to the managed session-close snippets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -362,6 +362,7 @@ This protocol applies when ending a Beads implementation workflow. It is subordi
    git status
 
    # Team-maintainer opt-in only, unless current instructions forbid it:
+   git add <files> && git commit -m "..."   # commit code before pulling
    git pull --rebase
    bd dolt push
    git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ This protocol applies when ending a Beads implementation workflow. It is subordi
    git status
 
    # Team-maintainer opt-in only, unless current instructions forbid it:
+   git add <files> && git commit -m "..."   # commit code before pulling
    git pull --rebase
    git push
    git status


### PR DESCRIPTION
Addresses the post-merge review comment on #724: the managed Beads-integration blocks in `AGENTS.md` and `CLAUDE.md` still showed a team-maintainer close sequence starting at `git pull --rebase` with no commit step. Adds the stage/commit line to both. The blocks are installer-managed (hash-stamped), so the durable fix belongs in the upstream beads template — noted in the commit body; a future block regeneration may need this re-applied.