### PR TITLE
fix(deps): update patched ajv versions

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16,7 +16,7 @@
 				"@mdx-js/react": "^3.0.0",
 				"@monaco-editor/react": "^4.6.0",
 				"@uiw/react-json-view": "^2.0.0-alpha.27",
-				"ajv": "^8.17.1",
+				"ajv": "^8.20.0",
 				"ajv-formats": "^3.0.1",
 				"clsx": "^2.1.0",
 				"docusaurus-json-schema-plugin": "^1.13.3",
@@ -9768,9 +9768,9 @@
 			}
 		},
 		"node_modules/file-loader/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -14271,9 +14271,9 @@
 			}
 		},
 		"node_modules/null-loader/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -18926,9 +18926,9 @@
 			}
 		},
 		"node_modules/url-loader/node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",

--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,7 @@
 	},
 	"dependencies": {
 		"effect": "3.22.1",
-		"ajv": "^8.17.1",
+		"ajv": "^8.20.0",
 		"ajv-formats": "^3.0.1",
 		"@cmfcmf/docusaurus-search-local": "^2.0.0",
 		"@docusaurus/core": "^3.9.2",


### PR DESCRIPTION
## Summary

- raise the direct AJV minimum to 8.20.0
- refresh Docusaurus loader-local AJV v6 copies from 6.12.6 to 6.15.0
- keep Docusaurus at 3.10.2 without an npm override

## Why

Dependabot's security update job could not resolve the mixed AJV v6/v8 graph without proposing a Docusaurus downgrade. The existing dependency ranges already accept patched AJV v6, so refreshing the lockfile fixes the advisory without changing the toolchain.

## Validation

- `npm audit --package-lock-only --json`: no AJV vulnerability
- `npm ci`
- `npm ls ajv --all`
- `npm run test:config-schema`
- `npm run test:ir-storage-profiles`
- `npm run build`

Existing unrelated local check failures:

- `npm run check:schema-sync`: the embedded morphir-rust config schema is stale
- `npm run typecheck`: TypeScript 7 rejects the existing `baseUrl` option

Beads: morphir-g74l