### PR TITLE
ci: parallelize CLI docs and speed up Rust/Scala builds

### DIFF
--- a/.github/actions/cache-scala-native-image/action.yml
+++ b/.github/actions/cache-scala-native-image/action.yml
@@ -1,0 +1,30 @@
+name: Cache Scala native image
+description: >-
+  Restore and save the Mill output directory for the Morphir Scala Elm process
+  extension native image, keyed by the pinned submodule SHA.
+inputs:
+  submodule-path:
+    description: Path to the morphir-scala git submodule.
+    required: false
+    default: ecosystem/morphir-scala
+  graalvm-version:
+    description: GraalVM major version used to build the native image.
+    required: false
+    default: "25"
+runs:
+  using: composite
+  steps:
+    - name: Resolve morphir-scala submodule SHA
+      id: scala-submodule
+      shell: bash
+      run: |
+        sha=$(git rev-parse "HEAD:${{ inputs.submodule-path }}")
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Scala native image build output
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.submodule-path }}/out
+        key: morphir-scala-native-${{ inputs.graalvm-version }}-${{ steps.scala-submodule.outputs.sha }}
+        restore-keys: |
+          morphir-scala-native-${{ inputs.graalvm-version }}-

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: Install the mold linker (Linux only).
     required: false
     default: "true"
+  enable-sccache:
+    description: Enable sccache compiler caching.
+    required: false
+    default: "true"
   shared-key:
     description: Shared rust-cache namespace across jobs.
     required: false
@@ -15,7 +19,15 @@ runs:
   using: composite
   steps:
     - name: Run sccache
+      if: inputs.enable-sccache == 'true'
       uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Configure sccache
+      if: inputs.enable-sccache == 'true'
+      shell: bash
+      run: |
+        echo 'SCCACHE_GHA_ENABLED=true' >> "$GITHUB_ENV"
+        echo 'RUSTC_WRAPPER=sccache' >> "$GITHUB_ENV"
 
     - name: Install mold linker
       if: inputs.install-mold == 'true'

--- a/.github/actions/setup-rust-ci/action.yml
+++ b/.github/actions/setup-rust-ci/action.yml
@@ -1,0 +1,35 @@
+name: Set up Rust CI
+description: >-
+  Configure sccache, optional mold, and the shared Morphir cargo cache for CI
+  Rust jobs.
+inputs:
+  install-mold:
+    description: Install the mold linker (Linux only).
+    required: false
+    default: "true"
+  shared-key:
+    description: Shared rust-cache namespace across jobs.
+    required: false
+    default: morphir-rust
+runs:
+  using: composite
+  steps:
+    - name: Run sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Install mold linker
+      if: inputs.install-mold == 'true'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mold
+        echo 'RUSTFLAGS=-C link-arg=-fuse-ld=mold' >> "$GITHUB_ENV"
+
+    - name: Cache cargo
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: ". -> target"
+        shared-key: ${{ inputs.shared-key }}
+        add-job-id-key: false
+        cache-on-failure: true
+        save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
 
 jobs:
   # Detect what files changed to enable fast-path for docs-only changes
@@ -62,6 +64,8 @@ jobs:
               # asserts every workspace package follows the current Rust baseline
               - 'tests/rust/test_workspace_rust_baseline.py'
               - '.github/workflows/ci.yml'
+              - '.github/actions/setup-rust-ci/**'
+              - '.github/actions/cache-scala-native-image/**'
             docs:
               - 'website/**'
               - 'docs/**'
@@ -76,6 +80,7 @@ jobs:
               - 'crates/morphir/Cargo.toml'
               - 'tests/ci/test_release_workflow.py'
               - 'tests/ci/test_scala_extension_workflow.py'
+              - 'tests/ci/test_ci_rust_optimizations.py'
               - 'tests/ci/test_select_release_assets.py'
               - '.github/scripts/select_release_assets.py'
               - '.github/workflows/ci.yml'
@@ -99,11 +104,8 @@ jobs:
       - name: Add Rust components
         run: rustup component add rustfmt clippy
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
-          key: morphir-lint
+      - name: Set up Rust CI
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Check formatting
         run: cargo fmt --package morphir --package integration-tests --check
@@ -181,6 +183,9 @@ jobs:
 
       - name: Cache Scala dependencies
         uses: coursier/cache-action@v8
+
+      - name: Cache Scala native image
+        uses: ./.github/actions/cache-scala-native-image
 
       - name: Build Morphir Scala Elm process extension
         working-directory: ecosystem/morphir-scala
@@ -270,11 +275,8 @@ jobs:
             echo "Restored Scala version: $ver from $VER_FILE"
           fi
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
-          key: morphir-cli-test
+      - name: Set up Rust CI
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Run tests
         run: cargo test --locked --package morphir
@@ -307,6 +309,26 @@ jobs:
       - name: Run CLI integration tests
         # integration-tests finds the CLI binary in target/release/morphir
         run: cargo test --locked --package integration-tests
+
+  # Generate and diff-check CLI reference docs — parallel with extension builds
+  # and integration tests (only needs a debug morphir build, not extensions).
+  check-cli-docs:
+    name: Check CLI docs
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install mise
+        uses: jdx/mise-action@v4
+
+      - name: Initialize environment
+        run: mise run init -- --ci
+
+      - name: Set up Rust CI
+        uses: ./.github/actions/setup-rust-ci
 
       - name: Generate CLI docs
         run: mise run docs:cli
@@ -352,7 +374,7 @@ jobs:
   check:
     name: All Checks
     runs-on: ubuntu-latest
-    needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, docs, release-workflow]
+    needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, check-cli-docs, docs, release-workflow]
     if: always()
     steps:
       - name: Check results
@@ -373,6 +395,10 @@ jobs:
             fi
             if [[ "${{ needs.morphir-cli-test.result }}" != "success" ]]; then
               echo "morphir-cli-test failed (result: ${{ needs.morphir-cli-test.result }})"
+              exit 1
+            fi
+            if [[ "${{ needs.check-cli-docs.result }}" != "success" ]]; then
+              echo "check-cli-docs failed (result: ${{ needs.check-cli-docs.result }})"
               exit 1
             fi
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
 
 jobs:
   release-info:
@@ -89,6 +87,7 @@ jobs:
         uses: ./.github/actions/setup-rust-ci
         with:
           install-mold: ${{ runner.os == 'Linux' }}
+          enable-sccache: ${{ runner.arch != 'ARM64' }}
           shared-key: morphir-release-${{ matrix.target }}
 
       - name: Build CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
 
 jobs:
   release-info:
@@ -83,10 +85,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+      - name: Set up Rust CI
+        uses: ./.github/actions/setup-rust-ci
         with:
-          key: morphir-cli-${{ matrix.target }}
+          install-mold: ${{ runner.os == 'Linux' }}
+          shared-key: morphir-release-${{ matrix.target }}
 
       - name: Build CLI
         run: cargo build --locked --release --package morphir --target ${{ matrix.target }}

--- a/tests/ci/test_ci_rust_optimizations.py
+++ b/tests/ci/test_ci_rust_optimizations.py
@@ -1,0 +1,68 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+RELEASE_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
+SETUP_RUST_CI_ACTION = REPO_ROOT / ".github" / "actions" / "setup-rust-ci" / "action.yml"
+CACHE_SCALA_NATIVE_IMAGE_ACTION = (
+    REPO_ROOT / ".github" / "actions" / "cache-scala-native-image" / "action.yml"
+)
+
+
+class CiRustOptimizationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.ci_workflow = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.release_workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.setup_rust_ci_action = SETUP_RUST_CI_ACTION.read_text(encoding="utf-8")
+        cls.cache_scala_native_image_action = CACHE_SCALA_NATIVE_IMAGE_ACTION.read_text(
+            encoding="utf-8"
+        )
+        cls.scala_build_job = cls.ci_workflow.split(
+            "  build-scala-extension:\n", maxsplit=1
+        )[1].split("  morphir-cli-test:\n", maxsplit=1)[0]
+
+    def test_ci_enables_sccache(self) -> None:
+        self.assertIn('SCCACHE_GHA_ENABLED: "true"', self.ci_workflow)
+        self.assertIn("RUSTC_WRAPPER: sccache", self.ci_workflow)
+
+    def test_rust_jobs_use_shared_setup_action(self) -> None:
+        self.assertEqual(
+            self.ci_workflow.count("uses: ./.github/actions/setup-rust-ci"),
+            3,
+        )
+
+    def test_setup_rust_ci_action_shares_cargo_cache(self) -> None:
+        self.assertIn("mozilla-actions/sccache-action@v0.0.10", self.setup_rust_ci_action)
+        self.assertIn("shared-key: ${{ inputs.shared-key }}", self.setup_rust_ci_action)
+        self.assertIn("add-job-id-key: false", self.setup_rust_ci_action)
+        self.assertIn("cache-on-failure: true", self.setup_rust_ci_action)
+        self.assertIn("default: morphir-rust", self.setup_rust_ci_action)
+        self.assertIn("link-arg=-fuse-ld=mold", self.setup_rust_ci_action)
+
+    def test_scala_build_caches_native_image_output(self) -> None:
+        self.assertIn(
+            "uses: ./.github/actions/cache-scala-native-image", self.scala_build_job
+        )
+        self.assertIn("git rev-parse", self.cache_scala_native_image_action)
+        self.assertIn("/out", self.cache_scala_native_image_action)
+
+    def test_release_package_job_uses_shared_rust_setup(self) -> None:
+        package_job = self.release_workflow.split("  package-cli:\n", maxsplit=1)[1].split(
+            "  publish-release:\n", maxsplit=1
+        )[0]
+        self.assertIn("uses: ./.github/actions/setup-rust-ci", package_job)
+        self.assertIn(
+            "install-mold: ${{ runner.os == 'Linux' }}",
+            package_job,
+        )
+        self.assertIn(
+            "shared-key: morphir-release-${{ matrix.target }}",
+            package_job,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_ci_rust_optimizations.py
+++ b/tests/ci/test_ci_rust_optimizations.py
@@ -35,6 +35,7 @@ class CiRustOptimizationTests(unittest.TestCase):
         )
 
     def test_setup_rust_ci_action_shares_cargo_cache(self) -> None:
+        self.assertIn("inputs.enable-sccache == 'true'", self.setup_rust_ci_action)
         self.assertIn("mozilla-actions/sccache-action@v0.0.10", self.setup_rust_ci_action)
         self.assertIn("shared-key: ${{ inputs.shared-key }}", self.setup_rust_ci_action)
         self.assertIn("add-job-id-key: false", self.setup_rust_ci_action)
@@ -62,6 +63,11 @@ class CiRustOptimizationTests(unittest.TestCase):
             "shared-key: morphir-release-${{ matrix.target }}",
             package_job,
         )
+        self.assertIn(
+            "enable-sccache: ${{ runner.arch != 'ARM64' }}",
+            package_job,
+        )
+        self.assertNotIn("SCCACHE_GHA_ENABLED", self.release_workflow)
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -141,13 +141,28 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("\n  morphir-live:\n", self.ci_workflow)
         # Parallelized Rust jobs: lint + two extension builds + test job feed into check
         self.assertIn(
-            "needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, docs, release-workflow]",
+            "needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, check-cli-docs, docs, release-workflow]",
             self.ci_workflow,
         )
         self.assertNotIn(
             "needs: [changes, morphir-cli, docs, release-workflow]",
             self.ci_workflow,
         )
+
+    def test_cli_docs_job_runs_in_parallel_with_integration_tests(self) -> None:
+        cli_docs_job = self.ci_workflow.split(
+            "  check-cli-docs:\n", maxsplit=1
+        )[1].split("  docs:\n", maxsplit=1)[0]
+        cli_test_job = self.ci_workflow.split(
+            "  morphir-cli-test:\n", maxsplit=1
+        )[1].split("  check-cli-docs:\n", maxsplit=1)[0]
+
+        self.assertIn("needs: changes", cli_docs_job)
+        self.assertNotIn("needs: [changes, lint", cli_docs_job)
+        self.assertIn("mise run docs:cli", cli_docs_job)
+        self.assertIn("git status --porcelain --ignored=matching", cli_docs_job)
+        self.assertNotIn("Generate CLI docs", cli_test_job)
+        self.assertNotIn("Check CLI docs are up to date", cli_test_job)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Extract CLI doc generation into a new \check-cli-docs\ job that runs in parallel with lint, extension builds, and integration tests (~30s off the critical path).
- Add a shared \setup-rust-ci\ composite action using sccache (GHA backend), mold linker, and a unified \morphir-rust\ rust-cache namespace across lint, test, and docs jobs.
- Cache Mill \out/\ for the Scala native-image build keyed by the pinned \morphir-scala\ submodule SHA and GraalVM version.
- Apply the same sccache + shared-cache setup to release packaging jobs (mold on Linux only).

## Expected impact
| Optimization | Est. savings (warm cache) |
|---|---|
| Parallel CLI docs job | ~30s wall-clock |
| Shared rust-cache + sccache | ~1-3 min on Rust compile steps |
| mold linker (Linux) | ~30s-2 min on release builds |
| Scala native-image cache | ~2-4 min when submodule unchanged |

First run after merge will populate caches; subsequent runs should see the gains.

## Test plan
- [x] \python3 -B -m unittest discover -s tests/ci\ (26 tests)
- [ ] CI green on this PR (watch cache restore/save in job logs)
- [ ] Confirm \check-cli-docs\ finishes before \morphir-cli-test\
- [ ] Confirm Scala build hits Mill cache on second push with no submodule bump

Made with [Cursor](https://cursor.com)