### PR TITLE
feat(cli): correlate Desktop launches

### DIFF
--- a/crates/morphir/src/observability.rs
+++ b/crates/morphir/src/observability.rs
@@ -5,6 +5,9 @@ use std::fmt;
 /// Environment variable used to pass a parent operation to a child process.
 pub const PARENT_OPERATION_ID_ENV: &str = "MORPHIR_PARENT_OPERATION_ID";
 
+/// Environment variable used to correlate one managed Desktop process launch.
+pub const LAUNCH_ID_ENV: &str = "MORPHIR_LAUNCH_ID";
+
 /// An opaque identifier for one user-requested Morphir operation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OperationId(String);
@@ -39,6 +42,131 @@ impl fmt::Display for OperationId {
     }
 }
 
+/// An opaque identifier for one attempt to launch a managed component.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LaunchId(String);
+
+impl LaunchId {
+    /// Create a new identifier without encoding user, host, path, or tool data.
+    pub fn new() -> Self {
+        Self(format!("launch-{}", uuid::Uuid::new_v4()))
+    }
+
+    /// Return the identifier as a string slice for structured fields and child processes.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Parse an identifier previously written by a Morphir launcher.
+    pub fn parse(value: &str) -> Option<Self> {
+        let uuid = uuid::Uuid::parse_str(value.strip_prefix("launch-")?).ok()?;
+        Some(Self(format!("launch-{uuid}")))
+    }
+}
+
+impl Default for LaunchId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for LaunchId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Correlation values owned by the CLI for one managed Desktop launch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DesktopLaunchContext {
+    operation_id: OperationId,
+    launch_id: LaunchId,
+}
+
+impl DesktopLaunchContext {
+    /// Start a launch beneath an existing user-requested CLI operation.
+    pub fn new(operation_id: &OperationId) -> Self {
+        Self::from_ids(operation_id.clone(), LaunchId::new())
+    }
+
+    /// Reconstruct a known launch, primarily for deterministic process and integration tests.
+    pub fn from_ids(operation_id: OperationId, launch_id: LaunchId) -> Self {
+        Self {
+            operation_id,
+            launch_id,
+        }
+    }
+
+    /// The CLI operation that owns this launch.
+    pub fn operation_id(&self) -> &OperationId {
+        &self.operation_id
+    }
+
+    /// The identifier unique to this process launch attempt.
+    pub fn launch_id(&self) -> &LaunchId {
+        &self.launch_id
+    }
+
+    /// The complete correlation pair to add to the Desktop child environment.
+    pub fn child_environment(&self) -> [(&'static str, &str); 2] {
+        [
+            (PARENT_OPERATION_ID_ENV, self.operation_id.as_str()),
+            (LAUNCH_ID_ENV, self.launch_id.as_str()),
+        ]
+    }
+}
+
+/// Stable Desktop lifecycle event names consumed by launchers and diagnostic tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DesktopLaunchEvent {
+    Ready,
+    LaunchFailed,
+    Crash,
+    Exit,
+}
+
+impl DesktopLaunchEvent {
+    /// Return the version-one JSON Lines event name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "desktop.ready",
+            Self::LaunchFailed => "desktop.launch.failed",
+            Self::Crash => "desktop.crash",
+            Self::Exit => "desktop.exit",
+        }
+    }
+
+    /// Recognize a lifecycle event from a Desktop JSON Lines record.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "desktop.ready" => Some(Self::Ready),
+            "desktop.launch.failed" => Some(Self::LaunchFailed),
+            "desktop.crash" => Some(Self::Crash),
+            "desktop.exit" => Some(Self::Exit),
+            _ => None,
+        }
+    }
+}
+
+/// Stable failure codes emitted by the CLI side of the Desktop launch handshake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DesktopLaunchErrorCode {
+    SpawnFailed,
+    ReadyTimedOut,
+    ExitedBeforeReady,
+}
+
+impl DesktopLaunchErrorCode {
+    /// Return the version-one diagnostic code.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SpawnFailed => "MORPHIR_DESKTOP_SPAWN_FAILED",
+            Self::ReadyTimedOut => "MORPHIR_DESKTOP_READY_TIMEOUT",
+            Self::ExitedBeforeReady => "MORPHIR_DESKTOP_EXIT_BEFORE_READY",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -61,5 +189,69 @@ mod tests {
         let uppercase = "op-123E4567-E89B-42D3-A456-426614174ABC";
 
         assert_eq!(OperationId::parse(uppercase).unwrap().as_str(), canonical);
+    }
+
+    #[test]
+    fn launch_ids_are_opaque_unique_uuid_values() {
+        let first = LaunchId::new();
+        let second = LaunchId::new();
+
+        assert_ne!(first, second);
+        assert!(first.as_str().starts_with("launch-"));
+        uuid::Uuid::parse_str(first.as_str().trim_start_matches("launch-")).unwrap();
+        assert_eq!(LaunchId::parse(first.as_str()), Some(first));
+        assert!(LaunchId::parse("bad-launch").is_none());
+    }
+
+    #[test]
+    fn managed_desktop_launch_supplies_one_correlation_pair() {
+        let operation_id = OperationId::parse("op-123e4567-e89b-42d3-a456-426614174000").unwrap();
+        let launch_id = LaunchId::parse("launch-123e4567-e89b-42d3-a456-426614174001").unwrap();
+        let launch = DesktopLaunchContext::from_ids(operation_id.clone(), launch_id.clone());
+        let generated = DesktopLaunchContext::new(&operation_id);
+
+        assert_eq!(launch.operation_id(), &operation_id);
+        assert_eq!(launch.launch_id(), &launch_id);
+        assert_eq!(generated.operation_id(), &operation_id);
+        assert_ne!(generated.launch_id(), &launch_id);
+        assert_eq!(
+            launch.child_environment(),
+            [
+                (PARENT_OPERATION_ID_ENV, operation_id.as_str()),
+                (LAUNCH_ID_ENV, launch_id.as_str()),
+            ]
+        );
+    }
+
+    #[test]
+    fn desktop_launch_event_names_are_stable() {
+        assert_eq!(DesktopLaunchEvent::Ready.as_str(), "desktop.ready");
+        assert_eq!(
+            DesktopLaunchEvent::LaunchFailed.as_str(),
+            "desktop.launch.failed"
+        );
+        assert_eq!(DesktopLaunchEvent::Crash.as_str(), "desktop.crash");
+        assert_eq!(DesktopLaunchEvent::Exit.as_str(), "desktop.exit");
+        assert_eq!(
+            DesktopLaunchEvent::parse("desktop.ready"),
+            Some(DesktopLaunchEvent::Ready)
+        );
+        assert_eq!(DesktopLaunchEvent::parse("desktop.unknown"), None);
+    }
+
+    #[test]
+    fn cli_launch_error_codes_are_stable() {
+        assert_eq!(
+            DesktopLaunchErrorCode::SpawnFailed.as_str(),
+            "MORPHIR_DESKTOP_SPAWN_FAILED"
+        );
+        assert_eq!(
+            DesktopLaunchErrorCode::ReadyTimedOut.as_str(),
+            "MORPHIR_DESKTOP_READY_TIMEOUT"
+        );
+        assert_eq!(
+            DesktopLaunchErrorCode::ExitedBeforeReady.as_str(),
+            "MORPHIR_DESKTOP_EXIT_BEFORE_READY"
+        );
     }
 }

--- a/crates/morphir/tests/cli_integration.rs
+++ b/crates/morphir/tests/cli_integration.rs
@@ -2499,13 +2499,16 @@ fn diagnostics_show_finds_correlated_events_and_redacts_legacy_secrets() {
     let log_dir = morphir_home.join("logs").join("desktop").join("2026-08-30");
     std::fs::create_dir_all(&log_dir).unwrap();
     let operation_id = "op-123e4567-e89b-42d3-a456-426614174000";
+    let launch_id = "launch-123e4567-e89b-42d3-a456-426614174001";
     let events = [
         serde_json::json!({
             "timestamp": "2026-08-30T03:04:05Z",
             "level": "INFO",
             "fields": {
-                "operation_id": operation_id,
-                "event_name": "desktop.session.start",
+                "operation_id": "op-123e4567-e89b-42d3-a456-426614174002",
+                "parent_operation_id": operation_id,
+                "launch_id": launch_id,
+                "event_name": "desktop.ready",
                 "authorization": "Bearer SHOULD_NOT_ESCAPE",
                 "apiKey": "CAMEL_API_KEY_SHOULD_NOT_ESCAPE",
                 "api_key": "SNAKE_API_KEY_SHOULD_NOT_ESCAPE",
@@ -2519,6 +2522,18 @@ fn diagnostics_show_finds_correlated_events_and_redacts_legacy_secrets() {
         }),
         serde_json::json!({
             "timestamp": "2026-08-30T03:04:06Z",
+            "level": "ERROR",
+            "fields": {
+                "operation_id": "op-123e4567-e89b-42d3-a456-426614174002",
+                "parent_operation_id": operation_id,
+                "launch_id": launch_id,
+                "event_name": "desktop.crash",
+                "error_code": "MORPHIR_DESKTOP_RENDERER_CRASHED",
+                "sourceCode": "PRIVATE_PROJECT_CONTENTS"
+            }
+        }),
+        serde_json::json!({
+            "timestamp": "2026-08-30T03:04:07Z",
             "level": "INFO",
             "fields": {
                 "operation_id": "op-123e4567-e89b-42d3-a456-426614174999",
@@ -2550,11 +2565,15 @@ fn diagnostics_show_finds_correlated_events_and_redacts_legacy_secrets() {
     );
     let shown: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(shown["operationId"], operation_id);
-    assert_eq!(shown["events"].as_array().unwrap().len(), 1);
+    assert_eq!(shown["events"].as_array().unwrap().len(), 2);
+    assert_eq!(shown["events"][0]["fields"]["event_name"], "desktop.ready");
+    assert_eq!(shown["events"][0]["fields"]["launch_id"], launch_id);
+    assert_eq!(shown["events"][1]["fields"]["event_name"], "desktop.crash");
     assert_eq!(
-        shown["events"][0]["fields"]["event_name"],
-        "desktop.session.start"
+        shown["events"][1]["fields"]["error_code"],
+        "MORPHIR_DESKTOP_RENDERER_CRASHED"
     );
+    assert!(shown["events"][1]["fields"].get("sourceCode").is_none());
     assert_eq!(shown["events"][0]["fields"]["authorization"], "[REDACTED]");
     for field in ["apiKey", "api_key", "accessKey", "credential"] {
         assert_eq!(shown["events"][0]["fields"][field], "[REDACTED]");
@@ -2573,6 +2592,7 @@ fn diagnostics_show_finds_correlated_events_and_redacts_legacy_secrets() {
     );
     assert_eq!(shown["events"][0]["fields"]["auth_message"], "[REDACTED]");
     assert!(!String::from_utf8_lossy(&output.stdout).contains("SHOULD_NOT_ESCAPE"));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("PRIVATE_PROJECT_CONTENTS"));
     assert!(!String::from_utf8_lossy(&output.stdout).contains("hunter2"));
     assert!(!String::from_utf8_lossy(&output.stdout).contains("dXNlcjpwYXNz"));
 }
@@ -2624,8 +2644,11 @@ fn diagnostics_collect_creates_an_inspectable_sanitized_archive() {
     let cli_log_root = temp_dir.path().join("private-user-logs");
     let private_workspace = temp_dir.path().join("private-workspace").join("model.json");
     let log_dir = cli_log_root.join("2026-08-30");
+    let desktop_log_dir = morphir_home.join("logs/desktop/2026-08-30");
     std::fs::create_dir_all(&log_dir).unwrap();
+    std::fs::create_dir_all(&desktop_log_dir).unwrap();
     let operation_id = "op-123e4567-e89b-42d3-a456-426614174000";
+    let launch_id = "launch-123e4567-e89b-42d3-a456-426614174001";
     std::fs::write(
         log_dir.join("fixture.jsonl"),
         serde_json::json!({
@@ -2639,6 +2662,24 @@ fn diagnostics_collect_creates_an_inspectable_sanitized_archive() {
                 "diagnostic": format!("failed to open {}", private_workspace.display()),
                 "token": "BUNDLE_SECRET_SENTINEL",
                 "source_url": "https://alice:hunter2@example.com/artifact"
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        desktop_log_dir.join("fixture.jsonl"),
+        serde_json::json!({
+            "timestamp": "2026-08-30T03:04:06Z",
+            "level": "ERROR",
+            "fields": {
+                "operation_id": "op-123e4567-e89b-42d3-a456-426614174002",
+                "parent_operation_id": operation_id,
+                "launch_id": launch_id,
+                "event_name": "desktop.crash",
+                "error_code": "MORPHIR_DESKTOP_RENDERER_CRASHED",
+                "sourceCode": "PRIVATE_DESKTOP_PROJECT_CONTENTS",
+                "authorization": "Bearer PRIVATE_DESKTOP_CREDENTIAL"
             }
         })
         .to_string(),
@@ -2681,6 +2722,8 @@ fn diagnostics_collect_creates_an_inspectable_sanitized_archive() {
     let combined = entries.values().flatten().copied().collect::<Vec<_>>();
     let combined = String::from_utf8(combined).unwrap();
     assert!(!combined.contains("BUNDLE_SECRET_SENTINEL"));
+    assert!(!combined.contains("PRIVATE_DESKTOP_PROJECT_CONTENTS"));
+    assert!(!combined.contains("PRIVATE_DESKTOP_CREDENTIAL"));
     assert!(!combined.contains("alice"));
     assert!(!combined.contains("hunter2"));
     assert!(combined.contains("https://[REDACTED]@example.com"));
@@ -2690,6 +2733,9 @@ fn diagnostics_collect_creates_an_inspectable_sanitized_archive() {
     assert!(combined.contains("$MORPHIR_LOG_DIR"));
     assert!(!combined.contains(&private_workspace.to_string_lossy().to_string()));
     assert!(combined.contains("$ABSOLUTE_PATH"));
+    assert!(combined.contains(launch_id));
+    assert!(combined.contains("desktop.crash"));
+    assert!(combined.contains("MORPHIR_DESKTOP_RENDERER_CRASHED"));
 
     let manifest: serde_json::Value = serde_json::from_slice(&entries["manifest.json"]).unwrap();
     assert_eq!(manifest["operationId"], operation_id);


### PR DESCRIPTION
## Summary
- add typed operation/launch correlation for CLI-managed Desktop processes
- define stable Desktop lifecycle events and CLI launch error codes
- extend diagnostics tests to prove correlated Desktop events are selected and sanitized
- update the `morphir-ui` submodule to the correlated Desktop implementation

## Dependency
- finos/morphir-ui#27 is merged
- the submodule points to landed commit `7eb1c8b272dd3588a72a4341a5ac0e4c39126cfc`

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p morphir --all-targets -- -D warnings`
- `cargo test -p morphir --lib observability` (6 passed)
- targeted CLI diagnostics and failure-path integration tests (3 passed)
- `cargo test -p morphir` reached 176 passed; 30 pre-existing Windows artifact-move tests fail with OS error 87 and are tracked separately
- Desktop gates: typecheck, lint, 138 tests with 15 platform skips, Prettier, production build

Part of #758.