### PR TITLE
fix(cli): keep braces out of compile's help text

### DIFF
--- a/completions/_morphir
+++ b/completions/_morphir
@@ -32,7 +32,7 @@ cmd compile display_order=2 args_override_self=#false help="Compile source code 
     flag "-l --language" help="Source language (e.g., gleam, elm)" {
         arg <LANGUAGE>
     }
-    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir-{language}" {
+    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir- followed by the language name" {
         arg <EXTENSION>
     }
     flag "-i --input" help="Input source directory or file. An installed or configured Elm process accepts one .elm file" {

--- a/completions/morphir.bash
+++ b/completions/morphir.bash
@@ -35,7 +35,7 @@ cmd compile display_order=2 args_override_self=#false help="Compile source code 
     flag "-l --language" help="Source language (e.g., gleam, elm)" {
         arg <LANGUAGE>
     }
-    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir-{language}" {
+    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir- followed by the language name" {
         arg <EXTENSION>
     }
     flag "-i --input" help="Input source directory or file. An installed or configured Elm process accepts one .elm file" {

--- a/completions/morphir.fish
+++ b/completions/morphir.fish
@@ -22,7 +22,7 @@ cmd compile display_order=2 args_override_self=#false help="Compile source code 
     flag "-l --language" help="Source language (e.g., gleam, elm)" {
         arg <LANGUAGE>
     }
-    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir-{language}" {
+    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir- followed by the language name" {
         arg <EXTENSION>
     }
     flag "-i --input" help="Input source directory or file. An installed or configured Elm process accepts one .elm file" {

--- a/crates/morphir/src/commands/compile.rs
+++ b/crates/morphir/src/commands/compile.rs
@@ -30,7 +30,7 @@ use std::path::{Path, PathBuf};
 pub struct CompileOptions {
     /// Language to compile (e.g., "gleam", "elm")
     pub language: Option<String>,
-    /// Extension provider id for single-file Elm compilation. Defaults to morphir-{language}.
+    /// Extension provider id for single-file Elm compilation. Defaults to morphir- followed by the language name.
     pub extension: Option<String>,
     /// Input path or directory
     pub input: Option<String>,

--- a/crates/morphir/src/main.rs
+++ b/crates/morphir/src/main.rs
@@ -50,7 +50,7 @@ enum Commands {
         /// Source language (e.g., gleam, elm)
         #[arg(short, long)]
         language: Option<String>,
-        /// Extension provider id for single-file Elm compilation. Defaults to morphir-{language}.
+        /// Extension provider id for single-file Elm compilation. Defaults to morphir- followed by the language name.
         #[arg(long)]
         extension: Option<String>,
         /// Input source directory or file. An installed or configured Elm process accepts one .elm file.

--- a/crates/morphir/tests/cli_integration.rs
+++ b/crates/morphir/tests/cli_integration.rs
@@ -89,7 +89,20 @@ fn compile_help_documents_explicit_extension_selection() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("--extension <EXTENSION>"), "{stdout}");
     assert!(stdout.contains("single-file Elm compilation"), "{stdout}");
-    assert!(stdout.contains("morphir-{language}"), "{stdout}");
+    // Clap wraps help to the terminal width, so compare against text with its
+    // whitespace collapsed rather than against the wrapped lines.
+    let flowed = stdout.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        flowed.contains("Defaults to morphir- followed by the language name"),
+        "{stdout}"
+    );
+    // Deliberately not `morphir-{language}`. Help text is copied verbatim into
+    // docs/cli/compile.md, which Docusaurus parses as MDX, where a brace opens a
+    // JSX expression and the page fails to render.
+    assert!(
+        !flowed.contains("morphir-{"),
+        "braces in prose help become a JSX expression in the generated docs: {stdout}"
+    );
 }
 
 #[test]

--- a/docs/cli/compile.md
+++ b/docs/cli/compile.md
@@ -7,7 +7,7 @@ Compile source code to Morphir IR
 
 ## Flags
 - **`-l --language <LANGUAGE>`** — Source language (e.g., gleam, elm)
-- **`--extension <EXTENSION>`** — Extension provider id for single-file Elm compilation. Defaults to morphir-{language}
+- **`--extension <EXTENSION>`** — Extension provider id for single-file Elm compilation. Defaults to morphir- followed by the language name
 - **`-i --input <INPUT>`** — Input source directory or file. An installed or configured Elm process accepts one .elm file
 - **`-o --output <OUTPUT>`** — Output directory
 - **`--package-name <PACKAGE_NAME>`** — Package name override

--- a/docs/cli/morphir.usage.kdl
+++ b/docs/cli/morphir.usage.kdl
@@ -12,7 +12,7 @@ cmd compile display_order=2 args_override_self=#false help="Compile source code 
     flag "-l --language" help="Source language (e.g., gleam, elm)" {
         arg <LANGUAGE>
     }
-    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir-{language}" {
+    flag --extension help="Extension provider id for single-file Elm compilation. Defaults to morphir- followed by the language name" {
         arg <EXTENSION>
     }
     flag "-i --input" help="Input source directory or file. An installed or configured Elm process accepts one .elm file" {

--- a/docs/man/man1/morphir.1
+++ b/docs/man/man1/morphir.1
@@ -212,7 +212,7 @@ Compile source code to Morphir IR
 Source language (e.g., gleam, elm)
 .TP
 \fB\-\-extension\fR \fI<EXTENSION>\fR
-Extension provider id for single\-file Elm compilation. Defaults to morphir\-{language}
+Extension provider id for single\-file Elm compilation. Defaults to morphir\- followed by the language name
 .TP
 \fB\-i, \-\-input\fR \fI<INPUT>\fR
 Input source directory or file. An installed or configured Elm process accepts one .elm file


### PR DESCRIPTION
The docs site build is red on `main`, which is why the Netlify check fails on every open pull request rather than only on the one that caused it.

## What is broken

```
Docusaurus static site generation failed for 1 paths:
  - "/docs/cli/compile"
      ReferenceError: language is not defined
```

The `--extension` flag added in #733 documents itself as *"Defaults to morphir-{language}"*. That reads well in a terminal, but `usage generate markdown` copies help text verbatim into `docs/cli/compile.md`, Docusaurus parses that file as MDX, and MDX reads `{language}` as a JSX expression referring to a variable that does not exist. One page fails to render, and the whole build fails with it.

## The fix

The help text now says "Defaults to morphir- followed by the language name". The `format!("morphir-{language}")` that actually builds the id is untouched — there the braces are real interpolation.

Regenerated `docs/cli/compile.md`, `docs/cli/morphir.usage.kdl`, the man page and the three completion files, so eight files change by one line each.

Verified by building the site locally: red before, `[SUCCESS] Generated static files in "build"` after.

## Worth noting

This is the second time a CLI help string has broken the site this way. The first was a `<repo>` placeholder that MDX read as an unclosed JSX tag, caught while reviewing #722. Both are invisible in `cargo test`, in `--help`, and in review — they only surface in a full Docusaurus build, which is the last thing to run.

A lint over the generated `docs/cli/*.md` for unescaped `{` and `<` would catch the next one at `mise run docs:cli` instead of at Netlify. Filed separately rather than bundled here, so this stays a one-line fix that can land immediately.