### PR TITLE
docs: define extension repository vocabulary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,9 +82,29 @@ _Avoid_: Morphir package, loaded extension
 A runnable payload for one extension runtime and, when applicable, one operating-system and architecture target.
 _Avoid_: Extension, source package
 
-**Installed extension catalog**:
+**Extension repository**:
+A logical collection of published extension releases, repository metadata, and artifacts, independent of how clients access it.
+_Avoid_: Index, registry when no service is involved, installed extension inventory
+
+**Repository endpoint**:
+A configured location through which a Morphir client accesses one repository, such as a directory, Git checkout, HTTP URL, or OCI reference.
+_Avoid_: Repository, registry, mirror
+
+**Extension registry**:
+A network service that hosts one or more extension repositories.
+_Avoid_: Local repository, catalog, index
+
+**Extension catalog**:
+The searchable view Morphir builds from the enabled extension repositories.
+_Avoid_: Repository, registry, installed extension inventory
+
+**Repository metadata**:
+The backend-specific records used to discover and resolve releases in a repository, such as an index, TUF metadata, or OCI manifests.
+_Avoid_: Repository, catalog, installed inventory
+
+**Installed extension inventory**:
 The host's local record of verified extension distributions available for selection and activation.
-_Avoid_: Package registry, loaded-extension registry
+_Avoid_: Extension catalog, extension repository, loaded-extension registry
 
 ## Tools
 
@@ -116,9 +136,9 @@ _Avoid_: Repository mirror, TLS certificate, signing key
 The immutable record for one exact tool version, including compatibility, channel membership, and platform artifacts.
 _Avoid_: Release channel, tool artifact, installed selection
 
-**Installed tool catalog**:
+**Installed tool inventory**:
 The local record of verified tool distributions and the exact release active for each tool.
-_Avoid_: Tool registry, release index, download cache
+_Avoid_: Tool catalog, tool registry, release index, download cache
 
 **Protected release**:
 An installed tool or extension release that cleanup cannot remove because it is active, retained for rollback, pinned, leased by a running process, or referenced by another durable record.

--- a/docs/adr/ADR-0008-repository-catalog-and-inventory-language.md
+++ b/docs/adr/ADR-0008-repository-catalog-and-inventory-language.md
@@ -1,0 +1,9 @@
+---
+status: accepted
+---
+
+# ADR-0008: Distinguish repositories, registries, catalogs, and installed inventory
+
+Morphir calls a logical collection of published releases, metadata, and artifacts a **repository**. A configured access location is a **repository endpoint**, a network service that hosts repositories is a **registry**, and the searchable view over enabled repositories is a **catalog**. Morphir Home's durable record of installed releases and active selections is an **installed inventory**. An index is one possible repository-metadata format, alongside TUF metadata and OCI manifests, rather than the public name for a repository or installed state.
+
+This language follows the boundaries used by TUF and OCI while retaining the narrower Cargo and Helm meaning of an index as metadata within a repository. It also lets a local directory and a hosted service implement the same repository contract without calling the directory a registry. Existing `--index`, `LocalIndex`, `InstalledCatalog`, and `catalog/` names remain compatibility details until their owning implementation migrates them. New user-facing commands use `repository`, discovery uses `catalog` or `search`, and installed-state output uses `inventory`.

--- a/docs/design/draft/extensions/distribution-and-acquisition.md
+++ b/docs/design/draft/extensions/distribution-and-acquisition.md
@@ -4,7 +4,8 @@ sidebar_label: Distribution and acquisition
 sidebar_position: 3
 status: draft
 tracking:
-  beads: [morphir-ct7h, morphir-h0pf, morphir-uhk3]
+  beads: [morphir-ct7h, morphir-h0pf, morphir-uhk3, morphir-ds9e.9]
+  github_issues: [761]
 ---
 
 # Extension distribution and package acquisition
@@ -46,7 +47,7 @@ The useful lessons are:
 3. Resolve the complete graph before acquiring content.
 4. Verify cached and downloaded bytes before materialization.
 5. Validate the materialized manifest against the selected identity.
-6. Pin the registry-index revision as well as package versions and digests.
+6. Pin the repository-metadata revision as well as package versions and digests.
 7. Treat local workspace replacements as policy over a stable identity, not as publishable dependencies.
 
 ## Shared distribution kernel
@@ -63,7 +64,7 @@ A common distribution kernel should provide pure value types and effects for:
 - content-addressed storage under `MorphirHome`;
 - offline and mirror-aware lookup.
 
-Interpreters provide network, Git, filesystem, credential, archive, and cache behavior. Buildkit, frontends, and the extension host consume resolved or materialized values and do not depend on registry URLs, cache layouts, or credentials.
+Interpreters provide network, Git, filesystem, credential, archive, and cache behavior. Buildkit, frontends, and the extension host consume resolved or materialized values and do not depend on repository endpoints, cache layouts, or credentials.
 
 Package and extension policy remains above this shared kernel:
 
@@ -71,11 +72,11 @@ Package and extension policy remains above this shared kernel:
 - the extension resolver understands capabilities, MEP versions, permissions, runtime kinds, operating systems, architectures, launch arguments, and daemon endpoints;
 - each family validates its own manifest after materialization.
 
-## Registry architecture
+## Repository architecture
 
-The first distributed registry backend should be service-free and mirrorable. A Git-backed index is a good launch option when paired with a local-directory backend for tests and air-gapped use.
+The first distributed repository backend should be service-free and mirrorable. A Git-backed repository is a good launch option when paired with a local-directory backend for development, tests, and air-gapped use.
 
-The index should partition histories by a canonical, filesystem-portable encoding of package identity. Each version record should contain only what resolution needs:
+Repository metadata should partition histories by a canonical, filesystem-portable encoding of package identity. Each version record should contain only what resolution needs:
 
 - exact identity and version;
 - dependency requirements when the package family supports dependencies;
@@ -86,38 +87,40 @@ The index should partition histories by a canonical, filesystem-portable encodin
 
 Presentation fields such as descriptions, licenses, documentation, maintainers, and search keywords may extend the record without becoming inputs to dependency resolution.
 
-The client pins the Git commit used for resolution. A future HTTP registry may expose the same logical operations, but reproducibility must not depend on a mutable `latest` response. Mirrors may provide the same identity and digest from a different location.
+The client pins the Git commit or metadata revision used for resolution. A future registry may expose the same logical operations over HTTP, but reproducibility must not depend on a mutable `latest` response. Multiple endpoints may provide the same repository identity and digest.
 
-### Index and repository topology
+### Repository and catalog topology
 
-Morphir packages and extension distributions use separate logical registry indexes. Each index has its own record schema, validation rules, version history, and resolution policy. A model-package index cannot contain extension records, and an extension index cannot contain model-package records.
+Morphir packages and extension distributions use separate logical repositories. Each repository has its own metadata schema, validation rules, version history, and resolution policy. A model-package repository cannot contain extension records, and an extension repository cannot contain model-package records.
 
-Both indexes implement the same client capability for version discovery, exact-record lookup, provenance, and mirroring. That shared capability does not erase the different record types.
+Both repository kinds implement the same client capability for version discovery, exact-record lookup, provenance, and mirroring. That shared capability does not erase the different record types.
 
-An index is a metadata view, not a Git repository. The Git-file backend may store both indexes in one repository under separate roots, for example `model-packages/` and `extensions/`. Deployments may also place them in separate repositories or expose them through different services. Repository layout is a backend and operational choice. It does not change the logical index boundary.
+A repository is a logical collection, not a directory, Git checkout, or service. Those are repository endpoints. One Git repository may host package and extension repository metadata under separate roots, for example `model-packages/` and `extensions/`. Deployments may also place them at separate endpoints or expose them through different registries. Endpoint layout is a backend and operational choice. It does not change the logical repository boundary.
 
-When one Git repository contains both indexes, a lock records the index kind, logical index identity, repository source, root path, and pinned commit. This prevents the shared repository from making an index reference ambiguous.
+The catalog is a searchable view over enabled repositories. It may merge results, but every result retains its repository identity and endpoint provenance. The catalog is neither the publication authority nor the installed-state record.
+
+When one endpoint contains both repository kinds, a lock records the repository kind, logical repository identity, endpoint, root path, and pinned metadata revision. This prevents the shared endpoint from making a repository reference ambiguous.
 
 ### Release channels
 
-Each index supports release channels as mutable version-selection policy. The first channel model includes:
+Each repository supports release channels as mutable version-selection policy. The first channel model includes:
 
 - `stable` for versions intended for general use;
 - `preview` for pre-release testing, also exposed as `insiders` by products that already use that name;
 - optional segmented preview channels such as `preview/<segment>` for a bounded prototype, compatibility test, or staged rollout.
 
-A segmented preview channel remains part of the same logical index. It does not create a new package identity, extension identity, or registry index. Index policy defines valid segment names, who may publish to them, and whether they inherit candidates from the general preview channel.
+A segmented preview channel remains part of the same logical repository. It does not create a new package identity, extension identity, or repository. Repository policy defines valid segment names, who may publish to them, and whether they inherit candidates from the general preview channel.
 
-A channel request resolves to an exact version before acquisition. The lock records the requested channel, exact selected identity and version, index revision, source, and digest. Reusing the lock never follows a moving channel. Refreshing or changing channels is an explicit resolution operation.
+A channel request resolves to an exact version before acquisition. The lock records the requested channel, exact selected identity and version, repository identity, metadata revision, source, and digest. Reusing the lock never follows a moving channel. Refreshing or changing channels is an explicit resolution operation.
 
-Stable resolution excludes preview versions unless the request or workspace policy opts into them. Promotion changes channel eligibility. It does not let a registry replace locked bytes for an existing exact identity and digest.
+Stable resolution excludes preview versions unless the request or workspace policy opts into them. Promotion changes channel eligibility. It does not let a repository replace locked bytes for an existing exact identity and digest.
 
 ## Morphir package flow
 
 ```mermaid
 flowchart LR
-    Requirement[Package requirement] --> Index[Registry index]
-    Index --> Resolve[Resolve graph]
+    Requirement[Package requirement] --> Repository[Package repository]
+    Repository --> Resolve[Resolve graph]
     Resolve --> Lock[Write or verify lock]
     Lock --> Acquire[Acquire sources]
     Acquire --> Verify[Verify and materialize]
@@ -132,20 +135,20 @@ Compilation receives a prepared source view and runs without package-network acc
 
 ```mermaid
 flowchart LR
-    Request[Capability request] --> Catalog[Installed extension catalog]
-    Catalog --> Resolver[Select distribution and artifact]
-    Resolver --> Acquire[Acquire if explicitly requested]
-    Acquire --> Verify[Verify and install]
-    Verify --> Runtime[Select runtime adapter]
+    Selection[Install selection] --> Repository[Extension repository]
+    Repository --> Verify[Resolve, verify, and install]
+    Verify --> Inventory[Installed extension inventory]
+    Request[Capability request] --> Inventory
+    Inventory --> Runtime[Select runtime adapter]
     Runtime --> MEP[Open MEP session]
 ```
 
-The installed extension catalog is local state, not the distributed registry.
+The installed extension inventory is local state, not a repository or catalog.
 It records the extension ID, name, version, runtime, platform, arguments,
 artifact digest, content-addressed store path, capabilities, MEP versions,
-index provenance, backend metadata, and executable mode. The matching lock also
-records the requested selection and artifact source; the catalog does not. The
-host uses the catalog and lock together to select an artifact and runtime
+repository provenance, backend metadata, and executable mode. The matching lock also
+records the requested selection and artifact source; the inventory does not. The
+host uses the inventory and lock together to select an artifact and runtime
 without contacting a registry during normal execution.
 
 An extension manifest needs:
@@ -174,8 +177,8 @@ it without changing an extension record or the MEP methods.
 
 Installation verifies the selected artifact's SHA-256 before publishing it to
 the content-addressed store. It then records the exact artifact in both the
-catalog and lock. Backend records also lock target IDs and supported Morphir IR
-versions. Normal activation is offline. It loads one catalog and lock snapshot,
+inventory and lock. Backend records also lock target IDs and supported Morphir IR
+versions. Normal activation is offline. It loads one inventory and lock snapshot,
 checks that they agree, canonicalizes the stored artifact under Morphir home,
 rehashes it, and verifies its runtime-specific mode before starting a session.
 
@@ -183,7 +186,7 @@ The MEP handshake is a second check, not a replacement for the lock:
 
 | Stage | Compared values | Result on mismatch |
 |---|---|---|
-| Catalog against lock | Extension ID, name, version, runtime, platform, arguments, digest, capabilities, MEP versions, index provenance, complete backend metadata, and executable mode | Activation stops before guest code runs. |
+| Inventory against lock | Extension ID, name, version, runtime, platform, arguments, digest, capabilities, MEP versions, repository provenance, complete backend metadata, and executable mode | Activation stops before guest code runs. |
 | Installed record against initialization | Extension ID, name, version, capability kinds, and the complete backend capability, including targets, IR versions, and `generate` | The host rejects initialization and does not call the backend. |
 | Requested operation against negotiated capability | Target ID, input IR version, and `generate` support | The host does not send `morphir.backend.generate`. |
 
@@ -211,12 +214,12 @@ The existing `morphir server` command becomes an extension daemon only if it imp
 
 - Normal compilation and generation do not download missing extensions without an explicit install policy.
 - Checksums provide integrity, not publisher authenticity. Signature or provenance verification remains an open policy decision.
-- Registry and Git credentials use protected secret references and never enter identities, locks, manifests, transcripts, or diagnostics.
+- Registry and repository credentials use protected secret references and never enter identities, locks, manifests, transcripts, or diagnostics.
 - Installation uses staging and atomic publication so readers never observe partial content.
 - Archives must reject path traversal, unsafe links, device files, and platform path collisions.
 - Native processes inherit a filtered environment and explicit working directory.
 - Daemon connections require a transport-specific identity, authentication, timeout, and ownership policy.
-- Locks retain the exact registry snapshot, selected records, sources, digests, and transitive package graph.
+- Locks retain the exact repository-metadata snapshot, selected records, sources, digests, and transitive package graph.
 
 ## Current host and guest split
 
@@ -236,13 +239,13 @@ independently built artifact through the production host boundary.
 3. Which version and range rules apply to Morphir-native packages and extensions?
 4. Which signature or build-provenance policy establishes publisher authenticity?
 5. How does a host distinguish a daemon it owns from an endpoint it only connects to?
-6. Which yank and revocation behavior must work before the first public registry?
+6. Which yank and revocation behavior must work before the first public repository?
 
 ## Non-goals
 
 - Copy MoonBit's index schema, resolver, or AGPL implementation.
-- Make MEP responsible for installation or registry storage.
+- Make MEP responsible for installation or repository storage.
 - Treat a Morphir package as an executable extension.
-- Require a network service for the first registry backend.
+- Require a network service for the first repository backend.
 - Let compiler or runtime cache layouts become public package contracts.
 - Infer trust from a checksum alone.

--- a/docs/design/draft/extensions/protocol.md
+++ b/docs/design/draft/extensions/protocol.md
@@ -37,11 +37,11 @@ MEP must support:
 - local native processes first, without ruling out WASM or remote execution;
 - a one-file Elm compilation path that does not require a Morphir project.
 
-MEP does not define extension installation, registry storage, daemon discovery, or Morphir IR itself. Those systems use the protocol but have separate formats and lifecycles.
+MEP does not define extension installation, repository storage, daemon discovery, or Morphir IR itself. Those systems use the protocol but have separate formats and lifecycles.
 
 The adjacent [extension distribution and package acquisition design](./distribution-and-acquisition.md) defines how a host resolves, acquires, verifies, installs, and selects extension artifacts. It also records the shared distribution machinery and separate semantics for reusable Morphir model packages.
 
-The Rust host stores its user-global extension registry under `MorphirHome`. Host implementations must use that resolver instead of hardcoding a user-home path, so `MORPHIR_HOME` relocates extension state along with other Morphir state. This changes discovery and installation behavior, not the MEP wire contract.
+The Rust host stores its user-global installed extension inventory under `MorphirHome`. Host implementations must use that resolver instead of hardcoding a user-home path, so `MORPHIR_HOME` relocates extension state along with other Morphir state. This changes discovery and installation behavior, not the MEP wire contract.
 
 ## Roles
 
@@ -573,7 +573,7 @@ Acceptance criteria:
 - unit tests use a fixture extension rather than Morphir Elm;
 - process crashes and malformed frames produce typed host errors;
 - timeouts do not leave child processes running;
-- the registry can select a native extension by language capability.
+- the host can select a native extension from the installed inventory by language capability.
 
 ### Phase 3: connect `morphir compile` to the Elm extension
 
@@ -663,7 +663,7 @@ The implementation should resolve these mismatches rather than preserve them:
 - design documents use names such as `compile/snippet` and `extension/capabilities`, while the Rust SDK uses `morphir.frontend.compile` and `morphir.extension.capabilities`;
 - SDK compile types carry source content, while the current CLI call carries input paths and a list of file paths;
 - SDK source locations are one-based, while editor protocols use zero-based ranges;
-- the current Rust extension registry loads only `.wasm` files despite documentation for native executables;
+- the current Rust extension loader loads only `.wasm` files despite documentation for native executables;
 - the current CLI requires project configuration even though the daemon design documents ad hoc compilation;
 - extension information and capability types are duplicated between the SDK and daemon.
 

--- a/docs/design/proposals/desktop-acquisition-and-launch.md
+++ b/docs/design/proposals/desktop-acquisition-and-launch.md
@@ -36,7 +36,7 @@ This design follows [ADR-0005](../../adr/ADR-0005-cli-managed-desktop.md) and [A
 | Extension | A host-launched capability provider | `morphir extension` |
 | Morphir package | Reusable modeled logic and types | Package commands and build resolution |
 
-The distribution kernel may share value types and effects across these families. Their manifests, catalogs, lifecycle rules, and user-facing commands remain distinct.
+The distribution kernel may share value types and effects across these families. Their manifests, installed inventories, lifecycle rules, and user-facing commands remain distinct.
 
 `component` is an architectural umbrella term and is not a CLI installation noun.
 
@@ -50,9 +50,9 @@ morphir desktop --offline [PATH]
 morphir desktop --wait [PATH]
 ```
 
-`morphir desktop` resolves the active `desktop` tool from the installed tool catalog. If none exists, it installs the default selection and then launches it. Invoking the named application is sufficient consent for this first-use acquisition, so the command reports the download without asking an additional question.
+`morphir desktop` resolves the active `desktop` tool from the installed tool inventory. If none exists, it installs the default selection and then launches it. Invoking the named application is sufficient consent for this first-use acquisition, so the command reports the download without asking an additional question.
 
-`--offline` prohibits registry and artifact network access. It launches a valid active release or fails with a diagnostic that includes the exact installation command to run when network access is available.
+`--offline` prohibits network access to repository endpoints and artifacts. It launches a valid active release or fails with a diagnostic that includes the exact installation command to run when network access is available.
 
 The optional path identifies the workspace or artifact to open. The default is the current directory. The CLI launches Desktop detached by default and returns after successful process creation. `--wait` keeps the CLI in the foreground and returns the Desktop process exit status.
 
@@ -107,7 +107,7 @@ Selection follows this precedence for a first installation:
 
 Project configuration does not silently select a different globally installed Desktop. A future project tool manifest may request local tools through an explicit restore operation, but it does not change the active global Desktop as a side effect of entering a directory.
 
-The catalog records both:
+The installed inventory records both:
 
 - requested selection, such as `channel stable` or `version 0.3.1`;
 - resolved release, including exact version, platform, source provenance, metadata revision, artifact digest, and launch description.
@@ -125,7 +125,7 @@ MORPHIR_HOME/
     desktop/
   config/
     desktop/
-  catalog/
+  catalog/ # Legacy on-disk schema name; the domain term is installed inventory.
     tools.json
     extensions.json
   store/
@@ -146,12 +146,12 @@ The root is one location, not one shared mutable file:
 
 - user-authored policy belongs in configuration;
 - durable application state belongs in a namespaced data directory;
-- active installation state belongs in versioned catalogs;
+- active installation state belongs in versioned inventories;
 - verified immutable content belongs in the content-addressed store;
 - disposable content belongs in cache;
 - coordination files belong in locks and temporary staging belongs in `tmp`.
 
-Each catalog and owned application file carries its own schema version. Components do not require one global home schema upgrade and must not write files owned by another component. The distribution kernel is the only writer for tool and extension catalogs and stores.
+Each inventory and owned application file carries its own schema version. Components do not require one global home schema upgrade and must not write files owned by another component. The distribution kernel is the only writer for tool and extension inventories and stores.
 
 The CLI passes the fully resolved absolute `MORPHIR_HOME` value to Desktop on every launch. This prevents the child process from deriving a different root through environment, symlink, profile, or platform differences.
 
@@ -169,7 +169,7 @@ During a compatibility period, Morphir may read one legacy platform global-user 
 
 The current metadata-only `tools.json` entries do not prove that a runnable artifact exists. Migration follows these rules:
 
-- A verified catalog entry is an installed tool.
+- A verified inventory entry is an installed tool.
 - A legacy entry with no artifact digest and launch description is imported only as historical intent.
 - List output labels such an entry as incomplete rather than installed.
 - Update or repair may turn the intent into a verified installation.
@@ -179,7 +179,7 @@ The current metadata-only `tools.json` entries do not prove that a runnable arti
 
 One tool installation or update runs under a per-tool interprocess lock:
 
-1. Read and validate the installed catalog.
+1. Read and validate the installed inventory.
 2. Resolve the requested selection for the current operating system and architecture.
 3. Check compatibility with the invoking CLI and supported Desktop launch contract.
 4. Acquire metadata and artifact bytes into secure staging beneath Morphir Home.
@@ -187,16 +187,16 @@ One tool installation or update runs under a per-tool interprocess lock:
 6. Extract portable archives while rejecting traversal, unsafe links, device files, and platform path collisions.
 7. Run the packaged application's non-interactive probe.
 8. Atomically publish immutable content into the verified store.
-9. Atomically replace the active catalog entry.
+9. Atomically replace the active inventory entry.
 10. Retain the previously active release for rollback and later garbage collection.
 
-A failure before step 9 leaves the previous catalog untouched. A failure while replacing the catalog restores or retains the previous complete file. Readers never observe a partially extracted release or partially written catalog.
+A failure before step 9 leaves the previous inventory untouched. A failure while replacing the inventory restores or retains the previous complete file. Readers never observe a partially extracted release or partially written inventory.
 
-Uninstall removes active catalog and selection state. Content-addressed bytes may remain until an explicit garbage-collection policy proves that no catalog or running release needs them.
+Uninstall removes active inventory and selection state. Content-addressed bytes may remain until an explicit garbage-collection policy proves that no inventory or running release needs them.
 
 ## Storage maintenance
 
-Morphir separates disposable cache cleanup from installed-artifact pruning. A cache entry is re-creatable content under `cache/`. A verified release under `store/` is installed state even when it is not active. `cache clean` never removes verified releases, and `tool prune` never treats an active catalog entry as disposable.
+Morphir separates disposable cache cleanup from installed-artifact pruning. A cache entry is re-creatable content under `cache/`. A verified release under `store/` is installed state even when it is not active. `cache clean` never removes verified releases, and `tool prune` never treats an active inventory entry as disposable.
 
 ### Manual commands
 
@@ -212,7 +212,7 @@ morphir tool prune [<NAME>] [--dry-run] [--keep <COUNT>] [--older-than <DURATION
 
 `tool prune` removes verified releases only when the maintenance engine proves they are unreachable. It protects:
 
-- every active catalog release;
+- every active inventory release;
 - the configured rollback releases;
 - exact versions pinned by durable configuration or selection state;
 - releases leased by running CLI, Desktop, or extension processes;
@@ -255,11 +255,11 @@ Deletion first renames an eligible entry into a maintenance trash directory bene
 
 Cleanup emits structured events for policy evaluation, reclaimed bytes, skipped protected entries, failures, and elapsed time. Manual and automatic runs receive operation IDs. Troubleshooting output points to the CLI log and names the cache namespace without logging cached content or source credentials.
 
-## Registry and trust
+## Repository and trust
 
-The first remote tool repository exposes immutable release descriptors plus mutable channel membership through the [tool release metadata v1 profile](../../spec/tool-release-metadata/index.md). A channel resolves to an exact descriptor before download. The installed catalog retains the exact trusted metadata version used for that resolution.
+The first remote tool repository exposes immutable release descriptors plus mutable channel membership through the [tool release metadata v1 profile](../../spec/tool-release-metadata/index.md). A channel resolves to an exact descriptor before download. The installed inventory retains the exact trusted metadata version used for that resolution.
 
-Artifact digests detect corruption only when the metadata carrying the digest is authentic. Public Desktop acquisition uses The Update Framework 1.0 with an out-of-band trusted root, consistent snapshots, sequential dual-threshold root rotation, signed freshness metadata, and SHA-256 target hashes. Mirrors share one repository identity and trust root. HTTPS remains required but is not the publisher-authentication mechanism. New resolution rejects expired metadata, while an installed release continues to launch from its exact catalog lock unless the client has persisted a trusted revocation.
+Artifact digests detect corruption only when the metadata carrying the digest is authentic. Public Desktop acquisition uses The Update Framework 1.0 with an out-of-band trusted root, consistent snapshots, sequential dual-threshold root rotation, signed freshness metadata, and SHA-256 target hashes. Mirrors share one repository identity and trust root. HTTPS remains required but is not the publisher-authentication mechanism. New resolution rejects expired metadata, while an installed release continues to launch from its exact inventory lock unless the client has persisted a trusted revocation.
 
 Network access supports bounded timeouts, proxies, standard certificate stores, resumable downloads where the server permits them, and useful diagnostics. Cached metadata and bytes are verified before reuse.
 
@@ -281,7 +281,7 @@ Windows executables and installers require code signing. The macOS application r
 
 ## Launch contract
 
-The CLI invokes the catalog's exact entry point directly without shell interpolation. It supplies:
+The CLI invokes the installed inventory's exact entry point directly without shell interpolation. It supplies:
 
 - the resolved absolute `MORPHIR_HOME`;
 - the requested workspace or artifact path;
@@ -380,8 +380,8 @@ artifact.download
 artifact.verify
 artifact.extract
 tool.probe
-catalog.activate
-catalog.rollback
+inventory.activate
+inventory.rollback
 desktop.spawn
 desktop.ready
 desktop.exit
@@ -421,7 +421,7 @@ Tests inject recognizable secret sentinels through every credential and configur
 - crash metadata and dumps associated with that operation when present;
 - CLI, Desktop, operating-system, architecture, and launch-contract versions;
 - sanitized effective acquisition policy and release source identities;
-- installed catalog metadata and integrity status;
+- installed inventory metadata and integrity status;
 - Morphir Home path and permission checks with the user-home prefix normalized;
 - a bundle manifest listing included files, exclusions, and checksums.
 
@@ -439,7 +439,7 @@ External metrics or trace export is opt-in. Enabling an exporter requires an exp
 | Digest mismatch | Quarantine or remove staged bytes; keep active release |
 | Archive escapes staging | Reject release; keep active release |
 | Probe fails | Do not activate candidate |
-| Concurrent install and launch | Launch old active release or wait for a complete catalog transaction |
+| Concurrent install and launch | Launch old active release or wait for a complete inventory transaction |
 | Concurrent updates | Serialize by tool identity |
 | Active bytes modified | Refuse launch and suggest `tool repair desktop` |
 | New Desktop requires newer CLI | Select the newest compatible release or explain the CLI upgrade requirement |
@@ -456,7 +456,7 @@ External metrics or trace export is opt-in. Enabling an exporter requires an exp
 ## Delivery sequence
 
 1. Make Morphir Home the unconditional root for cache and global configuration, then add cross-language conformance fixtures for path resolution and ownership.
-2. Extract generic selection, authenticated acquisition, content-addressed storage, locking, and atomic catalog operations from the extension-specific implementation.
+2. Extract generic selection, authenticated acquisition, content-addressed storage, locking, and atomic inventory operations from the extension-specific implementation.
 3. Define tool release records for archives, launch entry points, probes, and CLI compatibility.
 4. Replace the metadata-only tool commands and migrate legacy `tools.json` intent safely.
 5. Publish signed portable Desktop release artifacts for every supported platform.

--- a/docs/spec/tool-release-metadata/index.md
+++ b/docs/spec/tool-release-metadata/index.md
@@ -24,7 +24,7 @@ The CLI receives its first trusted root through an out-of-band path:
 
 The repository identity is the lowercase SHA-256 digest of the canonical JSON encoding of the initial root's `signed` object. Root signatures do not affect identity because they can be added or reordered without changing the trusted keys and roles. Moving between mirrors preserves this identity. Replacing the initial root changes the repository identity and requires explicit trust bootstrap.
 
-Trusted root state is durable security data beneath Morphir Home. Cached timestamp, snapshot, targets, release descriptors, and artifact bytes are disposable copies. Cache cleanup must never remove the current trusted root or the installed catalog's exact release locks.
+Trusted root state is durable security data beneath Morphir Home. Cached timestamp, snapshot, targets, release descriptors, and artifact bytes are disposable copies. Cache cleanup must never remove the current trusted root or the installed inventory's exact release locks.
 
 ## TUF profile
 
@@ -121,7 +121,7 @@ Revocation is monotonic for a repository metadata history. A later targets versi
 
 Publishers change channel membership and release status only in a later signed targets version. A `yanked` or `revoked` release has no channel memberships in current targets metadata.
 
-When a refresh learns that an installed release is revoked, the catalog records the trusted targets version and revocation reason before reporting the failure. Offline launch then enforces the known revocation without consulting a mirror.
+When a refresh learns that an installed release is revoked, the inventory records the trusted targets version and revocation reason before reporting the failure. Offline launch then enforces the known revocation without consulting a mirror.
 
 ## Channel and exact-version resolution
 
@@ -162,7 +162,7 @@ Proxy, TLS, timeout, and authentication behavior belongs to transport configurat
 
 | Operation | Offline behavior |
 | --- | --- |
-| Launch an installed active release | Use the catalog lock and reverify installed bytes. Do not read repository metadata. |
+| Launch an installed active release | Use the installed inventory lock and reverify installed bytes. Do not read repository metadata. |
 | Repair an installed release | Use a verified content-addressed object when present. Otherwise report that network access is required. |
 | Resolve a moving channel | Use cached metadata only when the complete set is unexpired. |
 | Install an exact release not already locked | Require unexpired cached metadata and cached verified target bytes. |


### PR DESCRIPTION
## Summary

- define repository, repository endpoint, registry, catalog, repository metadata, and installed inventory
- record the naming boundary in ADR-0008
- align the extension distribution and Desktop acquisition designs
- preserve current --index, LocalIndex, InstalledCatalog, and catalog/ names as compatibility details for later implementation work

Related to #761.

## Validation

- git diff --check
- cargo fmt --all --check
- generated schema formatting check
- Docusaurus compiled the documentation locally, then the Windows build failed on the existing prism-gleam module-resolution problem tracked as Beads issue morphir-i40i
