### PR TITLE
ci: cancel superseded runs on the same branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ on:
     branches:
       - main
 
+# Cancel in-progress runs when a new run supersedes them. Pull requests are keyed
+# by number rather than by head branch: two forks can both offer a branch called
+# `main`, and keying on the branch name would let one fork's push cancel the
+# other's run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## What

Adds a concurrency group to the CI workflow so a new push to a branch cancels the run that push superseded:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: true
```

## Why

Today every force-push during review leaves the previous run going, so we pay for a full matrix (Rust build, tests, docs, release-workflow checks) that nobody will read. Grouping by workflow and branch means only the newest commit's run survives.

## What is deliberately not changed

- **Release** — cancelling a release mid-publish is worse than paying for it.
- **Deploy Release to GitHub Pages** — already serialises on its own `pages` group with `cancel-in-progress: false`, which is the right behavior for a deployment.

`github.head_ref || github.ref` keys pull request runs by their source branch and everything else by ref, so a PR run and a branch push run share one group rather than racing each other.

This matches the concurrency block [finos/morphir-rust](https://github.com/finos/morphir-rust/blob/main/.github/workflows/ci.yml) already runs, so the two repositories behave the same way.