### PR TITLE
fix(cli): install native Linux Desktop tarballs

### DIFF
--- a/crates/morphir/src/commands/tool.rs
+++ b/crates/morphir/src/commands/tool.rs
@@ -213,7 +213,7 @@ fn desktop_package(
     version: Version,
     platform: Platform,
 ) -> Result<LocalDeveloperToolPackage> {
-    let (format, entry_point) = desktop_archive_contract(&source, platform.os())?;
+    let (format, entry_point) = desktop_archive_contract(&source, &platform, &version)?;
     LocalDeveloperToolPackage::new(
         source,
         ToolId::parse("desktop").into_diagnostic()?,
@@ -227,13 +227,17 @@ fn desktop_package(
     .into_diagnostic()
 }
 
-fn desktop_archive_contract(source: &Path, os: &str) -> Result<(ArchiveFormat, String)> {
+fn desktop_archive_contract(
+    source: &Path,
+    platform: &Platform,
+    version: &Version,
+) -> Result<(ArchiveFormat, String)> {
     let filename = source
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| miette!("Desktop package source must have a UTF-8 filename"))?;
     let lowercase = filename.to_ascii_lowercase();
-    match os {
+    match platform.os() {
         "windows" if lowercase.ends_with(".zip") => {
             Ok((ArchiveFormat::Zip, "morphir-desktop.exe".to_owned()))
         }
@@ -245,7 +249,17 @@ fn desktop_archive_contract(source: &Path, os: &str) -> Result<(ArchiveFormat, S
             "Morphir Desktop.app/Contents/MacOS/morphir-desktop".to_owned(),
         )),
         "linux" if lowercase.ends_with(".tar.gz") => {
-            Ok((ArchiveFormat::TarGzip, "morphir-desktop".to_owned()))
+            let arch = match platform.arch() {
+                "aarch64" => "arm64",
+                "x86_64" => "x64",
+                other => return Err(miette!("Unsupported Linux Desktop architecture: {other}")),
+            };
+            // electron-builder prefixes tar entries with its original artifact stem.
+            // Derive it from package identity, not the potentially renamed download.
+            Ok((
+                ArchiveFormat::TarGzip,
+                format!("morphir-desktop-{version}-linux-{arch}/morphir-desktop"),
+            ))
         }
         "linux" if lowercase.ends_with(".appimage") => {
             Ok((ArchiveFormat::Appimage, filename.to_owned()))
@@ -254,8 +268,8 @@ fn desktop_archive_contract(source: &Path, os: &str) -> Result<(ArchiveFormat, S
         _ => Err(miette!(
             "Unsupported Desktop package '{}' for host platform {}-{}",
             source.display(),
-            os,
-            std::env::consts::ARCH
+            platform.os(),
+            platform.arch()
         )),
     }
 }
@@ -285,14 +299,22 @@ fn provenance_labels(provenance: &ToolProvenance) -> (&'static str, &'static str
 mod tests {
     use super::*;
 
+    fn contract(source: &Path, os: &str) -> Result<(ArchiveFormat, String)> {
+        desktop_archive_contract(
+            source,
+            &Platform::new(os, "x86_64").unwrap(),
+            &Version::new(0, 1, 0),
+        )
+    }
+
     #[test]
     fn desktop_archives_use_the_release_contract_entry_points() {
         assert_eq!(
-            desktop_archive_contract(Path::new("desktop.zip"), "windows").unwrap(),
+            contract(Path::new("desktop.zip"), "windows").unwrap(),
             (ArchiveFormat::Zip, "morphir-desktop.exe".to_owned())
         );
         assert_eq!(
-            desktop_archive_contract(Path::new("desktop.zip"), "macos").unwrap(),
+            contract(Path::new("desktop.zip"), "macos").unwrap(),
             (
                 ArchiveFormat::Zip,
                 "Morphir Desktop.app/Contents/MacOS/morphir-desktop".to_owned(),
@@ -304,19 +326,40 @@ mod tests {
     fn versioned_linux_appimage_uses_its_own_filename_as_the_entry_point() {
         let filename = "morphir-desktop-0.1.0-linux-arm64.AppImage";
         assert_eq!(
-            desktop_archive_contract(Path::new(filename), "linux").unwrap(),
+            contract(Path::new(filename), "linux").unwrap(),
             (ArchiveFormat::Appimage, filename.to_owned())
         );
+    }
+
+    #[test]
+    fn linux_tarball_uses_electron_builders_archive_root() {
+        for (version, arch, builder_arch) in [
+            ("0.1.0", "aarch64", "arm64"),
+            ("1.2.3-preview.4", "x86_64", "x64"),
+        ] {
+            let stem = format!("morphir-desktop-{version}-linux-{builder_arch}");
+            for filename in [format!("{stem}.tar.gz"), "renamed.tar.gz".to_owned()] {
+                assert_eq!(
+                    desktop_archive_contract(
+                        Path::new(&filename),
+                        &Platform::new("linux", arch).unwrap(),
+                        &version.parse().unwrap(),
+                    )
+                    .unwrap(),
+                    (ArchiveFormat::TarGzip, format!("{stem}/morphir-desktop"))
+                );
+            }
+        }
     }
 
     #[test]
     fn windows_raw_packages_accept_the_release_name_and_legacy_fixture_name() {
         for filename in ["morphir-desktop.exe", "Morphir Desktop.exe"] {
             assert_eq!(
-                desktop_archive_contract(Path::new(filename), "windows").unwrap(),
+                contract(Path::new(filename), "windows").unwrap(),
                 (ArchiveFormat::Raw, filename.to_owned())
             );
         }
-        assert!(desktop_archive_contract(Path::new("unrelated.exe"), "windows").is_err());
+        assert!(contract(Path::new("unrelated.exe"), "windows").is_err());
     }
 }

--- a/crates/morphir/tests/cli_integration.rs
+++ b/crates/morphir/tests/cli_integration.rs
@@ -124,6 +124,33 @@ fn build_desktop_launch_fixture(fixture_root: &std::path::Path) -> PathBuf {
         archive.finish().unwrap();
         std::fs::remove_file(compiled_executable).unwrap();
         package
+    } else if cfg!(target_os = "linux") {
+        let arch = match std::env::consts::ARCH {
+            "aarch64" => "arm64",
+            "x86_64" => "x64",
+            other => panic!("Unsupported Desktop fixture architecture: {other}"),
+        };
+        let archive_root = format!("morphir-desktop-0.1.0-linux-{arch}");
+        let contents = fixture_root.join(&archive_root);
+        std::fs::create_dir(&contents).unwrap();
+        std::fs::rename(&compiled_executable, contents.join(executable_name)).unwrap();
+        // Match electron-builder's tar layout, including a renamed download.
+        let package = fixture_root.join("renamed-desktop-fixture.tar.gz");
+        let packed = std::process::Command::new("tar")
+            .arg("-czf")
+            .arg(&package)
+            .arg("-C")
+            .arg(fixture_root)
+            .arg(&archive_root)
+            .output()
+            .expect("failed to package Linux Desktop fixture with tar");
+        assert!(
+            packed.status.success(),
+            "{}",
+            String::from_utf8_lossy(&packed.stderr)
+        );
+        std::fs::remove_dir_all(contents).unwrap();
+        package
     } else {
         compiled_executable
     }


### PR DESCRIPTION
## Summary

Finish the installed Desktop acceptance work for `morphir-ds9e.3.2`.

Real Linux packaging exposed a missing-executable failure: electron-builder wraps tar entries in
`morphir-desktop-<version>-linux-<arch>/`, while local installation declared a root-level executable.
Derive the correct path from the validated version and target platform, not the downloaded
filename. This supports renamed archives, ARM64, x64, and preview versions.

Linux lifecycle integration fixtures now use the real tar directory layout and a renamed archive
instead of a raw executable. Companion UI release metadata received the same correction in
https://github.com/finos/morphir-ui/pull/33, now landed and pinned here at
`92d5471a9ceda5d771a8d17ed5cc1a4c2c1aec20`. The Bun TypeScript demo remains unchanged.

## Verification

- Regression failed before the fix on native Windows and Linux.
- Native Windows: 279 unit tests, 60 CLI integration tests, strict Clippy and formatting passed;
  2 existing external-tool integration cases ignored locally.
- Linux ARM64: 297 unit tests and 9 Desktop-focused integration tests passed.
- 9 Bun demo orchestration tests passed.
- `bun run tools/demo-desktop.ts --prepare-only` built, packaged and installed a real Linux
  ARM64 Desktop successfully using the corrected CLI.
- Earlier native Windows ARM64 demo passed both interactive launches with normal exit 0.
- After rebasing onto main `3147cd41` and aligning its Rust submodule pin, native unit tests,
  all 60 enabled CLI integration tests, and strict all-target Clippy passed again.

## Real isolated acceptance

The installed Linux ARM64 Desktop passed two GUI launches using `morphir desktop --offline --wait`.
Each displayed the selected sample model and `applyLambda` in Insight and XRay, then closed
normally with exit 0.

Bubblewrap mounted only installed files, the sample model, system libraries/configuration and
the WSLg display socket. The checkout, build snapshot and original package were not mounted.
A new network namespace had no routes. Positive host file/TCP controls succeeded; isolated
controls failed. Running Desktop process audits confirmed the same isolation. Electron's
sandbox was not disabled and no global network/security setting was changed.

Package SHA-256: `504a9305eb867ead794c79757d35d573e9e4c6366afecb828d9e271bf3f4f04e`, 71 verified files.

- First: `op-8b4ccc92-539f-4e48-95d9-c09153909efd`, `launch-e0077078-b36e-4369-83eb-40e0cb6181bd`.
- Repeat: `op-29cef130-5b6d-4fbb-9c1f-e2a2860c70af`, `launch-2a257dfb-4856-48b7-b5c7-263046d2b669`.

Both CLI and Desktop logs contain matching ready and exit records. Strict isolation was tested
on Linux under WSL2; native Windows GUI acceptance is separate evidence.

No follow-up story was created to defer a defect from this task.
