### PR TITLE
docs: define domain modeling principles

### DIFF
--- a/.claude/skills/technical-writer/scripts/generate_llms_txt.py
+++ b/.claude/skills/technical-writer/scripts/generate_llms_txt.py
@@ -123,6 +123,12 @@ KEY_DOCUMENTS = [
     "docs/generate/avro.md",
 ]
 
+# Documents that must remain discoverable in the compact index even when their
+# section is otherwise optional.
+PINNED_COMPACT_DOCUMENTS = {
+    "developers/domain-modeling.md",
+}
+
 
 def find_repo_root() -> Path:
     """Find the repository root by looking for .git or website directory."""
@@ -510,6 +516,15 @@ def generate_compact(sections: Dict[str, List[Dict]], docs_dir: Path) -> str:
     # Core documentation section
     lines.append("## Docs")
     lines.append("")
+
+    pinned_docs = [
+        doc
+        for section_data in sections.values()
+        for doc in section_data['docs']
+        if doc['path'] in PINNED_COMPACT_DOCUMENTS
+    ]
+    for doc in pinned_docs:
+        lines.append(f"- [{doc['title']}]({doc['url']}): {doc['description']}")
 
     # Add priority 1 and 2 sections
     for section_name, section_data in sorted(sections.items(),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,19 @@ The Morphir IR specification and JSON schemas are available in the morphir-dotne
 - **Separation of concerns** - Clearly define I/O boundaries
 - **Functional composition** - Build complex behavior from simple, composable functions
 
+### Domain Modeling
+
+- Make invalid states unrepresentable in public APIs, domain boundaries, and persistent state
+- Use algebraic data types (ADTs), tagged unions, sealed variants, and type-state to represent distinct cases
+- Avoid primitive obsession and stringly typed APIs; use newtypes, opaque types, branded types, or validated wrappers
+- Parse and validate primitives at I/O boundaries before converting them to domain types
+- Use exhaustive matching and smart constructors to preserve invariants
+- Require benchmarks or profiling for private compact representations; contain them behind named helpers, test conversions, and prevent API leaks
+- Inspect and extend existing domain types before adding primitive parameters, boolean flags, or free-form strings
+- Preserve readability; unrelated flags are not an optimization
+
+See the [Domain Modeling guide](docs/developers/domain-modeling.md).
+
 ## Development Practices
 
 ### Test-Driven Development (TDD)

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -10,6 +10,7 @@ Documentation for contributing to Morphir and advanced development topics.
 ## 📋 Contents
 
 - **[Contributing Guide](contributing.md)** - How to contribute to Morphir
+- **[Domain Modeling](domain-modeling.md)** - Make invalid states unrepresentable and give domain values distinct types
 - **[Contribution Guide Index](contribution-guide-index.md)** - Index of contribution resources
 - **[Contribution Guide README](contribution-guide-readme.md)** - Overview of contribution process
 - **[Morphir Developers Guide](morphir-developers-guide.md)** - Comprehensive guide for Morphir developers
@@ -59,6 +60,7 @@ See [Contributing Guide](contributing.md) for detailed instructions.
 When contributing to Morphir:
 
 - **Follow existing patterns** - Maintain consistency with the codebase
+- **Model the domain in types** - Follow the [domain modeling guide](domain-modeling.md)
 - **Write tests** - Ensure your changes are well-tested
 - **Document your code** - Help others understand your contributions
 - **Ask questions** - The community is here to help

--- a/docs/developers/domain-modeling.md
+++ b/docs/developers/domain-modeling.md
@@ -1,0 +1,72 @@
+---
+id: domain-modeling
+title: Domain modeling
+sidebar_position: 5
+---
+
+# Domain modeling
+
+Morphir code expresses domain rules in types. At public APIs, domain boundaries,
+and persistent state, prefer designs where invalid states cannot be represented.
+Types should tell readers which values and transitions the domain permits.
+
+## Represent states explicitly
+
+Use algebraic data types, tagged unions, sealed variants, or type-state to model
+distinct cases. Each case should carry only the data that is valid for that case.
+Do not encode mutually exclusive states as combinations of boolean flags or
+optional fields. Match every case exhaustively so that adding a state requires
+callers to decide how to handle it.
+
+Before adding primitive parameters, boolean state flags, or free-form strings,
+inspect the existing domain vocabulary. Extend an established domain type when
+the new concept belongs there. Tests should cover validation at system boundaries
+and every allowed or rejected state transition.
+
+## Give domain values distinct types
+
+Avoid primitive obsession and stringly typed domain APIs. Two values that share
+a machine representation can still mean different things. Represent those
+distinctions with newtypes, opaque types, branded types, or validated wrappers.
+A type alias is insufficient when it leaves distinct values interchangeable.
+
+Put validation in smart constructors and keep unchecked construction private.
+This makes the validated type evidence that its invariants hold. Do not wrap every
+scalar, however. Introduce a domain type only when it captures a real distinction
+or invariant.
+
+Primitive representations are appropriate at I/O boundaries. Parse and validate
+inputs that represent constrained domain concepts, then convert them to domain
+types. Ordinary internal values may remain primitive when they carry no domain
+distinction or invariant. Keep protocol and wire-format compatibility separate
+from internal domain representation.
+
+## Performance-sensitive internals
+
+A performance-sensitive internal path may use a compact primitive representation
+only when profiling or a reproducible benchmark demonstrates the need. Bit flags,
+packed values, and indices are acceptable when that evidence shows a material
+benefit. Prefer zero-cost typed abstractions when they provide the same result.
+
+Keep an exceptional representation private and narrowly contained. Named helpers
+must own its encoding and invariants. Conversion tests must prove the mapping
+between compact and domain representations. Boundary tests may exercise those
+conversions only if they cover every conversion path. Document the benchmark and
+the representation contract near the implementation. The compact form must not
+leak into public APIs.
+
+Readability and maintainability remain mandatory. A packed representation that
+readers cannot verify is not acceptable, and unrelated boolean flags do not become
+a valid optimization merely because they occupy fewer bits.
+
+## Review checklist
+
+When reviewing domain code, check for:
+
+- fields whose values can contradict each other;
+- primitive parameters that are easy to confuse or swap;
+- free-form strings where the domain has a constrained vocabulary;
+- public constructors or mutation paths that bypass invariants;
+- catch-all or default matches that hide non-exhaustive state handling;
+- performance exceptions without profiling or reproducible benchmark evidence,
+  narrow containment, named helpers, conversion tests, and a documented contract.

--- a/docs/developers/domain-modeling.md
+++ b/docs/developers/domain-modeling.md
@@ -28,7 +28,8 @@ and every allowed or rejected state transition.
 Avoid primitive obsession and stringly typed domain APIs. Two values that share
 a machine representation can still mean different things. Represent those
 distinctions with newtypes, opaque types, branded types, or validated wrappers.
-A type alias is insufficient when it leaves distinct values interchangeable.
+A type alias can document a distinction, but it is insufficient when values remain
+interchangeable and accidental interchange would violate a domain rule.
 
 Put validation in smart constructors and keep unchecked construction private.
 This makes the validated type evidence that its invariants hold. Do not wrap every

--- a/docs/user-guides/modeling-guides/modeling-finance.md
+++ b/docs/user-guides/modeling-guides/modeling-finance.md
@@ -30,7 +30,7 @@ value quantity price =
     (ToDecimal quantity) * price
 ```
 
-This bit of Elm defines a function that takes a `TradeQuantity` and `TradePrice` and calculates the `TradeValue`. This simple act is incredibly effective in avoiding misunderstandings and mistakes.
+This bit of Elm defines a function that takes a `TradeQuantity` and `TradePrice` and calculates the `TradeValue`. The aliases make the business language visible, but they do not create distinct Elm types. Use an alias when that documentation is sufficient. Use a custom type when accidentally interchanging values would violate a domain rule.
 
 ## Keeping Incompatible Concepts Separate
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2050,7 +2050,7 @@ Technical specifications including IR format and schemas
 - [Type System](https://morphir.finos.org/docs/spec/draft/types): Specification for the Morphir Type System in IR v4
 - [Value System](https://morphir.finos.org/docs/spec/draft/values): Specification for the Morphir Value System in IR v4
 - [What's New in Version 4](https://morphir.finos.org/docs/spec/draft/whats-new): Summary of changes in Morphir IR v4
-- [Specifications](https://morphir.finos.org/docs/spec/): Formal specifications for Morphir configuration and IR
+- [Specifications](https://morphir.finos.org/docs/spec/): Formal specifications for Morphir configuration, IR, and tool distribution
 - [IR Format Version Contract](https://morphir.finos.org/docs/spec/ir/format-version): Normative spelling, compatibility, diagnostics, and canonical ordering rules for Morphir IR formatVersion
 - [Morphir IR Specification](https://morphir.finos.org/docs/spec/ir/morphir-ir-specification): Complete specification of the Morphir Intermediate Representation (IR)
 - [JSON Schemas](https://morphir.finos.org/docs/spec/ir/schemas/): JSON schema definitions for Morphir IR format versions
@@ -2082,6 +2082,7 @@ Technical specifications including IR format and schemas
 - [Morphir configuration merge rules](https://morphir.finos.org/docs/spec/morphir-toml/morphir-toml-merge-rules): How Morphir merges configuration sources into an effective configuration
 - [Morphir TOML Configuration Specification](https://morphir.finos.org/docs/spec/morphir-toml/morphir-toml-specification): Formal specification for morphir.toml configuration files
 - [Morphir YAML configuration specification](https://morphir.finos.org/docs/spec/morphir-yaml/morphir-yaml-specification): Specification for morphir.yaml configuration files
+- [Tool release metadata v1](https://morphir.finos.org/docs/spec/tool-release-metadata/): This specification defines how Morphir authenticates, discovers, selects, and locks tool releases. It profiles The Update Framework 1.0.36 and adds Morphir fields to signed target metadata.
 - [WebAssembly](https://morphir.finos.org/docs/spec/webassembly/): This section collects Morphir specifications related to WebAssembly code generation, WIT input, and the Component Model.
 - [WebAssembly Backend](https://morphir.finos.org/docs/spec/webassembly/wasm-backend): This document defines the design for a Morphir backend that compiles Morphir IR to WebAssembly, with full support for the Component Model and Canonical ABI.
 - [Morphir and the WebAssembly Component Model](https://morphir.finos.org/docs/spec/webassembly/wasm-component-model): This document is a comprehensive guide to integrating Morphir with the WebAssembly Component Model ecosystem.
@@ -2199,6 +2200,7 @@ Contributing to Morphir development
 - [Decorations Implementation Summary](https://morphir.finos.org/docs/developers/decorations-implementation-summary): This document provides a summary of the decorations feature implementation in Morphir.
 - [Decorators Feature Implementation Plan](https://morphir.finos.org/docs/developers/decorators-implementation-plan): This implementation plan applies to the Go-based Morphir CLI in finos/morphir-go, not the Rust CLI in finos/morphir.
 - [Explaining Dev Bots](https://morphir.finos.org/docs/developers/dev-bots): The premise of Dev Bots is that we can and should automate a significant portion of the code that we currently write by hand.
+- [Domain modeling](https://morphir.finos.org/docs/developers/domain-modeling): Morphir code expresses domain rules in types. At public APIs, domain boundaries, and persistent state, prefer designs where invalid states cannot be represented.
 - [JVM: Executing morphir-cli](https://morphir.finos.org/docs/developers/integrating-morphir-and-jvm-projects): This document specifies all the necessary steps required to execute morphir-cli commands in a JVM project.
 - [Morphir Developers' Guide](https://morphir.finos.org/docs/developers/morphir-developers-guide): The purpose of the document is to provide a detailed explanation of how various Morphir code artefacts work. It also documents the standard coding practices adopted for the Morphir project.
 - [Publishing the Elm package](https://morphir.finos.org/docs/developers/publishing-elm-package): This document describes how maintainers can push new releases of morphir-elm into NPM and the Elm package repo.
@@ -2214,6 +2216,7 @@ Architecture Decision Records (ADRs)
 - [ADR-0004: Retire morphir-live rather than migrate it into morphir-ui](https://morphir.finos.org/docs/adr/ADR-0004-retire-morphir-live): crates/morphir-live is a Dioxus single-page app that browses workspaces, projects and models and edits morphir.toml through either a generated form or a raw TOML tab. We are retiring it.
 - [ADR-0005: Manage Morphir Desktop as a tool from Morphir Home](https://morphir.finos.org/docs/adr/ADR-0005-cli-managed-desktop): Morphir Desktop is the well-known user-launched tool desktop, not an extension. The CLI acquires, verifies, activates, updates, repairs, and launches it through the same distribution kernel used by...
 - [ADR-0006: Keep Morphir observability local by default](https://morphir.finos.org/docs/adr/ADR-0006-local-observability-by-default): Morphir CLI and Desktop enable bounded structured file logging by default beneath Morphir Home and correlate acquisition, activation, launch, and crash events with user-visible operation IDs.
+- [ADR-0007: Use TUF for tool release trust](https://morphir.finos.org/docs/adr/ADR-0007-tuf-tool-release-trust): Morphir tool repositories use The Update Framework 1.0 for publisher authentication, root rotation, metadata expiry, rollback protection, and artifact integrity.
 
 ### Community
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -12,6 +12,7 @@ analysis, optimization, and cross-platform code generation.
 
 ## Docs
 
+- [Domain modeling](https://morphir.finos.org/docs/developers/domain-modeling): Morphir code expresses domain rules in types. At public APIs, domain boundaries, and persistent state, prefer designs where invalid states cannot be represented.
 - [Morphir Web UI](https://morphir.finos.org/docs/getting-started/Morphir%20Web%20UI): This document details the purpose of the various functions of the Morphir UI, and how to use them and navigate between them.
 - [Getting Started with Morphir](https://morphir.finos.org/docs/getting-started/): Welcome! This section will help you get started with Morphir quickly.
 - [Editor Setup](https://morphir.finos.org/docs/getting-started/editor-setup): Morphir is designed to allow users to write business logic in multiple ways. That currently includes the following:


### PR DESCRIPTION
## Summary

- define a canonical ecosystem-wide domain modeling policy
- require invalid states to be unrepresentable and domain values to use distinct types
- permit measured, private compact representations without weakening public APIs

## Validation

- `mise run ci:validate-docs`
- `mise run website:build`
- `git diff --check origin/main...HEAD`

Tracks `morphir-ui-irf.9`. This PR must merge before the Morphir UI and Morphir Rust guidance PRs so their canonical links resolve.