### PR TITLE
fix(desktop): launch installed packages and add repeatable demo

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -157,6 +157,15 @@ depends = ["tools:install"]
 description = "Build and vendor a clean morphir-web worktree twice with provenance"
 run = "bun run tools/vendor-morphir-web.ts"
 
+[tasks."demo:desktop"]
+description = "Build, install and run the real Desktop demo in a fresh temporary Home"
+raw_args = true
+run = "bun run tools/demo-desktop.ts"
+
+[tasks."test:desktop-demo"]
+description = "Test Desktop demo orchestration without building or opening Desktop"
+run = "bun test tools/demo-desktop.test.ts"
+
 [tasks.check]
 description = "Run all checks"
 depends = [

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -159,7 +159,7 @@ run = "bun run tools/vendor-morphir-web.ts"
 
 [tasks."demo:desktop"]
 description = "Build, install and run the real Desktop demo in a fresh temporary Home"
-raw_args = true
+usage = 'flag "--prepare-only" help="Build and install without opening Desktop"'
 run = "bun run tools/demo-desktop.ts"
 
 [tasks."test:desktop-demo"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       docs: ${{ steps.filter.outputs.docs }}
       release: ${{ steps.filter.outputs.release }}
+      desktop-demo: ${{ steps.filter.outputs.desktop-demo }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -40,6 +41,13 @@ jobs:
         id: filter
         with:
           filters: |
+            desktop-demo:
+              - 'tools/demo-desktop*'
+              - 'tools/package.json'
+              - 'tools/bun.lock'
+              - 'tools/tsconfig.json'
+              - '.config/mise/config.toml'
+              - '.github/workflows/ci.yml'
             rust:
               - 'Cargo.toml'
               - 'Cargo.lock'
@@ -84,6 +92,25 @@ jobs:
               - 'tests/ci/test_select_release_assets.py'
               - '.github/scripts/select_release_assets.py'
               - '.github/workflows/ci.yml'
+
+  desktop-demo:
+    name: Desktop demo (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop-demo == 'true' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.4.0
+      - run: bun install --frozen-lockfile
+        working-directory: tools
+      - run: bun run typecheck
+        working-directory: tools
+      - run: bun test tools/demo-desktop.test.ts
 
   # Fast feedback: formatting + lint (no GraalVM, no Elm build)
   lint:
@@ -374,7 +401,7 @@ jobs:
   check:
     name: All Checks
     runs-on: ubuntu-latest
-    needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, check-cli-docs, docs, release-workflow]
+    needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, check-cli-docs, docs, release-workflow, desktop-demo]
     if: always()
     steps:
       - name: Check results
@@ -412,6 +439,12 @@ jobs:
           if [[ "${{ needs.changes.outputs.release }}" == "true" ]]; then
             if [[ "${{ needs.release-workflow.result }}" != "success" ]]; then
               echo "release workflow validation failed"
+              exit 1
+            fi
+          fi
+          if [[ "${{ needs.changes.outputs.desktop-demo }}" == "true" ]]; then
+            if [[ "${{ needs.desktop-demo.result }}" != "success" ]]; then
+              echo "Desktop demo tests failed"
               exit 1
             fi
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: sccache
+  # setup-rust-ci enables the compiler wrapper after installing sccache.
+  # mise may compile Cargo tools before that action runs on a cold cache.
 
 jobs:
   # Detect what files changed to enable fast-path for docs-only changes

--- a/crates/morphir/src/commands/desktop.rs
+++ b/crates/morphir/src/commands/desktop.rs
@@ -15,6 +15,8 @@ use std::{
 };
 
 mod readiness;
+#[cfg(windows)]
+mod windows;
 use readiness::ReadinessLogs;
 
 const DESKTOP_TOOL_ID: &str = "desktop";
@@ -74,7 +76,11 @@ pub fn run_desktop(operation_id: &OperationId, args: DesktopArgs) -> AppResult<m
     let launch = DesktopLaunchContext::new(operation_id);
     let version = active.version().clone();
     let executable = active.program().to_path_buf();
-    let mut command = Command::new(active.program());
+    #[cfg(windows)]
+    let launch_executable = windows::executable_path(&executable)?;
+    #[cfg(not(windows))]
+    let launch_executable = &executable;
+    let mut command = Command::new(launch_executable);
     command.args(active.args()).arg(&workspace);
     command.env_clear();
     command.envs(std::env::vars_os().filter(|(name, _)| should_inherit_environment(name)));

--- a/crates/morphir/src/commands/desktop/windows.rs
+++ b/crates/morphir/src/commands/desktop/windows.rs
@@ -1,0 +1,129 @@
+use miette::{IntoDiagnostic, WrapErr, miette};
+use std::{
+    ffi::OsString,
+    io,
+    os::windows::ffi::{OsStrExt, OsStringExt},
+    path::{Path, PathBuf},
+};
+use windows_sys::Win32::Storage::FileSystem::GetShortPathNameW;
+
+// Chromium's executable-path lookup still uses a MAX_PATH buffer, even when
+// longPathAware enables long paths for the application's own filesystem I/O.
+const ELECTRON_EXECUTABLE_PATH_LIMIT: usize = 260;
+
+pub(super) fn executable_path(path: &Path) -> miette::Result<PathBuf> {
+    let candidate = bounded_executable_path(path, existing_short_path)?;
+    if candidate != path {
+        let resolved = candidate
+            .canonicalize()
+            .into_diagnostic()
+            .wrap_err("Could not verify the Desktop short executable path")?;
+        if resolved != path.canonicalize().into_diagnostic()? {
+            return Err(miette!(
+                "Desktop short executable path does not resolve to the verified installation"
+            ));
+        }
+    }
+    Ok(candidate)
+}
+
+fn bounded_executable_path(
+    path: &Path,
+    short_path: impl FnOnce(&Path) -> io::Result<PathBuf>,
+) -> miette::Result<PathBuf> {
+    let fits =
+        |path: &Path| path.as_os_str().encode_wide().count() < ELECTRON_EXECUTABLE_PATH_LIMIT;
+    if fits(path) {
+        return Ok(path.to_path_buf());
+    }
+    if let Ok(candidate) = short_path(path)
+        && fits(&candidate)
+    {
+        return Ok(candidate);
+    }
+    Err(miette!(
+        "The installed Desktop executable path exceeds Electron's Windows limit of 259 UTF-16 code units and no usable existing short filename is available. Set MORPHIR_HOME to a shorter directory and reinstall Desktop there. No Windows settings were changed."
+    ))
+}
+
+fn existing_short_path(path: &Path) -> io::Result<PathBuf> {
+    let input: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    // Windows extended-length paths are bounded by 32,767 UTF-16 code units.
+    let mut output = vec![0_u16; 32_768];
+    // SAFETY: input is NUL-terminated and both buffers remain valid for the call.
+    let length =
+        unsafe { GetShortPathNameW(input.as_ptr(), output.as_mut_ptr(), output.len() as u32) };
+    if length == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if length as usize >= output.len() {
+        return Err(io::Error::other(
+            "Windows short executable path exceeds the supported length",
+        ));
+    }
+    Ok(PathBuf::from(OsString::from_wide(
+        &output[..length as usize],
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::windows::ffi::OsStrExt;
+
+    #[test]
+    fn deep_executable_uses_an_existing_short_name_or_reports_the_platform_limit() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = root.path().join("a-long-package-directory-name".repeat(6));
+        std::fs::create_dir(&directory).unwrap();
+        let directory = directory.join("another-long-package-directory-name".repeat(3));
+        std::fs::create_dir(&directory).unwrap();
+        let original = directory.join("morphir-desktop.exe");
+        std::fs::write(&original, b"fixture executable").unwrap();
+        let original = original.canonicalize().unwrap();
+        assert!(original.as_os_str().encode_wide().count() >= 260);
+        match executable_path(&original) {
+            Ok(path) => {
+                assert!(path.as_os_str().encode_wide().count() < 260);
+                assert_eq!(path.canonicalize().unwrap(), original);
+            }
+            Err(error) => {
+                let message = error.to_string();
+                assert!(message.contains("MORPHIR_HOME"), "{message}");
+                assert!(message.contains("short"), "{message}");
+            }
+        }
+    }
+
+    #[test]
+    fn short_executable_path_is_unchanged() {
+        let path = Path::new(r"C:\Morphir\morphir-desktop.exe");
+        assert_eq!(executable_path(path).unwrap(), path);
+    }
+
+    #[test]
+    fn unavailable_or_unshortened_names_report_how_to_recover() {
+        let path = PathBuf::from(format!(r"C:\{}\morphir-desktop.exe", "x".repeat(260)));
+        for result in [
+            Ok(path.clone()),
+            Err(io::Error::other("short names unavailable")),
+        ] {
+            let error = bounded_executable_path(&path, |_| result)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("MORPHIR_HOME"), "{error}");
+            assert!(error.contains("reinstall"), "{error}");
+        }
+    }
+
+    #[test]
+    fn executable_limit_counts_utf16_not_utf8_bytes() {
+        let path = PathBuf::from(format!(r"C:\{}\desktop.exe", "é".repeat(150)));
+        assert_eq!(
+            bounded_executable_path(&path, |_| panic!("short path not needed")).unwrap(),
+            path
+        );
+        let path = PathBuf::from(format!(r"C:\{}\desktop.exe", "🦀".repeat(130)));
+        assert!(bounded_executable_path(&path, |_| Err(io::Error::other("unavailable"))).is_err());
+    }
+}

--- a/crates/morphir/src/commands/tool.rs
+++ b/crates/morphir/src/commands/tool.rs
@@ -235,14 +235,14 @@ fn desktop_archive_contract(source: &Path, os: &str) -> Result<(ArchiveFormat, S
     let lowercase = filename.to_ascii_lowercase();
     match os {
         "windows" if lowercase.ends_with(".zip") => {
-            Ok((ArchiveFormat::Zip, "Morphir Desktop.exe".to_owned()))
+            Ok((ArchiveFormat::Zip, "morphir-desktop.exe".to_owned()))
         }
-        "windows" if filename == "Morphir Desktop.exe" => {
+        "windows" if matches!(filename, "morphir-desktop.exe" | "Morphir Desktop.exe") => {
             Ok((ArchiveFormat::Raw, filename.to_owned()))
         }
         "macos" if lowercase.ends_with(".zip") => Ok((
             ArchiveFormat::Zip,
-            "Morphir Desktop.app/Contents/MacOS/Morphir Desktop".to_owned(),
+            "Morphir Desktop.app/Contents/MacOS/morphir-desktop".to_owned(),
         )),
         "linux" if lowercase.ends_with(".tar.gz") => {
             Ok((ArchiveFormat::TarGzip, "morphir-desktop".to_owned()))
@@ -289,13 +289,13 @@ mod tests {
     fn desktop_archives_use_the_release_contract_entry_points() {
         assert_eq!(
             desktop_archive_contract(Path::new("desktop.zip"), "windows").unwrap(),
-            (ArchiveFormat::Zip, "Morphir Desktop.exe".to_owned())
+            (ArchiveFormat::Zip, "morphir-desktop.exe".to_owned())
         );
         assert_eq!(
             desktop_archive_contract(Path::new("desktop.zip"), "macos").unwrap(),
             (
                 ArchiveFormat::Zip,
-                "Morphir Desktop.app/Contents/MacOS/Morphir Desktop".to_owned(),
+                "Morphir Desktop.app/Contents/MacOS/morphir-desktop".to_owned(),
             )
         );
     }
@@ -307,5 +307,16 @@ mod tests {
             desktop_archive_contract(Path::new(filename), "linux").unwrap(),
             (ArchiveFormat::Appimage, filename.to_owned())
         );
+    }
+
+    #[test]
+    fn windows_raw_packages_accept_the_release_name_and_legacy_fixture_name() {
+        for filename in ["morphir-desktop.exe", "Morphir Desktop.exe"] {
+            assert_eq!(
+                desktop_archive_contract(Path::new(filename), "windows").unwrap(),
+                (ArchiveFormat::Raw, filename.to_owned())
+            );
+        }
+        assert!(desktop_archive_contract(Path::new("unrelated.exe"), "windows").is_err());
     }
 }

--- a/crates/morphir/tests/cli_integration.rs
+++ b/crates/morphir/tests/cli_integration.rs
@@ -27,9 +27,9 @@ fn write_local_desktop_package(directory: &std::path::Path, version: &str) -> Pa
     #[cfg(any(windows, target_os = "macos"))]
     {
         let executable = if cfg!(windows) {
-            "Morphir Desktop.exe"
+            "morphir-desktop.exe"
         } else {
-            "Morphir Desktop.app/Contents/MacOS/Morphir Desktop"
+            "Morphir Desktop.app/Contents/MacOS/morphir-desktop"
         };
         let package = directory.join(format!("morphir-desktop-{version}.zip"));
         let file = std::fs::File::create(&package).unwrap();
@@ -85,7 +85,7 @@ fn desktop_offline_reports_how_to_install_when_no_active_release_exists() {
 
 fn build_desktop_launch_fixture(fixture_root: &std::path::Path) -> PathBuf {
     let executable_name = if cfg!(windows) {
-        "Morphir Desktop.exe"
+        "morphir-desktop.exe"
     } else {
         "morphir-desktop"
     };
@@ -105,13 +105,17 @@ fn build_desktop_launch_fixture(fixture_root: &std::path::Path) -> PathBuf {
         String::from_utf8_lossy(&compilation.stderr)
     );
 
-    if cfg!(target_os = "macos") {
+    if cfg!(any(windows, target_os = "macos")) {
         let package = fixture_root.join("morphir-desktop-fixture.zip");
         let file = std::fs::File::create(&package).unwrap();
         let mut archive = zip::ZipWriter::new(file);
         archive
             .start_file(
-                "Morphir Desktop.app/Contents/MacOS/Morphir Desktop",
+                if cfg!(target_os = "macos") {
+                    "Morphir Desktop.app/Contents/MacOS/morphir-desktop"
+                } else {
+                    "morphir-desktop.exe"
+                },
                 zip::write::SimpleFileOptions::default().unix_permissions(0o755),
             )
             .unwrap();

--- a/docs/getting-started/morphir-cli.md
+++ b/docs/getting-started/morphir-cli.md
@@ -178,6 +178,72 @@ Repair requires the exact original package bytes. Uninstall removes the active s
 lock; content-addressed package bytes remain cache-owned and can be reclaimed with
 `morphir cache clean`.
 
+### Launch the installed Desktop
+
+```shell
+morphir desktop --offline --wait <workspace-directory-or-morphir-ir.json>
+```
+
+The CLI verifies the installed files, opens the selected workspace, and reports Desktop readiness.
+`--wait` keeps the command running until Desktop closes and returns its exit status. Without it,
+the CLI returns after startup. Logs beneath Morphir Home record the same launch ID. Desktop
+records the CLI operation ID as its parent operation ID. The installed app does not need the
+original ZIP or a source checkout.
+
+The developer workflow requires the explicit local installation above. `--offline` never downloads
+a missing release; it reports the installation command instead.
+
+### Desktop installation paths on Windows
+
+Desktop packages declare `longPathAware` for filesystem access. Electron's Chromium runtime still
+uses a [fixed-size buffer for its own executable path](https://github.com/chromium/chromium/blob/main/base/base_paths_win.cc).
+When that path reaches 260 UTF-16 code units, the CLI asks Windows for an existing short filename
+and verifies that it resolves to the same installed executable before launching it. Package
+verification remains unchanged; the CLI does not create aliases or change Windows settings.
+
+If the volume has no usable short filename, the CLI reports the limit before starting Desktop.
+Choose a shorter `MORPHIR_HOME` and install the package there, for example in PowerShell:
+
+```powershell
+$env:MORPHIR_HOME = 'C:\MorphirHome'
+morphir tool install desktop --source <path-to-package.zip> --channel developer --version 0.1.0
+morphir desktop --offline --wait <workspace-directory>
+```
+
+This selects a separate Home; it does not move or delete an existing installation. Keep the same
+`MORPHIR_HOME` value for subsequent commands. Windows long-path support must still be enabled for
+deep project files as described above.
+
+### Run the developer Desktop demo
+
+From an initialized checkout with Rust, Bun and native build tools installed:
+
+```shell
+mise run demo:desktop
+```
+
+This builds the CLI and an unsigned Desktop archive for the current platform, copies the Insight
+sample model, and installs Desktop into a fresh temporary Morphir Home. Build and dependency
+installation steps may use the network. No existing Morphir installation is changed.
+
+The task opens the installed application with `--offline --wait`. Select `applyLambda` and inspect
+its Insight and XRay views, then close the window. The task moves the original archive aside and
+opens Desktop again offline. Close the second window to finish. Failed build, install or launch
+commands stop the task and return their nonzero exit code.
+
+The printed demo directory retains the copied CLI, sample model, installed files, logs and the
+archive as `package.saved`. The task runs the installed CLI outside the checkout. It does not
+disable networking or make the source checkout unreadable, so this is not an OS-isolation test.
+Windows app-data and Linux XDG config directories are also redirected into the demo directory;
+macOS may still use Electron's normal OS profile location.
+
+To build and install without opening a window, or run the orchestration tests without building:
+
+```shell
+mise run demo:desktop -- --prepare-only
+mise run test:desktop-demo
+```
+
 ## Related tooling
 
 | Tool | Repository | Use when |

--- a/docs/getting-started/morphir-cli.md
+++ b/docs/getting-started/morphir-cli.md
@@ -226,7 +226,8 @@ This builds the CLI and an unsigned Desktop archive for the current platform, co
 sample model, and installs Desktop into a fresh temporary Morphir Home. Build and dependency
 installation steps may use the network. No existing Morphir installation is changed.
 
-The task opens the installed application with `--offline --wait`. Select `applyLambda` and inspect
+The task opens the installed application with `--offline --wait`. Open **IR Explorer**, select
+`applyLambda` and inspect
 its Insight and XRay views, then close the window. The task moves the original archive aside and
 opens Desktop again offline. Close the second window to finish. Failed build, install or launch
 commands stop the task and return their nonzero exit code.

--- a/tests/ci/test_ci_rust_optimizations.py
+++ b/tests/ci/test_ci_rust_optimizations.py
@@ -25,8 +25,15 @@ class CiRustOptimizationTests(unittest.TestCase):
         )[1].split("  morphir-cli-test:\n", maxsplit=1)[0]
 
     def test_ci_enables_sccache(self) -> None:
-        self.assertIn('SCCACHE_GHA_ENABLED: "true"', self.ci_workflow)
-        self.assertIn("RUSTC_WRAPPER: sccache", self.ci_workflow)
+        # mise can compile Cargo tools before the shared setup action runs.
+        # A global wrapper points those builds at an executable not installed yet.
+        self.assertNotIn("RUSTC_WRAPPER:", self.ci_workflow)
+        self.assertIn("echo 'RUSTC_WRAPPER=sccache'", self.setup_rust_ci_action)
+        self.assertIn("echo 'SCCACHE_GHA_ENABLED=true'", self.setup_rust_ci_action)
+        self.assertLess(
+            self.setup_rust_ci_action.index("uses: mozilla-actions/sccache-action"),
+            self.setup_rust_ci_action.index("echo 'RUSTC_WRAPPER=sccache'"),
+        )
 
     def test_rust_jobs_use_shared_setup_action(self) -> None:
         self.assertEqual(

--- a/tests/ci/test_release_workflow.py
+++ b/tests/ci/test_release_workflow.py
@@ -141,7 +141,7 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertNotIn("\n  morphir-live:\n", self.ci_workflow)
         # Parallelized Rust jobs: lint + two extension builds + test job feed into check
         self.assertIn(
-            "needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, check-cli-docs, docs, release-workflow]",
+            "needs: [changes, lint, build-elm-extension, build-scala-extension, morphir-cli-test, check-cli-docs, docs, release-workflow, desktop-demo]",
             self.ci_workflow,
         )
         self.assertNotIn(

--- a/tools/demo-desktop.test.ts
+++ b/tools/demo-desktop.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+	demoEnvironment,
+	execute,
+	nativePackage,
+	parseMode,
+	prepareDemo,
+	runDemo,
+	type Runner,
+} from "./demo-desktop";
+
+const roots: string[] = [];
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+test("selects native portable archives and rejects unsupported hosts", () => {
+	expect(nativePackage("win32", "arm64")).toEqual({
+		flag: "--win",
+		target: "zip",
+		os: "win",
+		arch: "arm64",
+	});
+	expect(nativePackage("darwin", "x64").target).toBe("zip");
+	expect(nativePackage("linux", "x64").target).toBe("tar.gz");
+	expect(() => nativePackage("freebsd", "x64")).toThrow("Unsupported");
+	expect(() => nativePackage("win32", "ia32")).toThrow("Unsupported");
+});
+
+test("only accepts interactive, prepare-only and help modes", () => {
+	expect(parseMode([])).toBe("interactive");
+	expect(parseMode(["--prepare-only"])).toBe("prepare");
+	expect(parseMode(["--help"])).toBe("help");
+	expect(() => parseMode(["--oops"])).toThrow("Usage");
+	expect(() => parseMode(["--prepare-only", "--oops"])).toThrow("Usage");
+});
+
+test("isolates Home, profile and logs without mutating inherited environment", () => {
+	const inherited = {
+		MORPHIR_HOME: "personal",
+		morphir_log_dir: "personal-logs",
+		MORPHIR_LOG_FILE: "false",
+		ELECTRON_RUN_AS_NODE: "1",
+		PATH: "tools",
+	};
+	const env = demoEnvironment("demo", inherited);
+	expect(env.MORPHIR_HOME).toBe(path.join("demo", "home"));
+	expect(env.APPDATA).toBe(path.join("demo", "profile", "appdata"));
+	expect(env.PATH).toBe("tools");
+	expect(env).not.toHaveProperty("morphir_log_dir");
+	expect(env).not.toHaveProperty("MORPHIR_LOG_FILE");
+	expect(env).not.toHaveProperty("ELECTRON_RUN_AS_NODE");
+	expect(inherited.MORPHIR_HOME).toBe("personal");
+});
+
+function fixture() {
+	const root = mkdtempSync(path.join(tmpdir(), "morphir-demo-test-"));
+	roots.push(root);
+	const repo = path.join(root, "repository with spaces");
+	const ui = path.join(repo, "ecosystem", "morphir-ui");
+	const app = path.join(ui, "apps", "morphir-desktop");
+	mkdirSync(app, { recursive: true });
+	writeFileSync(path.join(app, "package.json"), JSON.stringify({ version: "0.1.0" }));
+	const fixtureDir = path.join(ui, "packages", "morphir-ir", "test", "fixtures");
+	mkdirSync(fixtureDir, { recursive: true });
+	writeFileSync(path.join(fixtureDir, "insight-ir.json"), "sample model");
+	const cli = path.join(root, "compiled-cli");
+	writeFileSync(cli, "compiled CLI");
+	const calls: Parameters<Runner>[0][] = [];
+	const run: Runner = async (command) => {
+		calls.push(command);
+		if (command.args[0] === "cargo")
+			return JSON.stringify({
+				reason: "compiler-artifact",
+				target: { name: "morphir", kind: ["bin"] },
+				executable: cli,
+			});
+		if (command.args.includes("electron-builder")) {
+			const output = command.args
+				.find((arg) => arg.startsWith("--config.directories.output="))!
+				.split("=")
+				.slice(1)
+				.join("=");
+			mkdirSync(output, { recursive: true });
+			writeFileSync(path.join(output, "morphir-desktop-0.1.0-win-arm64.zip"), "package");
+		}
+		return "";
+	};
+	return { root, repo, calls, run };
+}
+
+test("prepares a fresh demo using argv arrays and the public verified install", async () => {
+	const f = fixture();
+	const demo = await prepareDemo(
+		{ repositoryRoot: f.repo, temporaryRoot: f.root, platform: "win32", arch: "arm64" },
+		f.run,
+	);
+	expect(path.dirname(demo.root)).toBe(f.root);
+	expect(readFileSync(demo.executable, "utf8")).toBe("compiled CLI");
+	expect(readFileSync(demo.workspace, "utf8")).toBe("sample model");
+	expect(f.calls.at(-1)?.args).toEqual([
+		demo.executable,
+		"tool",
+		"install",
+		"desktop",
+		"--source",
+		demo.packagePath,
+		"--channel",
+		"developer",
+		"--version",
+		"0.1.0",
+	]);
+	expect(f.calls.at(-1)?.cwd).toBe(demo.root);
+	expect(f.calls.at(-1)?.env?.MORPHIR_HOME).toBe(path.join(demo.root, "home"));
+	expect(f.calls.some((call) => call.args[1] === "desktop")).toBe(false);
+	expect(f.calls.find((call) => call.args.includes("electron-builder"))?.args).toContain(
+		"--publish=never",
+	);
+});
+
+test("repeats offline outside checkout only after the first exit and hides the original package", async () => {
+	const f = fixture();
+	const demo = await prepareDemo(
+		{ repositoryRoot: f.repo, temporaryRoot: f.root, platform: "win32", arch: "arm64" },
+		f.run,
+	);
+	let launches = 0;
+	await runDemo(demo, async (command) => {
+		expect(command.args).toEqual([
+			demo.executable,
+			"desktop",
+			"--offline",
+			"--wait",
+			demo.workspace,
+		]);
+		expect(command.cwd).toBe(demo.root);
+		expect(existsSync(demo.packagePath)).toBe(launches === 0);
+		launches++;
+		return "";
+	});
+	expect(launches).toBe(2);
+	expect(readFileSync(path.join(demo.root, "package.saved"), "utf8")).toBe("package");
+});
+
+test("failed launch prevents package move and second launch", async () => {
+	const f = fixture();
+	const demo = await prepareDemo(
+		{ repositoryRoot: f.repo, temporaryRoot: f.root, platform: "win32", arch: "arm64" },
+		f.run,
+	);
+	let launches = 0;
+	await expect(
+		runDemo(demo, async () => {
+			launches++;
+			throw new Error("exit 17");
+		}),
+	).rejects.toThrow("exit 17");
+	expect(launches).toBe(1);
+	expect(existsSync(demo.packagePath)).toBe(true);
+});
+
+test("build failure prevents package installation", async () => {
+	const f = fixture();
+	await expect(
+		prepareDemo(
+			{ repositoryRoot: f.repo, temporaryRoot: f.root, platform: "win32", arch: "arm64" },
+			async () => {
+				throw new Error("build failed");
+			},
+		),
+	).rejects.toThrow("build failed");
+	expect(f.calls).toHaveLength(0);
+});
+
+test("subprocess failures preserve the actual exit code", async () => {
+	await expect(
+		execute({ args: [process.execPath, "-e", "process.exit(17)"], cwd: tmpdir() }),
+	).rejects.toMatchObject({ exitCode: 17 });
+});

--- a/tools/demo-desktop.test.ts
+++ b/tools/demo-desktop.test.ts
@@ -34,8 +34,18 @@ test("only accepts interactive, prepare-only and help modes", () => {
 	expect(parseMode([])).toBe("interactive");
 	expect(parseMode(["--prepare-only"])).toBe("prepare");
 	expect(parseMode(["--help"])).toBe("help");
+	expect(parseMode([], "true")).toBe("prepare");
+	expect(parseMode([], "false")).toBe("interactive");
 	expect(() => parseMode(["--oops"])).toThrow("Usage");
 	expect(() => parseMode(["--prepare-only", "--oops"])).toThrow("Usage");
+});
+
+test("mise task uses the usage field supported by Netlify's bundled mise", () => {
+	const config = Bun.TOML.parse(
+		readFileSync(new URL("../.config/mise/config.toml", import.meta.url), "utf8"),
+	) as { tasks: Record<string, Record<string, unknown>> };
+	expect(config.tasks["demo:desktop"]).not.toHaveProperty("raw_args");
+	expect(config.tasks["demo:desktop"]?.usage).toContain("--prepare-only");
 });
 
 test("isolates Home, profile and logs without mutating inherited environment", () => {

--- a/tools/demo-desktop.ts
+++ b/tools/demo-desktop.ts
@@ -13,8 +13,11 @@ interface Command {
 }
 export type Runner = (command: Command) => Promise<string>;
 
-export function parseMode(args: readonly string[]): "interactive" | "prepare" | "help" {
-	if (args.length === 0) return "interactive";
+export function parseMode(
+	args: readonly string[],
+	prepareOnly?: string,
+): "interactive" | "prepare" | "help" {
+	if (args.length === 0) return prepareOnly === "true" ? "prepare" : "interactive";
 	if (args.length === 1 && args[0] === "--prepare-only") return "prepare";
 	if (args.length === 1 && args[0] === "--help") return "help";
 	throw new Error(usage);
@@ -228,7 +231,7 @@ export async function runDemo(demo: Demo, run: Runner = execute): Promise<void> 
 }
 
 async function main(): Promise<void> {
-	const mode = parseMode(process.argv.slice(2));
+	const mode = parseMode(process.argv.slice(2), process.env.usage_prepare_only);
 	if (mode === "help") {
 		console.log(
 			`${usage}\nBuild and install an unsigned native Desktop in a fresh temporary Home.\nDefault: two interactive offline launches. --prepare-only: install without opening a window.\nPrerequisites: initialized submodules, Rust, Bun and native build tools. Builds may use the network.\nArtifacts and logs are retained; existing installations are not changed.`,

--- a/tools/demo-desktop.ts
+++ b/tools/demo-desktop.ts
@@ -1,0 +1,252 @@
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, renameSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const usage = "Usage: mise run demo:desktop -- [--prepare-only | --help]";
+type Environment = Readonly<Record<string, string | undefined>>;
+interface Command {
+	readonly args: readonly string[];
+	readonly cwd: string;
+	readonly env?: Environment;
+	readonly output?: "capture" | "inherit";
+}
+export type Runner = (command: Command) => Promise<string>;
+
+export function parseMode(args: readonly string[]): "interactive" | "prepare" | "help" {
+	if (args.length === 0) return "interactive";
+	if (args.length === 1 && args[0] === "--prepare-only") return "prepare";
+	if (args.length === 1 && args[0] === "--help") return "help";
+	throw new Error(usage);
+}
+
+export function nativePackage(platform: string, arch: string) {
+	if (arch !== "arm64" && arch !== "x64")
+		throw new Error(`Unsupported Desktop demo architecture: ${arch}`);
+	switch (platform) {
+		case "win32":
+			return { flag: "--win", target: "zip", os: "win", arch } as const;
+		case "darwin":
+			return { flag: "--mac", target: "zip", os: "mac", arch } as const;
+		case "linux":
+			return { flag: "--linux", target: "tar.gz", os: "linux", arch } as const;
+		default:
+			throw new Error(`Unsupported Desktop demo platform: ${platform}`);
+	}
+}
+
+export function demoEnvironment(root: string, inherited: Environment): Environment {
+	const env = Object.fromEntries(
+		Object.entries(inherited).filter(
+			([key]) =>
+				!key.toUpperCase().startsWith("MORPHIR_") && key.toUpperCase() !== "ELECTRON_RUN_AS_NODE",
+		),
+	);
+	return {
+		...env,
+		MORPHIR_HOME: path.join(root, "home"),
+		APPDATA: path.join(root, "profile", "appdata"),
+		LOCALAPPDATA: path.join(root, "profile", "local"),
+		XDG_CONFIG_HOME: path.join(root, "profile", "config"),
+	};
+}
+
+function unsignedBuildEnvironment(): Environment {
+	return {
+		...Object.fromEntries(
+			Object.entries(process.env).filter(
+				([key]) =>
+					!key.toUpperCase().startsWith("CSC_") && !key.toUpperCase().startsWith("WIN_CSC_"),
+			),
+		),
+		CSC_IDENTITY_AUTO_DISCOVERY: "false",
+	};
+}
+
+class CommandFailure extends Error {
+	constructor(
+		readonly exitCode: number,
+		args: readonly string[],
+	) {
+		super(`Command exited ${exitCode}: ${args.join(" ")}`);
+	}
+}
+
+export const execute: Runner = async ({ args, cwd, env, output = "inherit" }) => {
+	const child = Bun.spawn([...args], {
+		cwd,
+		env,
+		stdin: "inherit",
+		stderr: "inherit",
+		stdout: output === "capture" ? "pipe" : "inherit",
+	});
+	const stdout = output === "capture" ? await new Response(child.stdout).text() : "";
+	const exitCode = await child.exited;
+	if (exitCode !== 0) throw new CommandFailure(exitCode, args);
+	return stdout;
+};
+
+function builtCli(output: string): string {
+	for (const line of output.split(/\r?\n/).filter(Boolean).reverse()) {
+		const value = JSON.parse(line);
+		if (
+			value.reason === "compiler-artifact" &&
+			value.target?.name === "morphir" &&
+			value.target?.kind?.includes("bin") &&
+			typeof value.executable === "string"
+		)
+			return value.executable;
+	}
+	throw new Error("Cargo did not report a built morphir executable");
+}
+
+interface Demo {
+	readonly root: string;
+	readonly executable: string;
+	readonly workspace: string;
+	readonly packagePath: string;
+	readonly env: Environment;
+}
+
+export async function prepareDemo(
+	options: {
+		readonly repositoryRoot: string;
+		readonly temporaryRoot: string;
+		readonly platform: string;
+		readonly arch: string;
+	},
+	run: Runner = execute,
+): Promise<Demo> {
+	const target = nativePackage(options.platform, options.arch);
+	const ui = path.join(options.repositoryRoot, "ecosystem", "morphir-ui");
+	const app = path.join(ui, "apps", "morphir-desktop");
+	const manifest = JSON.parse(readFileSync(path.join(app, "package.json"), "utf8"));
+	if (
+		typeof manifest.version !== "string" ||
+		!/^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(manifest.version)
+	) {
+		throw new Error("Desktop package.json must contain a valid version");
+	}
+	const root = mkdtempSync(path.join(options.temporaryRoot, "morphir-demo-"));
+	console.log(`Demo files and logs will be retained at: ${root}`);
+	const env = demoEnvironment(root, process.env);
+	for (const directory of [
+		"bin",
+		"home",
+		"workspace",
+		"profile/appdata",
+		"profile/local",
+		"profile/config",
+	]) {
+		mkdirSync(path.join(root, directory), { recursive: true });
+	}
+	const executable = path.join(
+		root,
+		"bin",
+		options.platform === "win32" ? "morphir.exe" : "morphir",
+	);
+	const workspace = path.join(root, "workspace", "morphir-ir.json");
+	copyFileSync(
+		path.join(ui, "packages", "morphir-ir", "test", "fixtures", "insight-ir.json"),
+		workspace,
+	);
+	const compilation = await run({
+		args: [
+			"cargo",
+			"build",
+			"--locked",
+			"-p",
+			"morphir",
+			"--bin",
+			"morphir",
+			"--message-format=json",
+		],
+		cwd: options.repositoryRoot,
+		output: "capture",
+	});
+	copyFileSync(builtCli(compilation), executable);
+	await run({ args: ["bun", "install", "--frozen-lockfile"], cwd: ui });
+	await run({ args: ["bun", "run", "build"], cwd: app });
+	const packages = path.join(root, "package");
+	await run({
+		args: [
+			"bunx",
+			"--no-install",
+			"electron-builder",
+			target.flag,
+			target.target,
+			`--${target.arch}`,
+			"--publish=never",
+			"--config.mac.notarize=false",
+			"--config.extraMetadata.morphirBuildChannel=developer",
+			`--config.directories.output=${packages}`,
+		],
+		cwd: app,
+		env: unsignedBuildEnvironment(),
+	});
+	const packagePath = path.join(
+		packages,
+		`morphir-desktop-${manifest.version}-${target.os}-${target.arch}.${target.target}`,
+	);
+	await run({
+		args: [
+			executable,
+			"tool",
+			"install",
+			"desktop",
+			"--source",
+			packagePath,
+			"--channel",
+			"developer",
+			"--version",
+			manifest.version,
+		],
+		cwd: root,
+		env,
+	});
+	return { root, executable, workspace, packagePath, env };
+}
+
+export async function runDemo(demo: Demo, run: Runner = execute): Promise<void> {
+	const command = {
+		args: [demo.executable, "desktop", "--offline", "--wait", demo.workspace],
+		cwd: demo.root,
+		env: demo.env,
+	};
+	console.log(
+		"First launch: select applyLambda and inspect Insight/XRay. Close Desktop to continue.",
+	);
+	await run(command);
+	// Move only the package generated in this fresh demo directory; never delete user data.
+	renameSync(demo.packagePath, path.join(demo.root, "package.saved"));
+	console.log(
+		"Second launch: original package path is absent. Inspect the model, then close Desktop.",
+	);
+	await run(command);
+	console.log(`Both commands exited successfully. Logs: ${path.join(demo.root, "home", "logs")}`);
+	console.log("This demo does not block networking or make the source checkout unreadable.");
+}
+
+async function main(): Promise<void> {
+	const mode = parseMode(process.argv.slice(2));
+	if (mode === "help") {
+		console.log(
+			`${usage}\nBuild and install an unsigned native Desktop in a fresh temporary Home.\nDefault: two interactive offline launches. --prepare-only: install without opening a window.\nPrerequisites: initialized submodules, Rust, Bun and native build tools. Builds may use the network.\nArtifacts and logs are retained; existing installations are not changed.`,
+		);
+		return;
+	}
+	const demo = await prepareDemo({
+		repositoryRoot: path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."),
+		temporaryRoot: tmpdir(),
+		platform: process.platform,
+		arch: process.arch,
+	});
+	if (mode === "interactive") await runDemo(demo);
+}
+
+if (import.meta.main) {
+	main().catch((error: unknown) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = error instanceof CommandFailure ? error.exitCode : 1;
+	});
+}

--- a/tools/demo-desktop.ts
+++ b/tools/demo-desktop.ts
@@ -214,7 +214,7 @@ export async function runDemo(demo: Demo, run: Runner = execute): Promise<void> 
 		env: demo.env,
 	};
 	console.log(
-		"First launch: select applyLambda and inspect Insight/XRay. Close Desktop to continue.",
+		"First launch: open IR Explorer, select applyLambda and inspect Insight/XRay. Close Desktop to continue.",
 	);
 	await run(command);
 	// Move only the package generated in this fresh demo directory; never delete user data.


### PR DESCRIPTION
## Summary

Land the parent fixes from the real installed Desktop demo for #758, tracked as morphir-ds9e.3.2.

- Match the actual Windows and macOS package executable names.
- Handle Chromium's Windows executable-path limit using an existing short filename, verified against the installed executable, or report a shorter MORPHIR_HOME remedy.
- Advance morphir-ui to 5bc7531, including finos/morphir-ui#31's bundled workspace dependencies, Windows manifest and IPC fixes.
- Add `mise run demo:desktop`, a native Bun task that builds the CLI and unsigned Desktop, installs into a fresh temporary Home, copies the Insight model, and launches twice offline with normal-exit waits. The original package is moved aside before the second launch. No existing installation is changed or removed.
- Add `--prepare-only`, orchestration tests and Windows/Linux CI coverage, plus user-facing instructions.

## Validation

- 268 parent unit tests and 60 CLI integration tests pass; two existing external-tool cases are covered by CI.
- Strict Clippy, Rust formatting, tools typecheck, 9 demo tests and 26 workflow tests pass.
- The real mise task passed end to end on Windows ARM64: both installed-GUI launches rendered Insight and XRay, reported correlated readiness, and exited 0. The second succeeded with the original package ZIP absent.
- UI PR #31 passed its own full CI and Windows/macOS/Linux packaging before landing.

The demo uses offline CLI mode and runs outside the checkout. It does not claim OS-enforced network blocking or source-checkout isolation. This PR does not close the stronger isolation acceptance or include the combined extension demo.