### PR TITLE
IR v4: implement decision records 0004 to 0014 (kit, schemas, examples, spec, codec pin)

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -152,6 +152,10 @@ run = [
     "jsonschema validate spec/ir/mck/report.schema.json spec/ir/mck/report.example.json",
 ]
 
+[tasks."mck:schema-check"]
+description = "Validate every accepted MCK JSON fence against the v4 schema"
+run = "bun run tools/validate-mck-fences.ts"
+
 [tasks."hooks:install"]
 description = "Activate the checked-in git hooks in .husky"
 run = "bun run tools/install-git-hooks.ts"
@@ -213,6 +217,7 @@ depends = [
     "fixtures:naming-corpus-check",
     "schema:validate",
     "mck:check",
+    "mck:schema-check",
 ]
 
 # ===== Testing Tasks =====

--- a/.config/mise/tasks/examples/validate.py
+++ b/.config/mise/tasks/examples/validate.py
@@ -125,6 +125,14 @@ def validate_file(
 
 def main() -> int:
     """Main entry point."""
+    # The status markers below are non-ASCII. On Windows the console's default
+    # code page (cp1252) cannot encode them, which crashes the script instead
+    # of reporting validation results. Force UTF-8 output where supported.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
     verbose = "--verbose" in sys.argv or "-v" in sys.argv
     json_output = "--json" in sys.argv
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
               - '.github/workflows/ci.yml'
             mck:
               - 'spec/ir/mck/**'
+              # checks every kit fence against the v4 JSON Schemas
+              - 'tools/validate-mck-fences.ts'
               - 'ecosystem/morphir-typescript'
               # the Gleam mirror is checked by the mck driver once its adapter
               # lands; routing its pointer bumps here keeps them from skipping
@@ -424,6 +426,9 @@ jobs:
 
       - name: Check the Morphir Compatibility Kit
         run: mise run mck:check
+
+      - name: Check kit fences against the v4 schemas
+        run: mise run mck:schema-check
 
   release-workflow:
     name: Release workflow

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,7 +23,6 @@
 [submodule "ecosystem/morphir-typescript"]
 	path = ecosystem/morphir-typescript
 	url = https://github.com/finos/morphir-typescript.git
-	branch = ir-v4-decisions-codec
 [submodule "ecosystem/morphir-gleam"]
 	path = ecosystem/morphir-gleam
 	url = https://github.com/finos/morphir-gleam.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -23,6 +23,7 @@
 [submodule "ecosystem/morphir-typescript"]
 	path = ecosystem/morphir-typescript
 	url = https://github.com/finos/morphir-typescript.git
+	branch = ir-v4-decisions-codec
 [submodule "ecosystem/morphir-gleam"]
 	path = ecosystem/morphir-gleam
 	url = https://github.com/finos/morphir-gleam.git

--- a/docs/design/draft/ir/README.md
+++ b/docs/design/draft/ir/README.md
@@ -59,10 +59,10 @@ This specification is organized into the following sections:
 | [Modules](./modules.md) | Draft | Module structure, documentation, and serialization |
 | [Packages](./packages.md) | Draft | Package specifications and definitions |
 | [Distributions](./distributions.md) | Draft | Distribution types, semantic versioning, and VFS layout |
-| [Decorations](./decorations.md) | Partial | Layered metadata system for IR annotations |
-| [Document](./document.md) | Draft | Schema-less JSON-like data type |
-| [Metadata](./meta.md) | Draft | File-level metadata (`$meta`) |
-| [References](./refs.md) | Draft | Node references (`$ref`) for deduplication |
+| [Decorations](./decorations.md) | Out of 4.0.0 (decision 0014) | Layered metadata system for IR annotations |
+| [Document](./document.md) | In 4.0.0 (decision 0013) | Schema-less JSON-like data type |
+| [Metadata](./meta.md) | Out of 4.0.0 (decision 0014) | File-level metadata (`$meta`) |
+| [References](./refs.md) | Out of 4.0.0 (decision 0014) | Node references (`$ref`) for deduplication |
 
 For process and WASM extension runtimes, MEP, and verified installation, see
 [Extensions](../extensions/README.mdx).
@@ -130,7 +130,7 @@ The VFS mode uses **one file per definition**:
 .morphir-dist/
 ├── manifest.json          # Distribution metadata and format version
 ├── morphir.toml           # Project-level configuration
-├── session.jsonl          # Append-only transaction journal (design only; not in the spec or schema)
+├── session.jsonl          # Append-only transaction journal (design only; not in the spec or schema; out of the IR per decision 0014)
 ├── pkg/                   # Local project IR (Namespace-to-Directory)
 │   └── my-org/
 │       └── my-project/
@@ -142,10 +142,10 @@ The VFS mode uses **one file per definition**:
 │       └── sdk/
 │           └── 1.2.0/
 │               └── ...
-└── deco/                  # Decorations (layered metadata)
-    ├── format.json            # Decoration system metadata
-    ├── schemas/               # Local schema cache
-    └── layers/                # Decoration layers (core, tooling, user)
+└── deco/                  # Decorations (layered metadata) (out of 4.0.0)
+    ├── format.json            # Decoration system metadata (out of 4.0.0)
+    ├── schemas/               # Local schema cache (out of 4.0.0)
+    └── layers/                # Decoration layers (core, tooling, user) (out of 4.0.0)
 ```
 
 ### VFS File Types
@@ -156,7 +156,7 @@ The VFS mode uses **one file per definition**:
 | `module.json` | Module manifest | Lists types and values in the module |
 | `*.type.json` | Type definition OR specification | TypeDefinition or TypeSpecification |
 | `*.value.json` | Value definition OR specification | ValueDefinition or ValueSpecification |
-| `session.jsonl` | Transaction journal | Append-only log for crash recovery |
+| `session.jsonl` | Transaction journal | Append-only log for crash recovery; out of the IR per decision 0014 |
 
 ### VFS File Polymorphism
 

--- a/docs/design/draft/ir/README.md
+++ b/docs/design/draft/ir/README.md
@@ -139,7 +139,7 @@ The VFS mode uses **one file per definition**:
 │           └── login.value.json
 ├── deps/                  # Dependency IR (versioned)
 │   └── morphir/
-│       └── sdk/
+│       └── _sdk/          # the escaped directory for the SDK package (decision 0011)
 │           └── 1.2.0/
 │               └── ...
 └── deco/                  # Decorations (layered metadata) (out of 4.0.0)

--- a/docs/design/draft/ir/annotations.md
+++ b/docs/design/draft/ir/annotations.md
@@ -43,7 +43,7 @@ For simple annotations, a string format is supported: `fqname:value`.
 | Single Value (1 arg) | `"package:module#name:value"` | FQName followed by colon and value |
 
 **Examples:**
-- `"morphir/sdk:annotations#stable"`
+- `"morphir/SDK:annotations#stable"`
 - `"my-org/sdk:annotations#deprecated:Use new-function instead"`
 - `"my-org/sdk:annotations#version:1.0.0"`
 
@@ -98,13 +98,13 @@ def oldMethod(x: Int): Int = ???
 {
   "annotations": [
     {
-      "name": "morphir/sdk:annotations#deprecated",
+      "name": "morphir/SDK:annotations#deprecated",
       "arguments": [
         { "Literal": { "StringLiteral": "Use newMethod instead" } },
         { "Literal": { "StringLiteral": "2.0.0" } }
       ]
     },
-    "morphir/sdk:annotations#stable"
+    "morphir/SDK:annotations#stable"
   ]
 }
 ```
@@ -191,7 +191,7 @@ Annotations are only supported on **Specification** types in Morphir IR v4.
       { "name": "my-org/sdk:annotations#json-name", "arguments": [{ "Literal": { "StringLiteral": "user_id" } }] }
     ],
     "typeParams": [],
-    "typeExp": "morphir/sdk:string#string"
+    "typeExp": "morphir/SDK:string#string"
   }
 }
 ```

--- a/docs/design/draft/ir/attributes.mdx
+++ b/docs/design/draft/ir/attributes.mdx
@@ -563,13 +563,13 @@ Attributes are serialized with omission of empty/None fields for compactness:
 
 ```json
 // Minimal (all defaults)
-{ "Reference": { "fqname": "morphir/sdk:basics#int" } }
+{ "Reference": { "fqname": "morphir/SDK:basics#int" } }
 
 // With source location only
 {
   "Reference": {
     "attributes": { "source": { "file": "src/Domain.elm", "line": 42, "col": 5 } },
-    "fqname": "morphir/sdk:basics#int"
+    "fqname": "morphir/SDK:basics#int"
   }
 }
 
@@ -581,7 +581,7 @@ Attributes are serialized with omission of empty/None fields for compactness:
         "numeric": { "Signed": { "bits": 32 } }
       }
     },
-    "fqname": "morphir/sdk:int#int32"
+    "fqname": "morphir/SDK:int#int32"
   }
 }
 
@@ -593,7 +593,7 @@ Attributes are serialized with omission of empty/None fields for compactness:
         "numeric": { "Bounded": { "min": 0, "max": 100 } }
       }
     },
-    "fqname": "morphir/sdk:basics#int"
+    "fqname": "morphir/SDK:basics#int"
   }
 }
 ```

--- a/docs/design/draft/ir/decorations.md
+++ b/docs/design/draft/ir/decorations.md
@@ -6,6 +6,8 @@ sidebar_position: 8
 
 # Decorations
 
+> **Status:** Out of v4.0.0 (decision 0014); returns as its own design with a specified merge algebra the kit can pin.
+
 Decorations provide a way to attach additional metadata to IR nodes without modifying the core IR structure. They are stored separately from the IR in a layered, composable system.
 
 ## Design Principles

--- a/docs/design/draft/ir/distributions.md
+++ b/docs/design/draft/ir/distributions.md
@@ -553,7 +553,7 @@ For Specs distributions (or dependencies), files contain specifications instead 
 
 ### Type Specification File
 
-File: `.morphir-dist/pkg/morphir/sdk/int.type.json`
+File: `.morphir-dist/pkg/morphir/_sdk/int.type.json`
 
 ```json
 {
@@ -568,7 +568,7 @@ File: `.morphir-dist/pkg/morphir/sdk/int.type.json`
 
 ### Value Specification File
 
-File: `.morphir-dist/pkg/morphir/sdk/add.value.json`
+File: `.morphir-dist/pkg/morphir/_sdk/add.value.json`
 
 ```json
 {

--- a/docs/design/draft/ir/distributions.md
+++ b/docs/design/draft/ir/distributions.md
@@ -336,7 +336,7 @@ Single-blob `morphir-ir.json`:
     "Library": {
       "packageName": "my-org/my-project",
       "dependencies": {
-        "morphir/sdk": {
+        "morphir/SDK": {
           "modules": {
             "basics": { "types": { "...": "..." }, "values": { "...": "..." } },
             "string": { "types": { "...": "..." }, "values": { "...": "..." } },
@@ -400,7 +400,7 @@ File: `.morphir-dist/pkg/my-org/domain/user.type.json`
         "Record": {
           "fields": {
             "created-at": { "Reference": { "fqname": "my-org/sdk:local-date-time#local-date-time" } },
-            "email": { "Reference": { "fqname": "morphir/sdk:string#string" } },
+            "email": { "Reference": { "fqname": "morphir/SDK:string#string" } },
             "user-ID": { "Reference": { "fqname": "my-org/domain:types#user-ID" } }
           }
         }
@@ -423,17 +423,17 @@ File: `.morphir-dist/pkg/my-org/domain/get-user-by-email.value.json`
     "value": {
       "ExpressionBody": {
         "inputTypes": {
-          "email": { "Reference": { "fqname": "morphir/sdk:string#string" } },
+          "email": { "Reference": { "fqname": "morphir/SDK:string#string" } },
           "users": {
             "Reference": {
-              "fqname": "morphir/sdk:list#list",
+              "fqname": "morphir/SDK:list#list",
               "args": [{ "Reference": { "fqname": "my-org/domain:types#user" } }]
             }
           }
         },
         "outputType": {
           "Reference": {
-            "fqname": "morphir/sdk:maybe#maybe",
+            "fqname": "morphir/SDK:maybe#maybe",
             "args": [{ "Reference": { "fqname": "my-org/domain:types#user" } }]
           }
         },
@@ -479,7 +479,7 @@ File: `.morphir-dist/manifest.json`
 {
   "formatVersion": "4.0.0",
   "distribution": "Specs",
-  "package": "morphir/sdk",
+  "package": "morphir/SDK",
   "version": "3.0.0",
   "created": "2026-01-15T12:00:00Z"
 }
@@ -580,10 +580,10 @@ File: `.morphir-dist/pkg/morphir/sdk/add.value.json`
       "This is a native operation implemented per-platform."
     ],
     "inputs": {
-      "a": { "Reference": { "fqname": "morphir/sdk:basics#int" } },
-      "b": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+      "a": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
+      "b": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
     },
-    "output": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+    "output": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
   }
 }
 ```

--- a/docs/design/draft/ir/document.md
+++ b/docs/design/draft/ir/document.md
@@ -6,12 +6,14 @@ sidebar_position: 9
 
 # Document Type
 
+> **Status:** In v4.0.0 per [decision 0013](../../../../kb/bundles/morphir/morphir-ir/decisions/0013-document-literal-is-in-v4-with-a-raw-payload.md); the SDK exposes construction, inspection and navigation only (no merge, equality, or ordering).
+
 The Document type provides a first-class, schema-less JSON-like data structure within the Morphir IR for representing untyped or dynamically-typed data.
 
 ## Design Principles
 
 - **Value-Level Concern**: Document is a Literal variant, not a Type variant
-- **SDK Type**: The type is `morphir/sdk:document#document` - a built-in reference
+- **SDK Type**: The type is `morphir/SDK:document#document` - a built-in reference
 - **Platform Native**: Operations are specs-only; backends implement natively
 - **JSON-Compatible**: Structure maps directly to JSON for easy interop
 
@@ -82,7 +84,7 @@ pub type Literal {
 
 ### Type Reference
 
-Document values have the type `morphir/sdk:document#document`:
+Document values have the type `morphir/SDK:document#document`:
 
 ```gleam
 // The Document type is a simple opaque type in the SDK
@@ -91,7 +93,7 @@ Document values have the type `morphir/sdk:document#document`:
 fn document_type() -> Type(a) {
   Reference(
     attributes: default_attributes(),
-    fqname: fqname_from_string("morphir/sdk:document#document"),
+    fqname: fqname_from_string("morphir/SDK:document#document"),
     args: [],
   )
 }
@@ -99,83 +101,15 @@ fn document_type() -> Type(a) {
 
 ## JSON Serialization
 
-### DocumentValue Encoding
+Decision 0013 settled the encoding: the payload of `DocumentLiteral` is the document itself, verbatim. There are no `Doc*` wrappers on the wire and no `{ "value": ... }` spelling, so `{ "DocumentLiteral": { "value": 1 } }` is the one-member document `{"value": 1}`.
 
 ```json
-// DocNull
-{ "DocNull": {} }
-
-// DocBool
-{ "DocBool": true }
-
-// DocInt
-{ "DocInt": 42 }
-
-// DocFloat
-{ "DocFloat": 3.14 }
-
-// DocString
-{ "DocString": "hello" }
-
-// DocArray
-{ "DocArray": [
-    { "DocInt": 1 },
-    { "DocInt": 2 },
-    { "DocInt": 3 }
-  ]
-}
-
-// DocObject
-{ "DocObject": {
-    "name": { "DocString": "Alice" },
-    "age": { "DocInt": 30 },
-    "active": { "DocBool": true }
-  }
-}
+{ "DocumentLiteral": { "name": "Alice", "age": 30, "tags": ["admin", "user"], "metadata": null } }
 ```
 
-### Shorthand Encoding
+Readers preserve number lexemes (`9007199254740993` and `0.10` survive a round trip); a binding that narrows them to a 64-bit float fails kit case `patterns-and-literals-0006`. A `DocumentLiteral` cannot appear in a `LiteralPattern` (`patterns-and-literals-0007`), and a v4 to v3 downgrade of a document refuses with `unsupported_v4_downgrade`.
 
-For compact representation, Document values can use JSON directly when unambiguous:
-
-```json
-// Shorthand (when context is clear)
-{
-  "DocumentLiteral": {
-    "name": "Alice",
-    "age": 30,
-    "tags": ["admin", "user"],
-    "metadata": null
-  }
-}
-
-// Canonical (explicit wrappers)
-{
-  "DocumentLiteral": {
-    "DocObject": {
-      "name": { "DocString": "Alice" },
-      "age": { "DocInt": 30 },
-      "tags": { "DocArray": [
-        { "DocString": "admin" },
-        { "DocString": "user" }
-      ]},
-      "metadata": { "DocNull": {} }
-    }
-  }
-}
-```
-
-### Decoding Rules
-
-| JSON Value | DocumentValue |
-|------------|---------------|
-| `null` | `DocNull` |
-| `true`/`false` | `DocBool` |
-| Integer number | `DocInt` |
-| Floating number | `DocFloat` |
-| String | `DocString` |
-| Array | `DocArray` |
-| Object | `DocObject` |
+The in-memory `DocumentValue` above is one binding's choice of representation; the wire format does not depend on it.
 
 ## SDK Specification
 
@@ -423,16 +357,16 @@ File: `.morphir-dist/pkg/my-org/api/values/parse-response.value.json`
     "value": {
       "ExpressionBody": {
         "inputTypes": {
-          "response": "morphir/sdk:document#document"
+          "response": "morphir/SDK:document#document"
         },
-        "outputType": ["morphir/sdk:maybe#maybe", "my-org/api:types#user"],
+        "outputType": ["morphir/SDK:maybe#maybe", "my-org/api:types#user"],
         "body": {
           "Apply": {
-            "function": { "Reference": { "fqname": "morphir/sdk:maybe#and-then" } },
+            "function": { "Reference": { "fqname": "morphir/SDK:maybe#and-then" } },
             "args": [
               {
                 "Apply": {
-                  "function": { "Reference": { "fqname": "morphir/sdk:document#get" } },
+                  "function": { "Reference": { "fqname": "morphir/SDK:document#get" } },
                   "args": [
                     { "Literal": { "StringLiteral": "data" } },
                     { "Variable": { "name": "response" } }

--- a/docs/design/draft/ir/meta.md
+++ b/docs/design/draft/ir/meta.md
@@ -6,6 +6,8 @@ sidebar_position: 10
 
 # File Metadata ($meta)
 
+> **Status:** Out of v4.0.0; the name `$meta` is reserved and ignored by readers ([decision 0014](../../../../kb/bundles/morphir/morphir-ir/decisions/0014-scope-of-v4-0-0-for-design-only-features.md)).
+
 The `$meta` key provides a standard location for file-level metadata in VFS JSON files without polluting the main schema.
 
 ## Design Principles
@@ -176,8 +178,8 @@ File: `.morphir-dist/pkg/my-org/domain/types/user.type.json`
       "body": {
         "Record": {
           "fields": {
-            "email": "morphir/sdk:string#string",
-            "name": "morphir/sdk:string#string"
+            "email": "morphir/SDK:string#string",
+            "name": "morphir/SDK:string#string"
           }
         }
       }

--- a/docs/design/draft/ir/modules.md
+++ b/docs/design/draft/ir/modules.md
@@ -247,7 +247,7 @@ Public interface of a module (used in dependencies):
         "body": {
           "Record": {
             "fields": {
-              "email": { "Reference": { "fqname": "morphir/sdk:string#string" } },
+              "email": { "Reference": { "fqname": "morphir/SDK:string#string" } },
               "user-ID": { "Reference": { "fqname": "my-org/domain:types#user-ID" } }
             }
           }
@@ -262,9 +262,9 @@ Public interface of a module (used in dependencies):
     "validate-email": {
       "doc": "Check if an email address is valid",
       "inputs": {
-        "email": { "Reference": { "fqname": "morphir/sdk:string#string" } }
+        "email": { "Reference": { "fqname": "morphir/SDK:string#string" } }
       },
-      "output": { "Reference": { "fqname": "morphir/sdk:basics#bool" } }
+      "output": { "Reference": { "fqname": "morphir/SDK:basics#bool" } }
     }
   }
 }
@@ -284,7 +284,7 @@ Full implementation of a module:
         "body": {
           "Record": {
             "fields": {
-              "email": { "Reference": { "fqname": "morphir/sdk:string#string" } },
+              "email": { "Reference": { "fqname": "morphir/SDK:string#string" } },
               "user-ID": { "Reference": { "fqname": "my-org/domain:types#user-ID" } }
             }
           }
@@ -297,9 +297,9 @@ Full implementation of a module:
       "TypeAliasDefinition": {
         "body": {
           "Reference": {
-            "fqname": "morphir/sdk:dict#dict",
+            "fqname": "morphir/SDK:dict#dict",
             "args": [
-              { "Reference": { "fqname": "morphir/sdk:string#string" } },
+              { "Reference": { "fqname": "morphir/SDK:string#string" } },
               { "Reference": { "fqname": "my-org/domain:types#user" } }
             ]
           }
@@ -313,9 +313,9 @@ Full implementation of a module:
       "doc": "Check if an email address is valid",
       "ExpressionBody": {
         "inputTypes": {
-          "email": { "Reference": { "fqname": "morphir/sdk:string#string" } }
+          "email": { "Reference": { "fqname": "morphir/SDK:string#string" } }
         },
-        "outputType": { "Reference": { "fqname": "morphir/sdk:basics#bool" } },
+        "outputType": { "Reference": { "fqname": "morphir/SDK:basics#bool" } },
         "body": { "Variable": { "name": "..." } }
       }
     }

--- a/docs/design/draft/ir/naming.md
+++ b/docs/design/draft/ir/naming.md
@@ -33,7 +33,7 @@ not yet been rewritten.
 Name:    words joined by `-`, abbreviations in `()`    →  value-in-(usd)
 Path:    names joined by `/`                           →  main/domain/orders
 QName:   {module-path}#{local}                         →  main/domain#user-account
-FQName:  {package}:{module}#{local}                    →  morphir/sdk:list#map
+FQName:  {package}:{module}#{local}                    →  morphir/SDK:list#map
 ```
 
 **Abbreviation handling:** Consecutive single-letter words are grouped in parentheses:
@@ -545,9 +545,9 @@ let fqn = FQName(
   module_path(path_unchecked([name_unchecked(["list"])])),
   name_unchecked(["map"]),
 )
-fqname_to_string(fqn)  // "morphir/sdk:list#map"
+fqname_to_string(fqn)  // "morphir/SDK:list#map"
 
-let parsed = fqname_from_string("morphir/sdk:list#map")
+let parsed = fqname_from_string("morphir/SDK:list#map")
 // Ok(fqn) - lossless round-trip
 ```
 
@@ -582,13 +582,13 @@ Path:
   description: "Canonical path: names joined by /"
   examples:
     - "main/domain"
-    - "morphir/sdk"
+    - "morphir/SDK"
 
 FQName:
   type: string
   pattern: "^([a-z0-9]+|\\([a-z0-9]+\\))(-([a-z0-9]+|\\([a-z0-9]+\\)))*(/([a-z0-9]+|\\([a-z0-9]+\\))(-([a-z0-9]+|\\([a-z0-9]+\\)))*)*:([a-z0-9]+|\\([a-z0-9]+\\))(-([a-z0-9]+|\\([a-z0-9]+\\)))*(/([a-z0-9]+|\\([a-z0-9]+\\))(-([a-z0-9]+|\\([a-z0-9]+\\)))*)*#([a-z0-9]+|\\([a-z0-9]+\\))(-([a-z0-9]+|\\([a-z0-9]+\\)))*$"
   description: "Canonical FQName: package:module#name"
   examples:
-    - "morphir/sdk:list#map"
+    - "morphir/SDK:list#map"
     - "my-org/project:main/domain#get-(html)"
 ```

--- a/docs/design/draft/ir/refs.md
+++ b/docs/design/draft/ir/refs.md
@@ -6,6 +6,8 @@ sidebar_position: 11
 
 # Node References ($ref)
 
+> **Status:** Out of v4.0.0 and not reserved (decision 0014): a reader must not need a resolution pass to know what a node means.
+
 The `$ref` mechanism provides structural deduplication within VFS JSON files, reducing repetition of common node patterns.
 
 ## Design Principles
@@ -20,7 +22,7 @@ The `$ref` mechanism provides structural deduplication within VFS JSON files, re
 
 | Mechanism | Purpose | Scope | Example |
 |-----------|---------|-------|---------|
-| **FQName** | Semantic type/value reference | Cross-package | `"morphir/sdk:string#string"` |
+| **FQName** | Semantic type/value reference | Cross-package | `"morphir/SDK:string#string"` |
 | **`$ref`** | Structural deduplication | File-local | `{ "$ref": "user" }` |
 
 These are complementary:
@@ -42,7 +44,7 @@ Reusable nodes are defined in a top-level `$defs` object:
     "date-time": { "Reference": { "fqname": "my-org/sdk:date-time#date-time" } },
     "maybe-user": {
       "Reference": {
-        "fqname": "morphir/sdk:maybe#maybe",
+        "fqname": "morphir/SDK:maybe#maybe",
         "args": [{ "$ref": "user" }]
       }
     }
@@ -160,11 +162,11 @@ pub type FileWithDefs(a) {
             "updated-by": { "Reference": { "fqname": "my-org/domain:types#user" } },
             "updated-at": { "Reference": { "fqname": "my-org/sdk:date-time#date-time" } },
             "deleted-by": { "Reference": {
-              "fqname": "morphir/sdk:maybe#maybe",
+              "fqname": "morphir/SDK:maybe#maybe",
               "args": [{ "Reference": { "fqname": "my-org/domain:types#user" } }]
             } },
             "deleted-at": { "Reference": {
-              "fqname": "morphir/sdk:maybe#maybe",
+              "fqname": "morphir/SDK:maybe#maybe",
               "args": [{ "Reference": { "fqname": "my-org/sdk:date-time#date-time" } }]
             } }
           }
@@ -184,11 +186,11 @@ pub type FileWithDefs(a) {
     "user": { "Reference": { "fqname": "my-org/domain:types#user" } },
     "date-time": { "Reference": { "fqname": "my-org/sdk:date-time#date-time" } },
     "maybe-user": { "Reference": {
-      "fqname": "morphir/sdk:maybe#maybe",
+      "fqname": "morphir/SDK:maybe#maybe",
       "args": [{ "$ref": "user" }]
     } },
     "maybe-date-time": { "Reference": {
-      "fqname": "morphir/sdk:maybe#maybe",
+      "fqname": "morphir/SDK:maybe#maybe",
       "args": [{ "$ref": "date-time" }]
     } }
   },
@@ -226,7 +228,7 @@ pub type FileWithDefs(a) {
     },
     "validation-error": {
       "Apply": {
-        "function": { "Reference": { "fqname": "morphir/sdk:result#err" } },
+        "function": { "Reference": { "fqname": "morphir/SDK:result#err" } },
         "args": [{ "Literal": { "StringLiteral": "Validation failed" } }]
       }
     }
@@ -255,16 +257,16 @@ References can reference other definitions:
 ```json
 {
   "$defs": {
-    "string": { "Reference": { "fqname": "morphir/sdk:string#string" } },
+    "string": { "Reference": { "fqname": "morphir/SDK:string#string" } },
     "list-of-string": {
       "Reference": {
-        "fqname": "morphir/sdk:list#list",
+        "fqname": "morphir/SDK:list#list",
         "args": [{ "$ref": "string" }]
       }
     },
     "maybe-list-of-string": {
       "Reference": {
-        "fqname": "morphir/sdk:maybe#maybe",
+        "fqname": "morphir/SDK:maybe#maybe",
         "args": [{ "$ref": "list-of-string" }]
       }
     }
@@ -345,7 +347,7 @@ This is an optimization - files can be written fully expanded.
 {
   "$defs": {
     "user": "my-org/domain:types#user",
-    "list-of-users": ["morphir/sdk:list#list", { "$ref": "user" }]
+    "list-of-users": ["morphir/SDK:list#list", { "$ref": "user" }]
   },
   "def": {
     "TypeAliasDefinition": {
@@ -371,7 +373,7 @@ This is an optimization - files can be written fully expanded.
   "formatVersion": "4.0.0",
   "name": "user",
   "$meta": { "source": "src/User.elm", "compiler": "morphir-elm 3.0.0" },
-  "$defs": { "string": "morphir/sdk:string#string" },
+  "$defs": { "string": "morphir/SDK:string#string" },
   "def": { ... }
 }
 ```

--- a/docs/design/draft/ir/types.md
+++ b/docs/design/draft/ir/types.md
@@ -434,16 +434,27 @@ Decoding also accepts the legacy array format for backwards compatibility:
 
 ```json
 // shorthand
-{ "Function": { "arg": "morphir/SDK:basics#int", "result": "morphir/SDK:string#string" } }
+{
+  "Function": {
+    "parameterType": "morphir/SDK:basics#int",
+    "returnType": "morphir/SDK:string#string"
+  }
+}
 
 // canonical
 {
   "Function": {
-    "arg": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
-    "result": { "Reference": { "fqname": "morphir/SDK:string#string" } }
+    "parameterType": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
+    "returnType": { "Reference": { "fqname": "morphir/SDK:string#string" } }
   }
 }
 ```
+
+:::note
+`parameterType` and `returnType` are the canonical member names (decision 0007).
+The spellings `arg`/`result` and `argumentType` are legacy. A reader accepts them
+for one release, reports a warning, and normalizes them to the canonical names.
+:::
 
 ### Unit
 

--- a/docs/design/draft/ir/types.md
+++ b/docs/design/draft/ir/types.md
@@ -47,13 +47,13 @@ V4 follows a **permissive input, canonical output** policy. Decoders accept mult
 **Examples:**
 ```json
 // Canonical (encoders should output this)
-{ "Public": { "TypeAliasDefinition": { "body": "morphir/sdk:string#string" } } }
+{ "Public": { "TypeAliasDefinition": { "body": "morphir/SDK:string#string" } } }
 { "Private": { "CustomTypeDefinition": { "params": [], "constructors": {} } } }
 
 // Accepted alternatives
-{ "pub": { "TypeAliasDefinition": { "body": "morphir/sdk:string#string" } } }
-{ "public": { "TypeAliasDefinition": { "body": "morphir/sdk:string#string" } } }
-{ "access": "Public", "value": { "TypeAliasDefinition": { "body": "morphir/sdk:string#string" } } }
+{ "pub": { "TypeAliasDefinition": { "body": "morphir/SDK:string#string" } } }
+{ "public": { "TypeAliasDefinition": { "body": "morphir/SDK:string#string" } } }
+{ "access": "Public", "value": { "TypeAliasDefinition": { "body": "morphir/SDK:string#string" } } }
 ```
 
 ## Type Expressions
@@ -222,9 +222,9 @@ For compact, readable IRs, type expressions support shorthand forms when attribu
 
 | Form | Interpretation | Disambiguation |
 |------|----------------|----------------|
-| `"morphir/sdk:basics#int"` | Type.Reference (no args) | Contains `:` and `#` → FQName |
+| `"morphir/SDK:basics#int"` | Type.Reference (no args) | Contains `:` and `#` → FQName |
 | `"a"` | Type.Variable | No `:` or `#` → variable name |
-| `["morphir/sdk:list#list", ...]` | Type.Reference with args | Array → parameterized type |
+| `["morphir/SDK:list#list", ...]` | Type.Reference with args | Array → parameterized type |
 
 #### Disambiguation Logic
 
@@ -247,26 +247,26 @@ else if object:
 { "Variable": { "name": "a" } }        // canonical
 
 // Simple reference (no type args)
-"morphir/sdk:basics#int"                           // shorthand
-{ "Reference": { "fqname": "morphir/sdk:basics#int" } }  // canonical
+"morphir/SDK:basics#int"                           // shorthand
+{ "Reference": { "fqname": "morphir/SDK:basics#int" } }  // canonical
 
 // Parameterized type: List Int
-["morphir/sdk:list#list", "morphir/sdk:basics#int"]      // shorthand
+["morphir/SDK:list#list", "morphir/SDK:basics#int"]      // shorthand
 {
   "Reference": {
-    "fqname": "morphir/sdk:list#list",
-    "args": [{ "Reference": { "fqname": "morphir/sdk:basics#int" } }]
+    "fqname": "morphir/SDK:list#list",
+    "args": [{ "Reference": { "fqname": "morphir/SDK:basics#int" } }]
   }
 }  // canonical
 
 // Parameterized type: Dict String Int
-["morphir/sdk:dict#dict", "morphir/sdk:string#string", "morphir/sdk:basics#int"]
+["morphir/SDK:dict#dict", "morphir/SDK:string#string", "morphir/SDK:basics#int"]
 
 // Nested: List (Maybe Int)
-["morphir/sdk:list#list", ["morphir/sdk:maybe#maybe", "morphir/sdk:basics#int"]]
+["morphir/SDK:list#list", ["morphir/SDK:maybe#maybe", "morphir/SDK:basics#int"]]
 
 // Mixed: Result String a (variable as type arg)
-["morphir/sdk:result#result", "morphir/sdk:string#string", "a"]
+["morphir/SDK:result#result", "morphir/SDK:string#string", "a"]
 ```
 
 #### Encoding/Decoding Rules
@@ -301,17 +301,17 @@ V4 follows a **permissive input, canonical output** policy for Reference types.
 
 | Format | Example | Notes |
 |--------|---------|-------|
-| **Canonical** | `"morphir/sdk:basics#int"` | Bare FQName string |
-| Wrapper with FQName | `{ "Reference": "morphir/sdk:basics#int" }` | Accepted |
-| Wrapper with object | `{ "Reference": { "fqname": "morphir/sdk:basics#int" } }` | Expanded form |
+| **Canonical** | `"morphir/SDK:basics#int"` | Bare FQName string |
+| Wrapper with FQName | `{ "Reference": "morphir/SDK:basics#int" }` | Accepted |
+| Wrapper with object | `{ "Reference": { "fqname": "morphir/SDK:basics#int" } }` | Expanded form |
 
 ```json
 // Canonical (encoders should output this)
-"morphir/sdk:basics#int"
+"morphir/SDK:basics#int"
 
 // Accepted alternatives
-{ "Reference": "morphir/sdk:basics#int" }
-{ "Reference": { "fqname": "morphir/sdk:basics#int" } }
+{ "Reference": "morphir/SDK:basics#int" }
+{ "Reference": { "fqname": "morphir/SDK:basics#int" } }
 ```
 
 #### With Type Arguments
@@ -322,23 +322,23 @@ V4 follows a **permissive input, canonical output** policy for Reference types.
 | Wrapper with object | `{ "Reference": { "fqname": "...", "args": [...] } }` | Expanded form |
 
 :::warning
-Bare arrays (e.g., `["morphir/sdk:list#list", "a"]`) are **NOT** allowed for Reference at the top level—this would conflict with TupleType which uses bare arrays.
+Bare arrays (e.g., `["morphir/SDK:list#list", "a"]`) are **NOT** allowed for Reference at the top level—this would conflict with TupleType which uses bare arrays.
 :::
 
 ```json
 // Canonical (encoders should output this for types with args)
-{ "Reference": ["morphir/sdk:list#list", "morphir/sdk:basics#int"] }
+{ "Reference": ["morphir/SDK:list#list", "morphir/SDK:basics#int"] }
 
 // Expanded form (accepted)
 {
   "Reference": {
-    "fqname": "morphir/sdk:list#list",
-    "args": ["morphir/sdk:basics#int"]
+    "fqname": "morphir/SDK:list#list",
+    "args": ["morphir/SDK:basics#int"]
   }
 }
 
 // Dict String Int
-{ "Reference": ["morphir/sdk:dict#dict", "morphir/sdk:string#string", "morphir/sdk:basics#int"] }
+{ "Reference": ["morphir/SDK:dict#dict", "morphir/SDK:string#string", "morphir/SDK:basics#int"] }
 ```
 
 ### Tuple (TupleType)
@@ -357,20 +357,20 @@ Bare arrays are unambiguous for TupleType because ReferenceType does **not** all
 
 ```json
 // Bare array (most compact, accepted)
-["morphir/sdk:basics#int", "morphir/sdk:string#string"]
+["morphir/SDK:basics#int", "morphir/SDK:string#string"]
 
 // Canonical (encoders should output this)
-{ "Tuple": ["morphir/sdk:basics#int", "morphir/sdk:string#string"] }
+{ "Tuple": ["morphir/SDK:basics#int", "morphir/SDK:string#string"] }
 
 // Expanded form (accepted)
 {
   "Tuple": {
-    "elements": ["morphir/sdk:basics#int", "morphir/sdk:string#string"]
+    "elements": ["morphir/SDK:basics#int", "morphir/SDK:string#string"]
   }
 }
 
 // With nested types
-{ "Tuple": ["a", "b", ["morphir/sdk:list#list", "c"]] }
+{ "Tuple": ["a", "b", ["morphir/SDK:list#list", "c"]] }
 ```
 
 ### Record
@@ -382,8 +382,8 @@ Field names as object keys, values are the field types:
 {
   "Record": {
     "fields": {
-      "user-name": "morphir/sdk:string#string",
-      "age": "morphir/sdk:basics#int"
+      "user-name": "morphir/SDK:string#string",
+      "age": "morphir/SDK:basics#int"
     }
   }
 }
@@ -392,8 +392,8 @@ Field names as object keys, values are the field types:
 {
   "Record": {
     "fields": {
-      "user-name": { "Reference": { "fqname": "morphir/sdk:string#string" } },
-      "age": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+      "user-name": { "Reference": { "fqname": "morphir/SDK:string#string" } },
+      "age": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
     }
   }
 }
@@ -407,7 +407,7 @@ Field names as object keys, values are the field types:
   "ExtensibleRecord": {
     "variable": "a",
     "fields": {
-      "name": "morphir/sdk:string#string"
+      "name": "morphir/SDK:string#string"
     }
   }
 }
@@ -417,7 +417,7 @@ Field names as object keys, values are the field types:
   "ExtensibleRecord": {
     "variable": "a",
     "fields": {
-      "name": { "Reference": { "fqname": "morphir/sdk:string#string" } }
+      "name": { "Reference": { "fqname": "morphir/SDK:string#string" } }
     }
   }
 }
@@ -434,13 +434,13 @@ Decoding also accepts the legacy array format for backwards compatibility:
 
 ```json
 // shorthand
-{ "Function": { "arg": "morphir/sdk:basics#int", "result": "morphir/sdk:string#string" } }
+{ "Function": { "arg": "morphir/SDK:basics#int", "result": "morphir/SDK:string#string" } }
 
 // canonical
 {
   "Function": {
-    "arg": { "Reference": { "fqname": "morphir/sdk:basics#int" } },
-    "result": { "Reference": { "fqname": "morphir/sdk:string#string" } }
+    "arg": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
+    "result": { "Reference": { "fqname": "morphir/SDK:string#string" } }
   }
 }
 ```
@@ -479,7 +479,7 @@ Decoding also accepts the legacy array format for backwards compatibility:
 ```json
 {
   "TypeAliasDefinition": {
-    "body": { "Reference": { "fqname": "morphir/sdk:string#string" } }
+    "body": { "Reference": { "fqname": "morphir/SDK:string#string" } }
   }
 }
 ```
@@ -509,7 +509,7 @@ Decoding also accepts the legacy array format for backwards compatibility:
 {
   "DerivedTypeSpecification": {
     "details": {
-      "baseType": { "Reference": { "fqname": "morphir/sdk:string#string" } },
+      "baseType": { "Reference": { "fqname": "morphir/SDK:string#string" } },
       "fromBaseType": "my-org/sdk:local-date#from-string",
       "toBaseType": "my-org/sdk:local-date#to-string"
     }

--- a/docs/design/draft/ir/values.md
+++ b/docs/design/draft/ir/values.md
@@ -523,7 +523,7 @@ V4 follows a **permissive input, canonical output** policy for TupleValue.
 | Expanded | `{ "Tuple": { "elements": [value1, ...] } }` | Wrapper with object |
 
 :::warning
-Bare arrays are **NOT** allowed for TupleValue. This would be ambiguous with ListValue. The wrapper is required to distinguish tuples from lists.
+A Tuple always carries its wrapper. A bare array at value position is a List (decision 0009), so `[value1, value2]` on its own never decodes to a Tuple.
 :::
 
 ```json
@@ -554,9 +554,10 @@ V4 follows a **permissive input, canonical output** policy for ListValue.
 |--------|---------|-------|
 | **Canonical** | `{ "List": [value1, value2, ...] }` | Wrapper with array |
 | Expanded | `{ "List": { "items": [value1, ...] } }` | Wrapper with object |
+| Shorthand | `[value1, value2, ...]` | Bare array |
 
-:::warning
-Bare arrays are **NOT** allowed for ListValue. This would be ambiguous with TupleValue. The wrapper is required to distinguish lists from tuples.
+:::note
+A bare array at value position is a List (decision 0009). There is no ambiguity with Tuple, because a Tuple always carries its wrapper. Writers still emit the canonical wrapped form.
 :::
 
 ```json

--- a/docs/design/draft/ir/values.md
+++ b/docs/design/draft/ir/values.md
@@ -6,6 +6,8 @@ sidebar_position: 4
 
 # Values Module
 
+> **Status:** `Hole` stays a value expression; `Native` and `External` are removed from it and are definition bodies only ([decision 0008](../../../../kb/bundles/morphir/morphir-ir/decisions/0008-hole-is-an-expression-native-and-external-are-definition-bodies.md)). Bare arrays are lists and bare scalars are literals at value position ([decision 0009](../../../../kb/bundles/morphir/morphir-ir/decisions/0009-bare-arrays-are-lists-and-bare-scalars-are-literals-at-value-position.md)).
+
 This module defines the value expressions, literals, patterns, and value definitions for Morphir IR.
 
 ## Literals
@@ -221,20 +223,6 @@ pub type Value(attributes) {
     reason: HoleReason,
     expected_type: Option(Type(attributes)),
   )
-
-  /// Native platform operation (no IR body)
-  Native(
-    attributes: attributes,
-    fqname: FQName,
-    native_info: NativeInfo,
-  )
-
-  /// External FFI call
-  External(
-    attributes: attributes,
-    external_name: String,
-    target_platform: String,
-  )
 }
 
 /// Information about native operations
@@ -280,12 +268,12 @@ pub type ValueDefinitionBody(attributes) {
     native_info: NativeInfo,
   )
 
-  /// External FFI (no IR body)
+  /// External FFI: per-target bindings with an optional fallback body
   ExternalBody(
     input_types: List(#(Name, Type(attributes))),
     output_type: Type(attributes),
-    external_name: String,
-    target_platform: String,
+    externals: List(ExternalBinding),
+    body: Option(Value(attributes)),
   )
 
   /// Incomplete definition (v4 - best-effort support)
@@ -295,6 +283,11 @@ pub type ValueDefinitionBody(attributes) {
     incompleteness: Incompleteness,
     partial_body: Option(Value(attributes)),
   )
+}
+
+/// One target's binding for an external operation
+pub type ExternalBinding {
+  ExternalBinding(target_platform: String, external_name: String)
 }
 
 /// Top-level value definition (in a module)
@@ -428,7 +421,7 @@ Bare arrays are unambiguous for TuplePattern because no other pattern type uses 
 ```json
 {
   "ConstructorPattern": {
-    "constructor": "morphir/sdk:maybe#just",
+    "constructor": "morphir/SDK:maybe#just",
     "args": [
       { "AsPattern": { "value": { "WildcardPattern": {} } } }
     ]
@@ -511,13 +504,13 @@ V4 supports compact shorthand for value expressions when attributes are empty.
 #### Reference
 
 ```json
-{ "Reference": { "fqname": "morphir/sdk:list#map" } }
+{ "Reference": { "fqname": "morphir/SDK:list#map" } }
 ```
 
 #### Constructor
 
 ```json
-{ "Constructor": { "fqname": "morphir/sdk:maybe#just" } }
+{ "Constructor": { "fqname": "morphir/SDK:maybe#just" } }
 ```
 
 #### Tuple (TupleValue)
@@ -621,7 +614,7 @@ Bare arrays are **NOT** allowed for ListValue. This would be ambiguous with Tupl
 ```json
 {
   "Apply": {
-    "function": { "Reference": { "fqname": "morphir/sdk:list#map" } },
+    "function": { "Reference": { "fqname": "morphir/SDK:list#map" } },
     "argument": { "Variable": { "name": "transform" } }
   }
 }
@@ -637,7 +630,7 @@ Bare arrays are **NOT** allowed for ListValue. This would be ambiguous with Tupl
       "Apply": {
         "function": {
           "Apply": {
-            "function": { "Reference": { "fqname": "morphir/sdk:basics#add" } },
+            "function": { "Reference": { "fqname": "morphir/SDK:basics#add" } },
             "argument": { "Variable": { "name": "x" } }
           }
         },
@@ -658,7 +651,7 @@ Name becomes the key:
     "x": {
       "def": {
         "ExpressionBody": {
-          "outputType": { "Reference": { "fqname": "morphir/sdk:basics#int" } },
+          "outputType": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
           "body": { "Literal": { "literal": { "IntegerLiteral": { "value": 42 } } } }
         }
       },
@@ -666,7 +659,7 @@ Name becomes the key:
         "Apply": {
           "function": {
             "Apply": {
-              "function": { "Reference": { "fqname": "morphir/sdk:basics#add" } },
+              "function": { "Reference": { "fqname": "morphir/SDK:basics#add" } },
               "argument": { "Variable": { "name": "x" } }
             }
           },
@@ -688,15 +681,15 @@ Binding names as keys:
     "bindings": {
       "is-even": {
         "ExpressionBody": {
-          "inputTypes": [["n", { "Reference": { "fqname": "morphir/sdk:basics#int" } }]],
-          "outputType": { "Reference": { "fqname": "morphir/sdk:basics#bool" } },
+          "inputTypes": [["n", { "Reference": { "fqname": "morphir/SDK:basics#int" } }]],
+          "outputType": { "Reference": { "fqname": "morphir/SDK:basics#bool" } },
           "body": { "Variable": { "name": "..." } }
         }
       },
       "is-odd": {
         "ExpressionBody": {
-          "inputTypes": [["n", { "Reference": { "fqname": "morphir/sdk:basics#int" } }]],
-          "outputType": { "Reference": { "fqname": "morphir/sdk:basics#bool" } },
+          "inputTypes": [["n", { "Reference": { "fqname": "morphir/SDK:basics#int" } }]],
+          "outputType": { "Reference": { "fqname": "morphir/SDK:basics#bool" } },
           "body": { "Variable": { "name": "..." } }
         }
       }
@@ -726,11 +719,11 @@ Binding names as keys:
     "subject": { "Variable": { "name": "maybe-value" } },
     "cases": [
       [
-        { "ConstructorPattern": { "constructor": "morphir/sdk:maybe#just", "args": [{ "AsPattern": { "v": { "WildcardPattern": {} } } }] } },
+        { "ConstructorPattern": { "constructor": "morphir/SDK:maybe#just", "args": [{ "AsPattern": { "v": { "WildcardPattern": {} } } }] } },
         { "Variable": { "name": "v" } }
       ],
       [
-        { "ConstructorPattern": { "constructor": "morphir/sdk:maybe#nothing" } },
+        { "ConstructorPattern": { "constructor": "morphir/SDK:maybe#nothing" } },
         { "Literal": { "literal": { "IntegerLiteral": { "value": 0 } } } }
       ]
     ]
@@ -759,24 +752,13 @@ Binding names as keys:
     "reason": {
       "UnresolvedReference": { "target": "my-org/project:module#deleted-function" }
     },
-    "expectedType": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+    "expectedType": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
   }
 }
 ```
 
-#### Native (v4 - platform operation)
-
-```json
-{
-  "Native": {
-    "fqname": "morphir/sdk:basics#add",
-    "nativeInfo": {
-      "hint": { "Arithmetic": {} },
-      "description": "Integer addition"
-    }
-  }
-}
-```
+Decision 0008 removes `Native` and `External` as value expressions. A native or foreign operation is always a
+definition (`NativeBody` or `ExternalBody`); every use site is a `Reference` to it.
 
 ### Value Definition Examples
 
@@ -788,14 +770,14 @@ Input names as keys:
 {
   "ExpressionBody": {
     "inputTypes": {
-      "x": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+      "x": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
     },
-    "outputType": { "Reference": { "fqname": "morphir/sdk:basics#int" } },
+    "outputType": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
     "body": {
       "Apply": {
         "function": {
           "Apply": {
-            "function": { "Reference": { "fqname": "morphir/sdk:basics#add" } },
+            "function": { "Reference": { "fqname": "morphir/SDK:basics#add" } },
             "argument": { "Variable": { "name": "x" } }
           }
         },
@@ -812,13 +794,31 @@ Input names as keys:
 {
   "NativeBody": {
     "inputTypes": {
-      "a": { "Reference": { "fqname": "morphir/sdk:basics#int" } },
-      "b": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+      "a": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
+      "b": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
     },
-    "outputType": { "Reference": { "fqname": "morphir/sdk:basics#int" } },
+    "outputType": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
     "nativeInfo": {
       "hint": { "Arithmetic": {} }
     }
+  }
+}
+```
+
+#### ExternalBody (external operation, two bindings and a fallback)
+
+```json
+{
+  "ExternalBody": {
+    "inputTypes": {
+      "x": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
+    },
+    "outputType": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
+    "externals": [
+      { "targetPlatform": "erlang", "externalName": "math:abs" },
+      { "targetPlatform": "javascript", "externalName": "Math.abs" }
+    ],
+    "body": { "Variable": { "name": "x" } }
   }
 }
 ```
@@ -829,10 +829,10 @@ Input names as keys:
 {
   "ValueSpecification": {
     "inputs": {
-      "x": { "Reference": { "fqname": "morphir/sdk:basics#int" } },
-      "y": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+      "x": { "Reference": { "fqname": "morphir/SDK:basics#int" } },
+      "y": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
     },
-    "output": { "Reference": { "fqname": "morphir/sdk:basics#int" } }
+    "output": { "Reference": { "fqname": "morphir/SDK:basics#int" } }
   }
 }
 ```

--- a/docs/spec/draft/distribution.md
+++ b/docs/spec/draft/distribution.md
@@ -68,10 +68,10 @@ Contains only the public interface (`TypeSpecification`, `ValueSpecification`).
 
 ```json
 // Full form
-{ "Specs": { "packageName": "morphir/sdk", "dependencies": {...}, "spec": {...} } }
+{ "Specs": { "packageName": "morphir/SDK", "dependencies": {...}, "spec": {...} } }
 
 // Compact form
-{ "Specs": { "packageName": "morphir/sdk" } }
+{ "Specs": { "packageName": "morphir/SDK" } }
 ```
 
 ### Application Distribution

--- a/docs/spec/draft/index.md
+++ b/docs/spec/draft/index.md
@@ -71,4 +71,4 @@ A `ValueSpecification` contains only the function signature (input types and out
 - **Explicit Attributes**: Attributes include source location, constraints (for types), and inferred types (for values).
 - **Module.json**: First-class support for `module.json` files containing full module definitions.
 - **Incomplete Definitions**: New `IncompleteTypeDefinition` and `IncompleteBody` support best-effort compilation.
-- **Native and External Values**: First-class support for platform builtins and FFI.
+- **Native and External Bodies**: Platform builtins and FFI bindings as value definition bodies (`NativeBody`, `ExternalBody`), never as expressions (decision 0008).

--- a/docs/spec/draft/names.md
+++ b/docs/spec/draft/names.md
@@ -105,10 +105,12 @@ written on Linux checks out on Windows and macOS.
 
 ### Path length
 
-When a path would exceed the **path budget** measured from the distribution root, the stem is truncated and suffixed
-with `__` followed by the first 8 hex digits of the SHA-256 of the untruncated stem. A truncated name is not
-recoverable from its filename, so the module's `module.json` must then carry a `fileNames` map from canonical name
-to filename stem.
+When a path would exceed the **path budget** measured from the distribution root, the stem is truncated: the writer
+keeps as many leading characters of the escaped stem as the budget allows for the stem less ten, removes any
+trailing `-` or `_` so the stem stays well-formed, and appends `__` followed by the first 8 hex digits of the
+SHA-256 of the untruncated escaped stem. A truncated name is not recoverable from its filename, so the module's
+manifest must then carry a `fileNames` map from canonical name to filename stem, and the name still appears under
+`types` or `values`.
 
 **The default budget is 4000.** Long paths are the ordinary case: `PATH_MAX` on Linux and macOS is 4096, and Windows
 10 version 1607 and later lifts `MAX_PATH` through the `LongPathsEnabled` setting. Defaulting to the most

--- a/docs/spec/draft/names.md
+++ b/docs/spec/draft/names.md
@@ -143,8 +143,8 @@ set `pathBudget` in `manifest.json`:
 
 Recording it unconditionally is what keeps the flipped default safe. A reader that cannot satisfy the recorded
 budget says so once, up front, instead of failing to open files one at a time, and no consumer has to guess what an
-unmarked tree assumed. For a tree written before this field existed, a reader treats a missing `pathBudget` as 4000
-and SHOULD warn.
+unmarked tree assumed. A manifest without `pathBudget` is invalid (decision 0012). There is no inferred default; a
+reader rejects such a tree rather than guessing a budget for it.
 
 Tooling SHOULD report when a tree written under the `long` budget contains a path over 260 characters, since that is
 the point at which it stops being checkout-safe on a stock Windows box.

--- a/docs/spec/draft/packages.md
+++ b/docs/spec/draft/packages.md
@@ -34,7 +34,7 @@ A package maps to a directory structure within the `.morphir-dist` root:
 - **Local Packages**: Located in `pkg/{package-path}/`.
     - Example: `pkg/my-org/my-project/`
 - **Dependencies**: Located in `deps/{package-path}/{version}/`.
-    - Example: `deps/morphir/sdk/1.2.0/`
+    - Example: `deps/morphir/_sdk/1.2.0/`
 
 ## Namespace Mapping
 

--- a/docs/spec/draft/types.md
+++ b/docs/spec/draft/types.md
@@ -42,12 +42,12 @@ A reference to another type or type alias.
   - fqName: Fully-qualified name of the referenced type (`FQName`)
   - args: List of type arguments (`List Type`)
 - **Examples**:
-  - `String` → FQName: `morphir/sdk:string#string`
-  - `List Int` → FQName: `morphir/sdk:list#list` with type argument `morphir/sdk:basics#int`
-  - `Dict String Int` → FQName: `morphir/sdk:dict#dict` with type arguments
-- **JSON (compact, no type args)**: `"morphir/sdk:string#string"` — bare FQName string
-- **JSON (compact, with type args)**: `{"Reference": ["morphir/sdk:list#list", "a"]}` — array with FQName first, followed by type args
-- **JSON (expanded)**: `{"Reference": {"fqname": "morphir/sdk:list#list", "args": [...]}}` — object with fqname and args keys
+  - `String` → FQName: `morphir/SDK:string#string`
+  - `List Int` → FQName: `morphir/SDK:list#list` with type argument `morphir/SDK:basics#int`
+  - `Dict String Int` → FQName: `morphir/SDK:dict#dict` with type arguments
+- **JSON (compact, no type args)**: `"morphir/SDK:string#string"` — bare FQName string
+- **JSON (compact, with type args)**: `{"Reference": ["morphir/SDK:list#list", "a"]}` — array with FQName first, followed by type args
+- **JSON (expanded)**: `{"Reference": {"fqname": "morphir/SDK:list#list", "args": [...]}}` — object with fqname and args keys
 - **Legacy format**: `[["morphir"], ["s", "d", "k"]], [["string"]], ["string"]]` (package, module, local name arrays)
 
 ### Tuple
@@ -58,9 +58,9 @@ A composition of multiple types in a fixed order.
 - **Components**:
   - attributes: `TypeAttributes`
   - elements: Element types in order (`List Type`)
-- **JSON (canonical)**: `{"Tuple": ["morphir/sdk:int#int", "morphir/sdk:string#string"]}`
-- **JSON (compact)**: `["morphir/sdk:int#int", "morphir/sdk:string#string"]` — a bare array in type position is always a tuple
-- **JSON (expanded)**: `{"Tuple": {"elements": ["morphir/sdk:int#int", "morphir/sdk:string#string"]}}`
+- **JSON (canonical)**: `{"Tuple": ["morphir/SDK:int#int", "morphir/SDK:string#string"]}`
+- **JSON (compact)**: `["morphir/SDK:int#int", "morphir/SDK:string#string"]` — a bare array in type position is always a tuple
+- **JSON (expanded)**: `{"Tuple": {"elements": ["morphir/SDK:int#int", "morphir/SDK:string#string"]}}`
 
 ### Record
 
@@ -70,9 +70,9 @@ A composition of named fields with their types.
 - **Components**:
   - attributes: `TypeAttributes`
   - fields: Dictionary of field names to types
-- **JSON (compact)**: `{"Record": {"field-name": "morphir/sdk:string#string", "age": "morphir/sdk:int#int"}}`
-  - Fields are stored directly under `Record` without a wrapper
-  - Field names use kebab-case
+- **JSON (canonical)**: `{"Record": {"fields": {"field-name": "morphir/SDK:string#string", "age": "morphir/SDK:basics#int"}}}`
+- **JSON (expanded)**: `{"Record": {"attributes": {...}, "fields": {...}}}`
+- Fields live under `fields` so `attributes` can sit beside them (decision 0004). The field map directly under `Record` is accepted for one release and reported as `legacy_spelling` (decision 0006).
 
 ### ExtensibleRecord
 
@@ -83,18 +83,19 @@ A record type that can be extended with additional fields.
   - attributes: `TypeAttributes`
   - variable: Type variable representing the extension (`Name`)
   - fields: Known fields (dictionary of names to types)
-- **JSON**: `{"ExtensibleRecord": {"variable": "a", "fields": {"name": "morphir/sdk:string#string"}}}`
+- **JSON**: `{"ExtensibleRecord": {"variable": "a", "fields": {"name": "morphir/SDK:string#string"}}}`
 
 ### Function
 
 Represents a function type.
 
-- **Structure**: `Function attributes argumentType returnType`
+- **Structure**: `Function attributes parameterType returnType`
 - **Components**:
   - attributes: `TypeAttributes`
-  - argumentType: Argument type (`Type`)
+  - parameterType: Parameter type (`Type`)
   - returnType: Return type (`Type`)
-- **JSON**: `{"Function": {"argumentType": "morphir/sdk:int#int", "returnType": "morphir/sdk:string#string"}}`
+- **JSON**: `{"Function": {"parameterType": "morphir/SDK:int#int", "returnType": "morphir/SDK:string#string"}}`
+- `argumentType`, and the Rust encoder's `arg`/`result`, are accepted for one release (decisions 0006, 0007).
 
 ### Unit
 
@@ -116,17 +117,17 @@ Type expressions use maximally compact forms where context is unambiguous:
 | Type Expression | JSON Format | Example |
 |-----------------|-------------|---------|
 | Variable | Bare name string | `"a"` |
-| Reference (no args) | Bare FQName string | `"morphir/sdk:int#int"` |
-| Reference (with args) | Array with fqname + args | `{"Reference": ["morphir/sdk:list#list", "a"]}` |
-| Record | Object with field map | `{"Record": {"name": "morphir/sdk:string#string"}}` |
+| Reference (no args) | Bare FQName string | `"morphir/SDK:int#int"` |
+| Reference (with args) | Array with fqname + args | `{"Reference": ["morphir/SDK:list#list", "a"]}` |
+| Record | Object with fields wrapper | `{"Record": {"fields": {"name": "morphir/SDK:string#string"}}}` |
 | Tuple | Bare array, or wrapper with array | `["a", "b"]` or `{"Tuple": ["a", "b"]}` |
-| Function | Object with argument and return | `{"Function": {"argumentType": ..., "returnType": ...}}` |
+| Function | Object with parameter and return | `{"Function": {"parameterType": ..., "returnType": ...}}` |
 | Unit | Empty object | `{"Unit": {}}` |
 
 **Disambiguation**: Variables and References without args are both strings, but can be distinguished:
 - Variables: simple name without special characters (e.g., `"a"`, `"comparable"`)
-- References: FQName format with `:` and `#` (e.g., `"morphir/sdk:int#int"`)
-- A bare array is always a Tuple. A Reference with type arguments always carries the `Reference` wrapper, so `["morphir/sdk:int#int", "morphir/sdk:string#string"]` is the pair `(Int, String)`, never a parameterized reference
+- References: FQName format with `:` and `#` (e.g., `"morphir/SDK:int#int"`)
+- A bare array is always a Tuple. A Reference with type arguments always carries the `Reference` wrapper, so `["morphir/SDK:int#int", "morphir/SDK:string#string"]` is the pair `(Int, String)`, never a parameterized reference
 
 ### Expanded Format
 
@@ -134,14 +135,14 @@ For tooling that prefers explicit structure, an expanded format is available:
 
 | Type Expression | JSON Format | Example |
 |-----------------|-------------|---------|
-| Variable | Object with name key | `{"Variable": {"name": "a"}}` |
-| Reference | Object with fqname and args | `{"Reference": {"fqname": "morphir/sdk:list#list", "args": ["a"]}}` |
-| Record | Object with field map | `{"Record": {"name": "morphir/sdk:string#string"}}` |
-| Tuple | Wrapper with elements | `{"Tuple": {"elements": [...]}}` |
-| Function | Object with argument and return | `{"Function": {"argumentType": ..., "returnType": ...}}` |
-| Unit | Empty object | `{"Unit": {}}` |
+| Variable | Object with attributes and name | `{"Variable": {"attributes": {...}, "name": "a"}}` |
+| Reference | Object with attributes, fqname and args | `{"Reference": {"attributes": {...}, "fqname": "morphir/SDK:list#list", "args": ["a"]}}` |
+| Record | Object with attributes and fields | `{"Record": {"attributes": {...}, "fields": {...}}}` |
+| Tuple | Object with attributes and elements | `{"Tuple": {"attributes": {...}, "elements": [...]}}` |
+| Function | Object with attributes, parameter and return | `{"Function": {"attributes": {...}, "parameterType": ..., "returnType": ...}}` |
+| Unit | Object with attributes | `{"Unit": {"attributes": {...}}}` |
 
-**Note**: The expanded format is identical to compact for Record, Tuple, Function, and Unit types. Use `morphir ir migrate --expanded` to produce expanded format output.
+**Note**: Every node's expanded payload starts with an optional `attributes` member (decision 0005). Writers use the compact form whenever attributes are empty; an expanded payload with empty attributes is accepted and never written.
 
 ## Type Specifications
 
@@ -176,7 +177,7 @@ type alias UserId = String
 {
   "TypeAliasSpecification": {
     "typeParams": [],
-    "type": "morphir/sdk:string#string"
+    "type": "morphir/SDK:string#string"
   }
 }
 ```
@@ -208,9 +209,11 @@ type alias Person = { name : String, age : Int, email : Maybe String }
     "typeParams": [],
     "type": {
       "Record": {
-        "name": "morphir/sdk:string#string",
-        "age": "morphir/sdk:basics#int",
-        "email": { "Reference": ["morphir/sdk:maybe#maybe", "morphir/sdk:string#string"] }
+        "fields": {
+          "name": "morphir/SDK:string#string",
+          "age": "morphir/SDK:basics#int",
+          "email": { "Reference": ["morphir/SDK:maybe#maybe", "morphir/SDK:string#string"] }
+        }
       }
     }
   }
@@ -227,7 +230,7 @@ type alias Predicate a = a -> Bool
 {
   "TypeAliasSpecification": {
     "typeParams": ["a"],
-    "type": { "Function": { "argumentType": "a", "returnType": "morphir/sdk:basics#bool" } }
+    "type": { "Function": { "parameterType": "a", "returnType": "morphir/SDK:basics#bool" } }
   }
 }
 ```
@@ -344,7 +347,7 @@ type List a = Nil | Cons a (List a)
     "typeParams": ["a"],
     "constructors": {
       "nil": [],
-      "cons": [["head", "a"], ["tail", { "Reference": ["morphir/sdk:list#list", "a"] }]]
+      "cons": [["head", "a"], ["tail", { "Reference": ["morphir/SDK:list#list", "a"] }]]
     }
   }
 }
@@ -365,13 +368,13 @@ type PaymentMethod
     "typeParams": [],
     "constructors": {
       "credit-card": [
-        ["number", "morphir/sdk:string#string"],
-        ["expiry", "morphir/sdk:string#string"],
-        ["cvv", "morphir/sdk:string#string"]
+        ["number", "morphir/SDK:string#string"],
+        ["expiry", "morphir/SDK:string#string"],
+        ["cvv", "morphir/SDK:string#string"]
       ],
       "bank-transfer": [
-        ["account-number", "morphir/sdk:string#string"],
-        ["routing-number", "morphir/sdk:string#string"]
+        ["account-number", "morphir/SDK:string#string"],
+        ["routing-number", "morphir/SDK:string#string"]
       ],
       "cash": []
     }
@@ -400,9 +403,9 @@ type LocalDate
 {
   "DerivedTypeSpecification": {
     "typeParams": [],
-    "baseType": "morphir/sdk:string#string",
-    "fromBaseType": "morphir/sdk:local-date#from-i-s-o",
-    "toBaseType": "morphir/sdk:local-date#to-i-s-o"
+    "baseType": "morphir/SDK:string#string",
+    "fromBaseType": "morphir/SDK:local-date#from-i-s-o",
+    "toBaseType": "morphir/SDK:local-date#to-i-s-o"
   }
 }
 ```
@@ -418,9 +421,9 @@ type Decimal
 {
   "DerivedTypeSpecification": {
     "typeParams": [],
-    "baseType": "morphir/sdk:string#string",
-    "fromBaseType": "morphir/sdk:decimal#from-string",
-    "toBaseType": "morphir/sdk:decimal#to-string"
+    "baseType": "morphir/SDK:string#string",
+    "fromBaseType": "morphir/SDK:decimal#from-string",
+    "toBaseType": "morphir/SDK:decimal#to-string"
   }
 }
 ```
@@ -437,8 +440,10 @@ type Money
     "typeParams": [],
     "baseType": {
       "Record": {
-        "amount": "morphir/sdk:decimal#decimal",
-        "currency": "morphir/sdk:string#string"
+        "fields": {
+          "amount": "morphir/SDK:decimal#decimal",
+          "currency": "morphir/SDK:string#string"
+        }
       }
     },
     "fromBaseType": "my-org/finance:money#from-record",
@@ -458,7 +463,7 @@ type NonEmpty a
 {
   "DerivedTypeSpecification": {
     "typeParams": ["a"],
-    "baseType": { "Reference": ["morphir/sdk:list#list", "a"] },
+    "baseType": { "Reference": ["morphir/SDK:list#list", "a"] },
     "fromBaseType": "my-org/collections:non-empty#from-list",
     "toBaseType": "my-org/collections:non-empty#to-list"
   }

--- a/docs/spec/draft/values.md
+++ b/docs/spec/draft/values.md
@@ -26,6 +26,7 @@ Literal constant values used in value expressions.
 - **IntegerLiteral**: Integer (arbitrary precision, includes negatives)
 - **FloatLiteral**: Floating-point number
 - **DecimalLiteral**: Arbitrary-precision decimal (stored as string for precision)
+- **DocumentLiteral**: A schema-less JSON-like document carried verbatim, typed `morphir/SDK:document#document`; cannot be pattern matched (decision 0013)
 
 ## Value Expressions
 
@@ -43,7 +44,7 @@ A literal constant value.
 Reference to a custom type constructor.
 
 - **Structure**: `Constructor attributes fqName`
-- **JSON**: `{"Constructor": "morphir/sdk:maybe#just"}`
+- **JSON**: `{"Constructor": "morphir/SDK:maybe#just"}`
 
 ### Tuple
 
@@ -52,7 +53,7 @@ A tuple value with multiple elements.
 - **Structure**: `Tuple attributes elements`
 - **JSON (canonical)**: `{"Tuple": [{"Variable": "x"}, {"Literal": {"IntegerLiteral": 1}}]}`
 - **JSON (expanded)**: `{"Tuple": {"elements": [...]}}`
-- A bare array is not a tuple value; it would be ambiguous with a list value
+- A bare array at value position is a List, never a tuple (decision 0009)
 
 ### List
 
@@ -60,7 +61,8 @@ A list of values.
 
 - **Structure**: `List attributes elements`
 - **JSON (canonical)**: `{"List": [{"Literal": {"IntegerLiteral": 1}}, {"Literal": {"IntegerLiteral": 2}}]}`
-- **JSON (expanded)**: `{"List": {"items": [...]}}`
+- **JSON (accepted)**: a bare array `[1, 2, 3]` (decision 0009)
+- **JSON (expanded)**: `{"List": {"attributes": {...}, "items": [...]}}`
 
 ### Record
 
@@ -71,9 +73,9 @@ A record value with named fields.
   - attributes: `ValueAttributes`
   - fields: Dictionary of field names to values (`Dict Name Value`)
 - **Note**: Field order does not affect equality—two records with the same fields in different orders are considered equal
-- **JSON (compact)**: `{"Record": {"name": {"Variable": "x"}, "age": {"Literal": {"IntegerLiteral": 25}}}}`
-  - Fields stored directly under `Record` without a wrapper
-  - Field names use kebab-case
+- **JSON (canonical)**: `{"Record": {"fields": {"name": {"Variable": "x"}, "age": {"Literal": {"IntegerLiteral": 25}}}}}`
+- **JSON (expanded)**: `{"Record": {"attributes": {...}, "fields": {...}}}`
+- Fields live under `fields` so `attributes` can sit beside them (decision 0004). The field map directly under `Record` is accepted for one release and reported as `legacy_spelling` (decision 0006).
 
 ### Variable
 
@@ -87,7 +89,7 @@ Reference to a variable in scope.
 Reference to a defined value (function or constant).
 
 - **Structure**: `Reference attributes fqName`
-- **JSON**: `{"Reference": "morphir/sdk:basics#add"}` — FQName directly under Reference
+- **JSON**: `{"Reference": "morphir/SDK:basics#add"}` — FQName directly under Reference
 
 ### Field
 
@@ -108,7 +110,7 @@ A function that extracts a field.
 Function application.
 
 - **Structure**: `Apply attributes function argument`
-- **JSON**: `{"Apply": {"function": {"Reference": "morphir/sdk:basics#add"}, "argument": {"Literal": {"IntegerLiteral": 1}}}}`
+- **JSON**: `{"Apply": {"function": {"Reference": "morphir/SDK:basics#add"}, "argument": {"Literal": {"IntegerLiteral": 1}}}}`
 
 ### Lambda
 
@@ -182,17 +184,17 @@ Value expressions use object wrappers to distinguish expression types:
 | Value Expression | JSON Format | Example |
 |------------------|-------------|---------|
 | Variable | `{"Variable": name}` | `{"Variable": "x"}` |
-| Reference | `{"Reference": fqname}` | `{"Reference": "morphir/sdk:basics#add"}` |
+| Reference | `{"Reference": fqname}` | `{"Reference": "morphir/SDK:basics#add"}` |
 | Literal | `{"Literal": {...}}` | `{"Literal": {"IntegerLiteral": 42}}` |
-| Constructor | `{"Constructor": fqname}` | `{"Constructor": "morphir/sdk:maybe#just"}` |
-| Record | `{"Record": {fields}}` | `{"Record": {"name": {...}}}` |
+| Constructor | `{"Constructor": fqname}` | `{"Constructor": "morphir/SDK:maybe#just"}` |
+| Record | `{"Record": {"fields": {...}}}` | `{"Record": {"fields": {"name": {...}}}}` |
 | Apply | `{"Apply": {...}}` | `{"Apply": {"function": {...}, "argument": {...}}}` |
 | Unit | `{"Unit": {}}` | `{"Unit": {}}` |
+| Bare boolean/number | literal shorthand | `true`, `42` |
+| Bare array | List shorthand | `[1, 2]` |
 
 **Key differences from Type expressions**:
-- Value expressions always use object wrappers (e.g., `{"Variable": "x"}`)
-- Type expressions can use bare strings for Variables and References without args
-- This distinction allows parsers to unambiguously identify expression types in any context
+- A bare string is a Variable or a Reference, never a StringLiteral; a bare boolean or number is a literal; a bare array is a List; a Tuple always carries its wrapper (decision 0009).
 
 ### Hole (v4)
 
@@ -207,30 +209,11 @@ An incomplete or broken reference, enabling best-effort compilation.
   - Reference to a deleted/renamed function
   - Placeholder during incremental development
   - Representing compilation errors without failing the entire build
-
-### Native (v4)
-
-A native platform operation with no IR body.
-
-- **Structure**: `Native attributes fqName nativeInfo`
-- **Components**:
-  - attributes: `ValueAttributes`
-  - fqName: Fully-qualified name of the native operation (`FQName`)
-  - nativeInfo: Information about the native operation (`NativeInfo`)
-
-### External (v4)
-
-An external FFI (Foreign Function Interface) call.
-
-- **Structure**: `External attributes externalName targetPlatform`
-- **Components**:
-  - attributes: `ValueAttributes`
-  - externalName: Name of the external function (`String`)
-  - targetPlatform: Target platform identifier (`String`)
+- Native and external operations are not expressions; they are the definition bodies `NativeBody` and `ExternalBody` (decision 0008).
 
 ## NativeInfo (v4)
 
-Information about native operations.
+Information about native operations, used by `NativeBody`.
 
 - **Structure**: `NativeInfo hint description`
 - **Components**:
@@ -301,12 +284,13 @@ A native/builtin operation with no IR body.
 
 An external FFI operation with no IR body.
 
-- **Structure**: `ExternalBody inputTypes outputType externalName targetPlatform`
+- **Structure**: `ExternalBody inputTypes outputType externals body`
 - **Components**:
   - inputTypes: List of parameter names and types (`List (Name, Type)`)
   - outputType: Return type (`Type`)
-  - externalName: Name of the external function (`String`)
-  - targetPlatform: Target platform identifier (`String`)
+  - externals: Per-target bindings (`List { targetPlatform : String, externalName : String }`), at least one
+  - body: Optional fallback expression (`Maybe Value`)
+- The single-binding spelling with top-level `externalName`/`targetPlatform` is accepted for one release (decision 0006).
 
 #### IncompleteBody (v4)
 
@@ -328,7 +312,7 @@ A **Value Specification** defines the public interface of a value—the function
 - API documentation generation from signatures
 - Separate compilation of dependent modules
 
-**Deriving specifications**: A specification is derived from any `ValueDefinitionBody` by extracting the input types and output type. The implementation details (`body`, `nativeInfo`, `externalName`, etc.) are discarded.
+**Deriving specifications**: A specification is derived from any `ValueDefinitionBody` by extracting the input types and output type. The implementation details (`body`, `nativeInfo`, `externals`, etc.) are discarded.
 
 - **Structure**: `ValueSpecification inputs output`
 - **Components**:

--- a/docs/spec/ir/fixtures/naming-conformance.json
+++ b/docs/spec/ir/fixtures/naming-conformance.json
@@ -942,6 +942,12 @@
       "available": 16,
       "truncatedStem": "value__1b878a36",
       "hostVerified": true
+    },
+    {
+      "escapedStem": "value-in-_usd",
+      "available": 20,
+      "truncatedStem": "value-in__b5c6a9d3",
+      "hostVerified": true
     }
   ]
 }

--- a/docs/spec/ir/fixtures/naming-conformance.json
+++ b/docs/spec/ir/fixtures/naming-conformance.json
@@ -10,14 +10,14 @@
     "legacyDecodeCases apply the rule from decision 0001: a maximal run of two or more single-letter words collapses into one initialism, and a run of one stays a word. That run-of-one rule is what makes a single-letter type variable decode as the word \"a\" rather than as an initialism.",
     "The legacy array [\"f\",\"r\",\"2052\",\"a\"] is inherently ambiguous, because the multi-character token 2052 breaks the letter run. The deterministic result recorded here renders identically to FR2052A in both PascalCase conventions but differs in snakeCase. Implementations must match the recorded value rather than guess.",
     "rejectCases record validity per style. An input legal under one style and not the other is the disjointness property that decision 0002 relies on for its union decoder.",
-    "Path-length truncation from decision 0001 is not covered here, because it depends on a SHA-256 digest that the Morphir SDK cannot express. Those cases are host-verified."
+    "truncationCases are host-verified: they depend on SHA-256, which the Morphir SDK cannot express, so a host binding computes the digest and compares. The rule is decision 0012's: keep available-10 characters of the escaped stem, drop trailing '-' and '_', append '__' and eight hex digits."
   ],
   "patterns": {
     "name": {
       "uppercase": "^([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*$",
       "doubledHyphen": "^(--)?[a-z0-9]+(--?[a-z0-9]+)*$"
     },
-    "fileStem": "^_?[a-z0-9]+(-_?[a-z0-9]+)*_?$"
+    "fileStem": "^_?[a-z0-9]+(-_?[a-z0-9]+)*(__[0-9a-f]{8})?_?$"
   },
   "reservedDeviceStems": [
     "con",
@@ -928,6 +928,20 @@
         "doubledHyphen": "my-org:domain#value-in--usd"
       },
       "documentTreePath": "pkg/my-org/domain/value-in-_usd.value.json"
+    }
+  ],
+  "truncationCases": [
+    {
+      "escapedStem": "customer-relationship-management-record",
+      "available": 25,
+      "truncatedStem": "customer-relati__44a101f8",
+      "hostVerified": true
+    },
+    {
+      "escapedStem": "value-in-_usd-per-unit",
+      "available": 16,
+      "truncatedStem": "value__1b878a36",
+      "hostVerified": true
     }
   ]
 }

--- a/docs/spec/ir/schemas/v4/document-tree-files.md
+++ b/docs/spec/ir/schemas/v4/document-tree-files.md
@@ -673,81 +673,62 @@ When type/value files are part of a PackageSpecification:
       "outputType": "morphir/SDK:basics#float",
       "body": {
         "LetDefinition": {
-          "attributes": {},
-          "valueName": "subtotal",
-          "valueDefinition": {
+          "name": "subtotal",
+          "definition": {
             "ExpressionBody": {
               "inputTypes": {},
               "outputType": "morphir/SDK:basics#float",
               "body": {
                 "Apply": {
-                  "attributes": {},
                   "function": {
                     "Reference": {
-                      "attributes": {},
-                      "fqname": "morphir/SDK:list#sum",
-                      "args": []
+                      "fqname": "morphir/SDK:list#sum"
                     }
                   },
                   "argument": {
                     "Field": {
-                      "attributes": {},
-                      "subject": {
+                      "target": {
                         "Variable": {
-                          "attributes": {},
                           "name": "order"
                         }
                       },
-                      "fieldName": "line-items"
+                      "name": "line-items"
                     }
                   }
                 }
               }
             }
           },
-          "inValue": {
+          "in": {
             "Apply": {
-              "attributes": {},
               "function": {
                 "Reference": {
-                  "attributes": {},
-                  "fqname": "morphir/SDK:basics#multiply",
-                  "args": []
+                  "fqname": "morphir/SDK:basics#multiply"
                 }
               },
               "argument": {
                 "Tuple": {
-                  "attributes": {},
                   "elements": [
                     {
                       "Variable": {
-                        "attributes": {},
                         "name": "subtotal"
                       }
                     },
                     {
                       "Apply": {
-                        "attributes": {},
                         "function": {
                           "Reference": {
-                            "attributes": {},
-                            "fqname": "morphir/SDK:basics#add",
-                            "args": []
+                            "fqname": "morphir/SDK:basics#add"
                           }
                         },
                         "argument": {
                           "Tuple": {
-                            "attributes": {},
                             "elements": [
                               {
-                                "Literal": {
-                                  "attributes": {},
-                                  "literal": { "FloatLiteral": 1.0 }
-                                }
+                                "Literal": { "FloatLiteral": 1.0 }
                               },
                               {
                                 "Variable": {
-                                  "attributes": {},
                                   "name": "tax-rate"
                                 }
                               }

--- a/docs/spec/ir/schemas/v4/document-tree-files.md
+++ b/docs/spec/ir/schemas/v4/document-tree-files.md
@@ -48,6 +48,7 @@ The corresponding JSON tree replaces each `.yaml` extension with `.json`.
 - [`formatVersion`](#formatversion): IR format version
 - `distribution`: Distribution type (`"Library"`, `"Specs"`, or `"Application"`)
 - `package`: Package name (canonical path format, e.g., `"my-org/my-project"`)
+- `pathBudget`: Path budget in characters from the distribution root (decision 0012; 4000 default profile, 200 portable)
 
 **Optional Fields**:
 - `version`: Package version (semantic version string)
@@ -63,6 +64,7 @@ The corresponding JSON tree replaces each `.yaml` extension with `.json`.
   "formatVersion": 4,
   "distribution": "Library",
   "package": "my-org/my-project",
+  "pathBudget": 4000,
   "version": "1.2.0",
   "created": "2026-01-15T12:00:00Z",
   "layout": "VfsMode"
@@ -75,6 +77,7 @@ The corresponding JSON tree replaces each `.yaml` extension with `.json`.
   "formatVersion": 4,
   "distribution": "Specs",
   "package": "morphir/SDK",
+  "pathBudget": 4000,
   "version": "3.0.0",
   "created": "2026-01-15T12:00:00Z",
   "layout": "VfsMode"
@@ -87,6 +90,7 @@ The corresponding JSON tree replaces each `.yaml` extension with `.json`.
   "formatVersion": 4,
   "distribution": "Application",
   "package": "my-org/my-cli",
+  "pathBudget": 4000,
   "version": "2.0.0",
   "created": "2026-01-15T12:00:00Z",
   "layout": "VfsMode",
@@ -122,6 +126,7 @@ The corresponding JSON tree replaces each `.yaml` extension with `.json`.
 - `doc`: Module-level documentation (string or array of strings)
 - `types`: Either array of type names (manifest style) or object with inline definitions (inline style)
 - `values`: Either array of value names (manifest style) or object with inline definitions (inline style)
+- `fileNames`: Canonical name to truncated file stem, for names whose stem was truncated for the path budget (decision 0012); every key must also appear in `types` or `values`
 
 **Encoding Styles**:
 
@@ -135,6 +140,19 @@ Lists type/value names; definitions in separate files:
   "doc": "Domain model for main application",
   "types": ["user", "user-ID", "order"],
   "values": ["get-user-by-email", "create-order", "validate-user"]
+}
+```
+
+**Example with a truncated stem**:
+```json
+{
+  "formatVersion": 4,
+  "path": "domain",
+  "types": ["customer-relationship-management-record"],
+  "values": [],
+  "fileNames": {
+    "customer-relationship-management-record": "customer-relati__44a101f8"
+  }
 }
 ```
 
@@ -201,7 +219,7 @@ Contains definitions directly:
   - `spec`: Type specification (interface) - contains `TypeAliasSpecification`, `OpaqueTypeSpecification`, `CustomTypeSpecification`, or `DerivedTypeSpecification`
 
 **Optional Fields**:
-- `doc`: Documentation (string or array of strings) - can be at top level or nested in `def`/`spec`
+- `doc`: Documentation (string or array of strings), nested inside `def` or `spec` (decision 0010)
 
 **File Naming**:
 - Use the escaped stem, `escape(name)`, not the canonical name
@@ -215,9 +233,9 @@ Contains definitions directly:
 {
   "formatVersion": 4,
   "name": "user",
-  "doc": "Represents a user in the system",
   "def": {
     "access": "Public",
+    "doc": "Represents a user in the system",
     "TypeAliasDefinition": {
       "typeParams": [],
       "typeExp": {
@@ -287,7 +305,7 @@ Contains definitions directly:
   - `spec`: Value specification (interface) - contains `inputs` (object) and `output` (type)
 
 **Optional Fields**:
-- `doc`: Documentation (string or array of strings) - can be at top level or nested in `def`/`spec`
+- `doc`: Documentation (string or array of strings), nested inside `def` or `spec` (decision 0010)
 
 **File Naming**:
 - Use the escaped stem, `escape(name)`, not the canonical name
@@ -301,9 +319,9 @@ Contains definitions directly:
 {
   "formatVersion": 4,
   "name": "get-user-by-email",
-  "doc": "Retrieve a user by email address",
   "def": {
     "access": "Public",
+    "doc": "Retrieve a user by email address",
     "ExpressionBody": {
       "inputTypes": {
         "email": "morphir/SDK:string#string",
@@ -484,10 +502,7 @@ is also accepted. Prerelease and build metadata are rejected.
 - Single-line: `"doc": "Brief description"`
 - Multi-line: `"doc": ["Line 1", "Line 2", "Line 3"]`
 
-**Location**: Can appear at:
-- Top level of file
-- Nested in `def` or `spec` object
-- Both (top-level takes precedence for display)
+**Location**: Inside `def` or `spec`, first beside the variant (decision 0010). Not at the top level of a node file.
 
 ### def
 
@@ -644,12 +659,12 @@ When type/value files are part of a PackageSpecification:
 {
   "formatVersion": 4,
   "name": "calculate-total",
-  "doc": [
-    "Calculate the total price of an order including tax.",
-    "Applies discounts and regional tax rates."
-  ],
   "def": {
     "access": "Public",
+    "doc": [
+      "Calculate the total price of an order including tax.",
+      "Applies discounts and regional tax rates."
+    ],
     "ExpressionBody": {
       "inputTypes": {
         "order": "my-org/domain:orders#order",
@@ -836,9 +851,9 @@ When type/value files are part of a PackageSpecification:
 {
   "formatVersion": 4,
   "name": "user",
-  "doc": "Represents a user in the system",
   "def": {
     "access": "Public",
+    "doc": "Represents a user in the system",
     "TypeAliasDefinition": {
       "typeParams": [],
       "typeExp": {
@@ -882,9 +897,9 @@ When type/value files are part of a PackageSpecification:
 {
   "formatVersion": 4,
   "name": "get-user-by-email",
-  "doc": "Retrieve a user by their email address",
   "def": {
     "access": "Public",
+    "doc": "Retrieve a user by their email address",
     "ExpressionBody": {
       "inputTypes": {
         "email": "morphir/SDK:string#string",
@@ -1006,12 +1021,17 @@ A filename is the **escaped stem** of a Name, not the canonical name. See
 - One of `types`/`values` can be array, other can be object
 - Consistency is preferred
 
+**`fileNames`**:
+- `fileNames` values must match `FileStem`
+- Each key must be listed in `types` or `values`
+
 ### Distribution Manifest Validation
 
 **Required for all distributions**:
 - `formatVersion`: Must satisfy the [shared v3-and-later contract](../../format-version.md)
 - `distribution`: Must be `"Library"`, `"Specs"`, or `"Application"`
 - `package`: Must be valid PackageName (canonical format)
+- `pathBudget`: Must be present (decision 0012)
 
 **Required for Application distributions**:
 - `entryPoints`: Must be present and non-empty object
@@ -1168,6 +1188,14 @@ Module-level metadata is stored in `module.json`. Additional metadata can be inc
 - `deprecated`: Boolean indicating if module is deprecated
 - `since`: Version when module was introduced
 - `extensions`: Object for tool-specific metadata
+
+### Reserved: $meta
+
+A top-level `$meta` member in any document-tree file is reserved (decision 0014). Readers ignore it and never report it as unknown; writers never emit it. It is not specified in 4.0.0.
+
+### Not part of a distribution
+
+`session.jsonl`, the daemon's transaction journal, is workspace state and is never read as part of a distribution (decision 0014).
 
 ## File Format Comparison
 

--- a/docs/spec/ir/schemas/v4/full/schema-checker.mdx
+++ b/docs/spec/ir/schemas/v4/full/schema-checker.mdx
@@ -264,7 +264,7 @@ Version 4 uses **wrapper objects** instead of tagged arrays:
 // V4 format
 {
   "Library": {
-    "packageName": "morphir/sdk",
+    "packageName": "morphir/SDK",
     "dependencies": {},
     "def": { "modules": {} }
   }

--- a/docs/spec/ir/schemas/v4/index.md
+++ b/docs/spec/ir/schemas/v4/index.md
@@ -528,6 +528,7 @@ Same as V3, but with `TypeAttributes`:
 - **ExtensibleRecord**: `{"ExtensibleRecord": {"variable": Name, "fields": {"field-name": Type}}}`
 - **Function**: `{"Function": {"parameterType": Type, "returnType": Type}}`
 - **Unit**: `{"Unit": {}}`
+- Every node also has an expanded spelling whose payload starts with `attributes` (decision 0005).
 
 ### Type Specifications
 
@@ -579,7 +580,7 @@ Same as V3 with `ValueAttributes`:
 
 ### Literals
 
-Same as V3:
+The six V3 literals plus one:
 
 - **BoolLiteral**
 - **CharLiteral**
@@ -587,6 +588,7 @@ Same as V3:
 - **IntegerLiteral**
 - **FloatLiteral**
 - **DecimalLiteral**
+- **DocumentLiteral** (decision 0013)
 
 ## Migration
 
@@ -607,6 +609,7 @@ Possible but **lossy**:
 - Inferred types are lost
 - Inline documentation is lost
 - New value expressions must be transformed
+- A `DocumentLiteral` cannot be downgraded; the writer refuses with `unsupported_v4_downgrade`
 
 See [Migration Guide - V4 → V3](../migration-guide/#v4--v3) for details.
 

--- a/docs/spec/ir/schemas/v4/index.md
+++ b/docs/spec/ir/schemas/v4/index.md
@@ -467,7 +467,7 @@ A complete Library distribution example showing the full structure:
 > - Distribution uses `{ "Library": { ... } }` wrapper
 > - Modules are objects keyed by module path: `{ "module/path": {...} }`
 > - Types and values within modules are objects keyed by name: `{ "type-name": {...} }`
-> - Record fields are objects keyed by field name: `{ "field-name": type }`
+> - A Record carries its fields under a `fields` member, itself an object keyed by field name (decision 0004): `{"Record": {"fields": {"field-name": type}}}`
 > - Dependencies are objects keyed by package name: `{ "package/name": spec }`
 
 ### Module Definition

--- a/docs/spec/ir/schemas/v4/index.md
+++ b/docs/spec/ir/schemas/v4/index.md
@@ -444,10 +444,7 @@ A complete Library distribution example showing the full structure:
                     "outputType": "morphir/SDK:basics#float",
                     "body": {
                       "Literal": {
-                        "attributes": {},
-                        "literal": {
-                          "FloatLiteral": 0
-                        }
+                        "FloatLiteral": 0.0
                       }
                     }
                   }

--- a/docs/spec/ir/schemas/v4/index.md
+++ b/docs/spec/ir/schemas/v4/index.md
@@ -90,7 +90,7 @@ String: "morphir/SDK:list#map"
 **Annotations:**
 V4 introduces structured annotations for semantic metadata:
 ```json
-"annotations": ["morphir/sdk:annotations#stable"]
+"annotations": ["morphir/SDK:annotations#stable"]
 ```
 
 **Benefits:**
@@ -111,7 +111,7 @@ V4 supports inline documentation for types and values:
       "doc": "Unique identifier for a user in the system",
       "TypeAliasSpecification": {
         "typeParams": [],
-        "typeExp": "morphir/sdk:string#string"
+        "typeExp": "morphir/SDK:string#string"
       }
     }
   }
@@ -141,8 +141,8 @@ List.map Just [1, 2, 3]
   "Apply": {
     "function": {
       "Apply": {
-        "function": "morphir/sdk:list#map",
-        "argument": "morphir/sdk:maybe#Just"
+        "function": "morphir/SDK:list#map",
+        "argument": "morphir/SDK:maybe#Just"
       }
     },
     "argument": [1, 2, 3]
@@ -235,7 +235,7 @@ distribution:
     "Library": {
       "packageName": "my-org/my-project",
       "dependencies": {
-        "morphir/sdk": { "modules": [...] }
+        "morphir/SDK": { "modules": [...] }
       },
       "def": { "modules": [...] }
     }
@@ -249,7 +249,7 @@ distribution:
   "formatVersion": 4,
   "distribution": {
     "Specs": {
-      "packageName": "morphir/sdk",
+      "packageName": "morphir/SDK",
       "dependencies": {
         "other/pkg": { "modules": [...] }
       },
@@ -267,7 +267,7 @@ distribution:
     "Application": {
       "packageName": "my-org/my-app",
       "dependencies": {
-        "morphir/sdk": { "modules": [...] }
+        "morphir/SDK": { "modules": [...] }
       },
       "def": { "modules": [...] },
       "entryPoints": {
@@ -321,26 +321,73 @@ A complete Library distribution example showing the full structure:
 
 ```json
 {
-  "formatVersion": 4,
+  "formatVersion": "4.0.0",
   "distribution": {
     "Library": {
       "packageName": "regulation",
       "dependencies": {
-        "morphir/sdk": {
+        "morphir/SDK": {
           "modules": {
             "basics": {
               "types": {
-                "int": { "OpaqueTypeSpecification": {} },
-                "float": { "OpaqueTypeSpecification": {} },
-                "bool": { "OpaqueTypeSpecification": {} }
+                "int": {
+                  "OpaqueTypeSpecification": {}
+                },
+                "float": {
+                  "OpaqueTypeSpecification": {}
+                },
+                "bool": {
+                  "OpaqueTypeSpecification": {}
+                }
               },
               "values": {
                 "add": {
                   "inputs": {
-                    "a": "morphir/sdk:basics#int",
-                    "b": "morphir/sdk:basics#int"
+                    "a": "morphir/SDK:basics#int",
+                    "b": "morphir/SDK:basics#int"
                   },
-                  "output": "morphir/sdk:basics#int"
+                  "output": "morphir/SDK:basics#int"
+                }
+              }
+            },
+            "list": {
+              "types": {
+                "list": {
+                  "TypeAliasSpecification": {
+                    "typeParams": [
+                      "a"
+                    ],
+                    "typeExp": {
+                      "Reference": [
+                        "morphir/SDK:list#list",
+                        "a"
+                      ]
+                    }
+                  }
+                }
+              },
+              "values": {
+                "map": {
+                  "inputs": {
+                    "f": {
+                      "Function": {
+                        "parameterType": "a",
+                        "returnType": "b"
+                      }
+                    },
+                    "list": {
+                      "Reference": [
+                        "morphir/SDK:list#list",
+                        "a"
+                      ]
+                    }
+                  },
+                  "output": {
+                    "Reference": [
+                      "morphir/SDK:list#list",
+                      "b"
+                    ]
+                  }
                 }
               }
             }
@@ -367,6 +414,24 @@ A complete Library distribution example showing the full structure:
                       }
                     }
                   }
+                },
+                "inflows": {
+                  "access": "Public",
+                  "TypeAliasDefinition": {
+                    "typeParams": [],
+                    "typeExp": {
+                      "Record": {
+                        "fields": {
+                          "assets": {
+                            "Reference": [
+                              "morphir/SDK:list#list",
+                              "regulation:u-s/f-r-2052-a/data-tables/inflows#assets"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               },
               "values": {
@@ -374,17 +439,14 @@ A complete Library distribution example showing the full structure:
                   "access": "Public",
                   "ExpressionBody": {
                     "inputTypes": {
-                      "tables": {
-                        "typeAttributes": {},
-                        "type": "regulation:u-s/f-r-2052-a/data-tables#data-tables"
-                      }
+                      "tables": "regulation:u-s/f-r-2052-a/data-tables#data-tables"
                     },
-                    "outputType": "morphir/sdk:basics#float",
+                    "outputType": "morphir/SDK:basics#float",
                     "body": {
                       "Literal": {
                         "attributes": {},
                         "literal": {
-                          "FloatLiteral": 0.0
+                          "FloatLiteral": 0
                         }
                       }
                     }
@@ -462,9 +524,9 @@ Same as V3, but with `TypeAttributes`:
 - **Reference** (no arguments): a bare FQName string, `"morphir/SDK:basics#int"`
 - **Reference** (with arguments): `{"Reference": [FQName, Type, ...]}`; the expanded `{"Reference": {"fqname": FQName, "args": [Type]}}` is accepted
 - **Tuple**: `{"Tuple": [Type, ...]}`; a bare array `[Type, ...]` is also a tuple, and `{"Tuple": {"elements": [...]}}` is accepted
-- **Record**: `{"Record": {"field-name": Type}}`
+- **Record**: `{"Record": {"fields": {"field-name": Type}}}`
 - **ExtensibleRecord**: `{"ExtensibleRecord": {"variable": Name, "fields": {"field-name": Type}}}`
-- **Function**: `{"Function": {"argumentType": Type, "returnType": Type}}`
+- **Function**: `{"Function": {"parameterType": Type, "returnType": Type}}`
 - **Unit**: `{"Unit": {}}`
 
 ### Type Specifications

--- a/docs/spec/ir/schemas/v4/whats-new.md
+++ b/docs/spec/ir/schemas/v4/whats-new.md
@@ -178,24 +178,25 @@ V4 supports compact shorthand notation for types and values when attributes are 
 ```json
 // Variable
 "a"                                    // shorthand
-{ "Variable": { "name": "a" } }        // canonical
+{ "Variable": { "name": "a" } }        // expanded (attributes first)
+{ "Variable": { "attributes": {}, "name": "a" } }
 
 // Simple reference (no type args)
-"morphir/sdk:basics#int"                           // shorthand
-{ "Reference": { "fqname": "morphir/sdk:basics#int" } }  // canonical
+"morphir/SDK:basics#int"                           // shorthand
+{ "Reference": { "fqname": "morphir/SDK:basics#int" } }  // canonical
 
 // Parameterized type: List Int
-{ "Reference": ["morphir/sdk:list#list", "morphir/sdk:basics#int"] }      // canonical
+{ "Reference": ["morphir/SDK:list#list", "morphir/SDK:basics#int"] }      // canonical
 
 // Nested: List (Maybe Int)
-{ "Reference": ["morphir/sdk:list#list", { "Reference": ["morphir/sdk:maybe#maybe", "morphir/sdk:basics#int"] }] }
+{ "Reference": ["morphir/SDK:list#list", { "Reference": ["morphir/SDK:maybe#maybe", "morphir/SDK:basics#int"] }] }
 
 // Mixed: Result String a (variable as type arg)
-{ "Reference": ["morphir/sdk:result#result", "morphir/sdk:string#string", "a"] }
+{ "Reference": ["morphir/SDK:result#result", "morphir/SDK:string#string", "a"] }
 
 // Tuple: (Int, String)
-["morphir/sdk:basics#int", "morphir/sdk:string#string"]   // shorthand
-{ "Tuple": ["morphir/sdk:basics#int", "morphir/sdk:string#string"] }   // canonical
+["morphir/SDK:basics#int", "morphir/SDK:string#string"]   // shorthand
+{ "Tuple": ["morphir/SDK:basics#int", "morphir/SDK:string#string"] }   // canonical
 ```
 
 **Disambiguation Logic:**
@@ -216,7 +217,7 @@ true                                   // shorthand for BoolLiteral
 42                                     // shorthand for IntegerLiteral
 
 // References & Variables
-"morphir/sdk:basics#add"               // shorthand for Reference
+"morphir/SDK:basics#add"               // shorthand for Reference
 "x"                                    // shorthand for Variable
 
 // Lists
@@ -228,7 +229,7 @@ true                                   // shorthand for BoolLiteral
 - If string contains `:` and `#` → FQName reference
 - If string (no special chars) → Variable name
 - If boolean/number → Literal
-- If array → List value
+- If array → List value (decision 0009; a Tuple always carries its wrapper)
 - If object → Canonical wrapper object format
 
 #### Ultra-compact Patterns
@@ -255,14 +256,14 @@ V4 supports inline documentation for types and values within module definitions.
       "doc": "Unique identifier for a user in the system",
       "TypeAliasDefinition": {
         "typeParams": [],
-        "typeExp": "morphir/sdk:string#string"
+        "typeExp": "morphir/SDK:string#string"
       }
     }
   }
 }
 ```
 
-Modules key their types and values by canonical name. The `doc` member sits beside `access` and the definition variant; the nested `{ "doc": ..., "value": ... }` wrapper is also accepted on input.
+Modules key their types and values by canonical name. The `doc` member is placed first beside the variant (decision 0010). The nested `{ "doc": ..., "value": ... }` wrapper is accepted on input for one release and reported as `legacy_spelling` (decision 0006).
 
 **Benefits:**
 - **Self-documenting IR**: Documentation travels with code
@@ -342,7 +343,7 @@ Hole(
         "target": "my-org/project:module#deleted-function"
       }
     },
-    "expectedType": "morphir/sdk:basics#int"
+    "expectedType": "morphir/SDK:basics#int"
   }
 }
 ```
@@ -352,72 +353,7 @@ Hole(
 - Preserving partial IR during refactoring
 - Marking incomplete implementations
 
-#### Native
-
-Represents a native platform operation with no IR body.
-
-**Structure:**
-```gleam
-Native(
-  attributes: attributes,
-  fqname: FQName,
-  native_info: NativeInfo
-)
-```
-
-**NativeInfo:**
-```gleam
-NativeInfo(
-  hint: NativeHint,          // Arithmetic, Comparison, StringOp, CollectionOp, PlatformSpecific
-  description: Option(String)
-)
-```
-
-**Example:**
-```json
-{
-  "Native": {
-    "fqname": "morphir/sdk:basics#add",
-    "nativeInfo": {
-      "hint": { "Arithmetic": {} },
-      "description": "Integer addition"
-    }
-  }
-}
-```
-
-**Use cases:**
-- Representing SDK builtins (add, subtract, string operations)
-- Platform-specific operations (database queries, HTTP calls)
-- Operations that cannot be expressed in pure IR
-
-#### External
-
-Represents an external FFI call to another platform.
-
-**Structure:**
-```gleam
-External(
-  attributes: attributes,
-  external_name: String,
-  target_platform: String
-)
-```
-
-**Example:**
-```json
-{
-  "External": {
-    "externalName": "calculateTaxRate",
-    "targetPlatform": "JavaScript"
-  }
-}
-```
-
-**Use cases:**
-- FFI calls to JavaScript, Python, etc.
-- Integration with platform-specific libraries
-- Interop with non-Morphir code
+Native and external operations are definition bodies, not expressions (decision 0008); see section 7.
 
 ---
 
@@ -443,10 +379,10 @@ NativeBody(
 {
   "NativeBody": {
     "inputTypes": {
-      "a": "morphir/sdk:basics#int",
-      "b": "morphir/sdk:basics#int"
+      "a": "morphir/SDK:basics#int",
+      "b": "morphir/SDK:basics#int"
     },
-    "outputType": "morphir/sdk:basics#int",
+    "outputType": "morphir/SDK:basics#int",
     "nativeInfo": {
       "hint": { "Arithmetic": {} }
     }
@@ -463,10 +399,22 @@ For external FFI definitions.
 ExternalBody(
   input_types: List(#(Name, Type(attributes))),
   output_type: Type(attributes),
-  external_name: String,
-  target_platform: String
+  externals: List(ExternalBinding),
+  body: Option(Value(attributes))
+)
+
+ExternalBinding(
+  target_platform: String,
+  external_name: String
 )
 ```
+
+**Example:**
+```json
+{ "ExternalBody": { "inputTypes": { "x": "morphir/SDK:basics#int" }, "outputType": "morphir/SDK:basics#int", "externals": [{ "targetPlatform": "erlang", "externalName": "math:abs" }, { "targetPlatform": "javascript", "externalName": "Math.abs" }], "body": { "Variable": "x" } } }
+```
+
+The single-binding spelling with top-level `externalName`/`targetPlatform` is accepted for one release (decision 0006).
 
 #### IncompleteBody
 
@@ -504,6 +452,14 @@ The expanded `{ "IntegerLiteral": { "value": 42 } }` form is accepted on input.
 
 **Migration**: Decoders should accept both `WholeNumberLiteral` and `IntegerLiteral` for backwards compatibility. Encoders should output `IntegerLiteral`.
 
+#### DocumentLiteral (new)
+
+```json
+{ "DocumentLiteral": { "name": "Alice", "age": 30, "tags": ["admin", "user"], "metadata": null } }
+```
+
+The payload is the document itself; there is no `{ "value": ... }` spelling. Number lexemes are preserved. A document cannot be pattern matched. Typed `morphir/SDK:document#document` (decision 0013).
+
 ---
 
 ### 9. Permissive Input, Canonical Output Policy
@@ -519,7 +475,7 @@ This applies to all V4 constructs. The table below summarizes key formats:
 |-----------|-----------------|---------------|
 | **Access** | `"Public"`, `"Private"` | `"public"`, `"private"`, `"pub"` |
 | **AccessControlled** | `{ "Public": {...} }` | `{ "pub": {...} }`, `{ "access": "Public", "value": {...} }` |
-| **ReferenceType (no args)** | `"morphir/sdk:basics#int"` | `{ "Reference": "..." }`, `{ "Reference": { "fqname": "..." } }` |
+| **ReferenceType (no args)** | `"morphir/SDK:basics#int"` | `{ "Reference": "..." }`, `{ "Reference": { "fqname": "..." } }` |
 | **ReferenceType (with args)** | `{ "Reference": ["fqname", t1, ...] }` | `{ "Reference": { "fqname": "...", "args": [...] } }` |
 | **TupleType** | `{ "Tuple": [t1, t2, ...] }` | `[t1, t2, ...]`, `{ "Tuple": { "elements": [...] } }` |
 | **TuplePattern** | `{ "TuplePattern": [p1, p2, ...] }` | `[p1, p2, ...]`, `{ "TuplePattern": { "patterns": [...] } }` |
@@ -548,8 +504,8 @@ V4 moves from **tagged arrays** to **wrapper objects** for the canonical format:
 ```json
 {
   "Apply": {
-    "function": { "Reference": { "fqname": "..." } },
-    "argument": { "Literal": { "literal": {...} } }
+    "function": { "Reference": "..." },
+    "argument": { "Literal": { "IntegerLiteral": 1 } }
   }
 }
 ```
@@ -578,7 +534,7 @@ Unlike attributes (used for implementation-level metadata like source locations)
 **Compact Shorthand:**
 ```json
 "annotations": [
-  "morphir/sdk:annotations#stable",
+  "morphir/SDK:annotations#stable",
   "my-org/sdk:annotations#deprecated:Use new-version instead"
 ]
 ```

--- a/docs/spec/ir/schemas/v4/whats-new.md
+++ b/docs/spec/ir/schemas/v4/whats-new.md
@@ -178,12 +178,12 @@ V4 supports compact shorthand notation for types and values when attributes are 
 ```json
 // Variable
 "a"                                    // shorthand
-{ "Variable": { "name": "a" } }        // expanded (attributes first)
-{ "Variable": { "attributes": {}, "name": "a" } }
+{ "Variable": { "name": "a" } }        // expanded, attributes omitted
+{ "Variable": { "attributes": {}, "name": "a" } }        // expanded (attributes first)
 
 // Simple reference (no type args)
 "morphir/SDK:basics#int"                           // shorthand
-{ "Reference": { "fqname": "morphir/SDK:basics#int" } }  // canonical
+{ "Reference": { "fqname": "morphir/SDK:basics#int" } }  // accepted
 
 // Parameterized type: List Int
 { "Reference": ["morphir/SDK:list#list", "morphir/SDK:basics#int"] }      // canonical
@@ -480,12 +480,12 @@ This applies to all V4 constructs. The table below summarizes key formats:
 | **TupleType** | `{ "Tuple": [t1, t2, ...] }` | `[t1, t2, ...]`, `{ "Tuple": { "elements": [...] } }` |
 | **TuplePattern** | `{ "TuplePattern": [p1, p2, ...] }` | `[p1, p2, ...]`, `{ "TuplePattern": { "patterns": [...] } }` |
 | **TupleValue** | `{ "Tuple": [v1, v2, ...] }` | `{ "Tuple": { "elements": [...] } }` (NO bare arrays) |
-| **ListValue** | `{ "List": [v1, v2, ...] }` | `{ "List": { "items": [...] } }` (NO bare arrays) |
+| **ListValue** | `{ "List": [v1, v2, ...] }` | `[v1, v2, ...]`, `{ "List": { "items": [...] } }` |
 | **Literals** | `{ "IntegerLiteral": 42 }` | `{ "IntegerLiteral": { "value": 42 } }`, `{ "WholeNumberLiteral": 42 }` |
 
 :::note Design Rationale
 - **TupleType** allows bare arrays because ReferenceType does NOT (avoiding ambiguity)
-- **TupleValue/ListValue** do NOT allow bare arrays because they would be ambiguous with each other
+- A bare array is a List, and a Tuple always carries its wrapper, so the two cannot be confused (decision 0009)
 - **Access abbreviations** like `"pub"` improve ergonomics for hand-written IR
 :::
 

--- a/kb/bundles/morphir/morphir-ir/ir-v4-stabilization.md
+++ b/kb/bundles/morphir/morphir-ir/ir-v4-stabilization.md
@@ -160,7 +160,11 @@ operations as definition bodies (0008), bare arrays as lists and bare scalars as
 member (0010), the SDK package as `morphir/SDK` (0011), one legacy name grammar and one FileStem (0012),
 `DocumentLiteral` in 4.0.0 (0013), and the scope of the remaining design-only features (0014). Items 1 to 5 and 7
 below are therefore decided; the list is kept as the record of what was asked. Item 6 (the exact-release table)
-stays open. The kit flips, schema, example, and prose changes that implement the records are plan 2d.
+stays open. The kit flips, schema, example, and prose changes that implement the records are plan 2d. Plan 2d
+landed on 2026-09-05: the kit carries 74 cases with the records' spellings (`accepted warning=legacy_spelling`
+marks the one-release window), the reference codec passes every JSON fence, both schemas and every accepted
+fence agree (`mise run mck:schema-check`), and the examples and pages are rewritten. Item 6 is the only open
+decision.
 
 These cannot be closed by editing prose. Each needs a maintainer decision, and each has a bead.
 
@@ -219,9 +223,8 @@ decision row about a spelling has a `pending` case naming its bead; rows about s
 body validation, the `session.jsonl` and `deco` scope) have none, because they are not spellings. Case IDs
 (`types-0003`) are stable and are the way beads and decision records cite the kit.
 
-Rejection-only cases such as names-0003 are active. The Record spelling case (types-0005) and the whole-document
-case (distributions-0004) are pending on the vocabulary decision, and the review of the seed kit found that the
-v4 schema validates any content inside an access-controlled definition, so it never decided that spelling.
+Rejection-only cases such as names-0003 are active. No case is pending except versions-0002. It is a write
+refusal the kit grammar cannot express until plan 2b.
 
 ## Tracking
 

--- a/kb/bundles/morphir/morphir-ir/ir-v4-stabilization.md
+++ b/kb/bundles/morphir/morphir-ir/ir-v4-stabilization.md
@@ -164,7 +164,7 @@ stays open. The kit flips, schema, example, and prose changes that implement the
 landed on 2026-09-05: the kit carries 74 cases with the records' spellings (`accepted warning=legacy_spelling`
 marks the one-release window), the reference codec passes every JSON fence, both schemas and every accepted
 fence agree (`mise run mck:schema-check`), and the examples and pages are rewritten. Item 6 is the only open
-decision.
+spelling decision. Item 8, where the naming codec model lives, stays open under decision 0003.
 
 These cannot be closed by editing prose. Each needs a maintainer decision, and each has a bead.
 

--- a/kb/bundles/morphir/morphir-ir/log.md
+++ b/kb/bundles/morphir/morphir-ir/log.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-05
 
-* **Update**: Implemented decisions 0004 to 0014 (plan 2d): kit cases flipped and extended to 74, reference codec, both schemas, examples, specification and design pages, and the naming corpus's truncation cases. The remaining open decision is the 4.1.0 support policy (bead morphir-ir-v4-stabilize.8).
+* **Update**: Implemented decisions 0004 to 0014 (plan 2d): kit cases flipped and extended to 74, reference codec, both schemas, examples, specification and design pages, and the naming corpus's truncation cases. The remaining open decisions are the 4.1.0 support policy and the naming codec's home (decision 0003).
 
 ## 2026-09-04
 

--- a/kb/bundles/morphir/morphir-ir/log.md
+++ b/kb/bundles/morphir/morphir-ir/log.md
@@ -1,5 +1,9 @@
 # Log
 
+## 2026-09-05
+
+* **Update**: Implemented decisions 0004 to 0014 (plan 2d): kit cases flipped and extended to 74, reference codec, both schemas, examples, specification and design pages, and the naming corpus's truncation cases. The remaining open decision is the 4.1.0 support policy (bead morphir-ir-v4-stabilize.8).
+
 ## 2026-09-04
 
 * **Creation**: Added [decision 0004](/decisions/0004-record-fields-are-spelled-under-a-fields-member.md) and [decision 0005](/decisions/0005-attributes-are-an-optional-first-member-of-every-node-payload.md), the first two spelling decisions closed through the Morphir Compatibility Kit; both were surfaced by the reference codec's first run against the kit.

--- a/spec/ir/mck/definitions.md
+++ b/spec/ir/mck/definitions.md
@@ -43,6 +43,8 @@ OpaqueTypeSpecification: {}
 
 ## definitions-0003: Custom type definition with constructors {node=TypeDefinition}
 
+Decision 0007 names a constructor's slots parameters in the model; the wire spelling, a list of `[name, type]` pairs per constructor, is unchanged.
+
 ```yaml canonical
 CustomTypeDefinition:
   typeParams: [a]
@@ -88,6 +90,108 @@ ExpressionBody:
 { "ExpressionBody": { "inputTypes": { "x": "morphir/SDK:basics#int" }, "outputType": "morphir/SDK:basics#int", "body": { "Variable": "x" } } }
 ```
 
-## definitions-0006: Documentation on a definition {node=AccessControlledTypeDefinition status=pending}
+## definitions-0006: Documentation on a definition {node=AccessControlledTypeDefinition}
 
-The schema accepts `doc` flattened beside `access` and nested as `{doc, value}`. Bead morphir-ir-v4-stabilize.5 picks the canonical spelling; the flattened form is what the CLI writes and both examples use.
+Decision 0010: `doc` is a flattened member placed first beside the variant. The nested `{ "doc", "value" }` wrapper is accepted for the window of decision 0006. Bead morphir-ir-v4-stabilize.5.
+
+```yaml canonical
+Public:
+  doc: The user's display name
+  TypeAliasDefinition:
+    typeParams: []
+    typeExp: morphir/SDK:string#string
+```
+
+```json canonical
+{ "Public": { "doc": "The user's display name", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } } }
+```
+
+```json accepted
+{ "access": "Public", "doc": "The user's display name", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } }
+```
+
+```json accepted warning=legacy_spelling
+{ "Public": { "doc": "The user's display name", "value": { "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } } } }
+```
+
+## definitions-0007: Native and external bodies {node=ValueDefinition}
+
+Decision 0008: `ExternalBody` carries a list of per-target bindings and an optional fallback `body`, so a Gleam-style external with a body encodes faithfully. The single-binding spelling with `externalName` and `targetPlatform` at the top level is accepted for the window of decision 0006 as a one-entry list.
+
+```yaml canonical
+ExternalBody:
+  inputTypes:
+    msg: morphir/SDK:string#string
+  outputType: morphir/SDK:basics#unit
+  externals:
+    - targetPlatform: javascript
+      externalName: console.log
+```
+
+```json canonical
+{ "ExternalBody": { "inputTypes": { "msg": "morphir/SDK:string#string" }, "outputType": "morphir/SDK:basics#unit", "externals": [{ "targetPlatform": "javascript", "externalName": "console.log" }] } }
+```
+
+```json accepted warning=legacy_spelling
+{ "ExternalBody": { "inputTypes": { "msg": "morphir/SDK:string#string" }, "outputType": "morphir/SDK:basics#unit", "externalName": "console.log", "targetPlatform": "javascript" } }
+```
+
+## definitions-0008: External body with two bindings and a fallback {node=ValueDefinition}
+
+```yaml canonical
+ExternalBody:
+  inputTypes:
+    x: morphir/SDK:basics#int
+  outputType: morphir/SDK:basics#int
+  externals:
+    - targetPlatform: erlang
+      externalName: math:abs
+    - targetPlatform: javascript
+      externalName: Math.abs
+  body:
+    Variable: x
+```
+
+```json canonical
+{ "ExternalBody": { "inputTypes": { "x": "morphir/SDK:basics#int" }, "outputType": "morphir/SDK:basics#int", "externals": [{ "targetPlatform": "erlang", "externalName": "math:abs" }, { "targetPlatform": "javascript", "externalName": "Math.abs" }], "body": { "Variable": "x" } } }
+```
+
+## definitions-0009: Native body {node=ValueDefinition}
+
+```yaml canonical
+NativeBody:
+  inputTypes:
+    a: morphir/SDK:basics#int
+    b: morphir/SDK:basics#int
+  outputType: morphir/SDK:basics#int
+  nativeInfo:
+    hint:
+      Arithmetic: {}
+```
+
+```json canonical
+{ "NativeBody": { "inputTypes": { "a": "morphir/SDK:basics#int", "b": "morphir/SDK:basics#int" }, "outputType": "morphir/SDK:basics#int", "nativeInfo": { "hint": { "Arithmetic": {} } } } }
+```
+
+## definitions-0010: Documentation on a value specification {node=ModuleSpecification}
+
+Decision 0010: a value specification's `doc` is first beside its own members; the nested `{ "doc", "value" }` wrapper is accepted for the window.
+
+```yaml canonical
+types: {}
+values:
+  add:
+    doc: Adds two integers
+    inputs:
+      a: morphir/SDK:basics#int
+      b: morphir/SDK:basics#int
+    output: morphir/SDK:basics#int
+```
+
+```json canonical
+{ "types": {}, "values": { "add": { "doc": "Adds two integers", "inputs": { "a": "morphir/SDK:basics#int", "b": "morphir/SDK:basics#int" }, "output": "morphir/SDK:basics#int" } } }
+```
+
+```json accepted warning=legacy_spelling
+{ "types": {}, "values": { "add": { "doc": "Adds two integers", "value": { "inputs": { "a": "morphir/SDK:basics#int", "b": "morphir/SDK:basics#int" }, "output": "morphir/SDK:basics#int" } } } }
+```

--- a/spec/ir/mck/definitions.md
+++ b/spec/ir/mck/definitions.md
@@ -156,6 +156,12 @@ ExternalBody:
 { "ExternalBody": { "inputTypes": { "x": "morphir/SDK:basics#int" }, "outputType": "morphir/SDK:basics#int", "externals": [{ "targetPlatform": "erlang", "externalName": "math:abs" }, { "targetPlatform": "javascript", "externalName": "Math.abs" }], "body": { "Variable": "x" } } }
 ```
 
+Decision 0008: targetPlatform values are unique within externals.
+
+```json rejected diagnostic=duplicate_member
+{ "ExternalBody": { "inputTypes": { "x": "morphir/SDK:basics#int" }, "outputType": "morphir/SDK:basics#int", "externals": [{ "targetPlatform": "javascript", "externalName": "a" }, { "targetPlatform": "javascript", "externalName": "b" }] } }
+```
+
 ## definitions-0009: Native body {node=ValueDefinition}
 
 ```yaml canonical

--- a/spec/ir/mck/distributions.md
+++ b/spec/ir/mck/distributions.md
@@ -52,14 +52,34 @@ distribution:
 { "formatVersion": 4, "distribution": ["Library", "example/v4-test", {}, { "modules": [] }] }
 ```
 
-## distributions-0004: Complete library, JSON and YAML agree {node=Distribution status=pending}
+## distributions-0004: Complete library, JSON and YAML agree {node=Distribution}
 
-The complete example writes record fields under a fields member, which types-0005 leaves to bead morphir-ir-v4-stabilize.1. Until that decision lands, this whole-document case is pending and its two renderings are illustrations only.
+The published complete example and its YAML rendering are the same distribution. Both write record fields under `fields` (decision 0004), the SDK as `morphir/SDK` (decision 0011), and the list function's `parameterType` (decision 0007).
 
-```text
+```text canonical
 website/static/ir/examples/v4/complete-example.json
 ```
 
-```text
+```text canonical
 spec/ir/mck/documents/complete-example.yaml
+```
+
+## distributions-0005: The SDK dependency is keyed morphir/SDK {node=Distribution}
+
+Decision 0011. `morphir/sdk` is a valid name for some other package, so it is not rejected; it is simply not the SDK.
+
+```yaml canonical
+formatVersion: 4
+distribution:
+  Library:
+    packageName: example
+    dependencies:
+      morphir/SDK:
+        modules: {}
+    def:
+      modules: {}
+```
+
+```json canonical
+{ "formatVersion": 4, "distribution": { "Library": { "packageName": "example", "dependencies": { "morphir/SDK": { "modules": {} } }, "def": { "modules": {} } } } }
 ```

--- a/spec/ir/mck/document-tree.md
+++ b/spec/ir/mck/document-tree.md
@@ -55,6 +55,7 @@ formatVersion: 4
 name: user-ID
 def:
   Public:
+    doc: The user's identifier
     TypeAliasDefinition:
       typeParams: []
       typeExp: morphir/SDK:string#string
@@ -73,8 +74,94 @@ distribution:
             types:
               user-ID:
                 Public:
+                  doc: The user's identifier
                   TypeAliasDefinition:
                     typeParams: []
                     typeExp: morphir/SDK:string#string
+            values: {}
+```
+
+## document-tree-0004: A stem truncated for the path budget is recorded in fileNames {node=Distribution}
+
+Decision 0012. The budget is 64 characters from the distribution root. `pkg/my-org/my-project/domain/` is 29 characters and `.type.yaml` is 10, leaving 25 for the stem; a truncated stem keeps `25 - 10 = 15` characters of the escaped stem, drops any trailing `-` or `_`, and appends `__` plus the first 8 hex digits of the SHA-256 of the untruncated escaped stem. The module manifest maps the canonical name to the stem, and the name still appears under `types`.
+
+```yaml file path=manifest set=truncate
+formatVersion: 4
+distribution: Library
+package: my-org/my-project
+pathBudget: 64
+```
+
+```yaml file path=pkg/my-org/my-project/domain/module set=truncate
+formatVersion: 4
+path: domain
+types: [customer-relationship-management-record]
+values: []
+fileNames:
+  customer-relationship-management-record: customer-relati__44a101f8
+```
+
+```yaml file path=pkg/my-org/my-project/domain/customer-relati__44a101f8.type set=truncate
+formatVersion: 4
+name: customer-relationship-management-record
+def:
+  Public:
+    TypeAliasDefinition:
+      typeParams: []
+      typeExp: morphir/SDK:string#string
+```
+
+```yaml canonical
+formatVersion: 4
+distribution:
+  Library:
+    packageName: my-org/my-project
+    dependencies: {}
+    def:
+      modules:
+        domain:
+          Public:
+            types:
+              customer-relationship-management-record:
+                Public:
+                  TypeAliasDefinition:
+                    typeParams: []
+                    typeExp: morphir/SDK:string#string
+            values: {}
+```
+
+## document-tree-0005: A top-level $meta member is reserved and ignored {node=Distribution}
+
+Decision 0014. A reader never reports `unknown_member` for `$meta` at the top level of a document-tree file, and never writes one. `session.jsonl` is daemon workspace state, not part of a distribution.
+
+```yaml file path=manifest set=meta
+formatVersion: 4
+distribution: Library
+package: my-org/my-project
+pathBudget: 4000
+$meta:
+  generator: example
+```
+
+```yaml file path=pkg/my-org/my-project/domain/module set=meta
+formatVersion: 4
+path: domain
+types: []
+values: []
+$meta:
+  generator: example
+```
+
+```yaml canonical
+formatVersion: 4
+distribution:
+  Library:
+    packageName: my-org/my-project
+    dependencies: {}
+    def:
+      modules:
+        domain:
+          Public:
+            types: {}
             values: {}
 ```

--- a/spec/ir/mck/documents/complete-example.yaml
+++ b/spec/ir/mck/documents/complete-example.yaml
@@ -80,7 +80,5 @@ distribution:
                   outputType: "morphir/SDK:basics#float"
                   body:
                     Literal:
-                      attributes: {}
-                      literal:
-                        FloatLiteral: 0
+                      FloatLiteral: 0.0
             doc: Data tables module for regulatory reporting

--- a/spec/ir/mck/documents/complete-example.yaml
+++ b/spec/ir/mck/documents/complete-example.yaml
@@ -3,7 +3,7 @@ distribution:
   Library:
     packageName: regulation
     dependencies:
-      morphir/sdk:
+      morphir/SDK:
         modules:
           basics:
             types:
@@ -16,9 +16,9 @@ distribution:
             values:
               add:
                 inputs:
-                  a: "morphir/sdk:basics#int"
-                  b: "morphir/sdk:basics#int"
-                output: "morphir/sdk:basics#int"
+                  a: "morphir/SDK:basics#int"
+                  b: "morphir/SDK:basics#int"
+                output: "morphir/SDK:basics#int"
           list:
             types:
               list:
@@ -27,22 +27,22 @@ distribution:
                     - a
                   typeExp:
                     Reference:
-                      - "morphir/sdk:list#list"
+                      - "morphir/SDK:list#list"
                       - a
             values:
               map:
                 inputs:
                   f:
                     Function:
-                      argumentType: a
+                      parameterType: a
                       returnType: b
                   list:
                     Reference:
-                      - "morphir/sdk:list#list"
+                      - "morphir/SDK:list#list"
                       - a
                 output:
                   Reference:
-                    - "morphir/sdk:list#list"
+                    - "morphir/SDK:list#list"
                     - b
     def:
       modules:
@@ -69,7 +69,7 @@ distribution:
                       fields:
                         assets:
                           Reference:
-                            - "morphir/sdk:list#list"
+                            - "morphir/SDK:list#list"
                             - "regulation:u-s/f-r-2052-a/data-tables/inflows#assets"
             values:
               calculate-total:
@@ -77,7 +77,7 @@ distribution:
                 ExpressionBody:
                   inputTypes:
                     tables: "regulation:u-s/f-r-2052-a/data-tables#data-tables"
-                  outputType: "morphir/sdk:basics#float"
+                  outputType: "morphir/SDK:basics#float"
                   body:
                     Literal:
                       attributes: {}

--- a/spec/ir/mck/names.md
+++ b/spec/ir/mck/names.md
@@ -74,10 +74,48 @@ morphir/SDK:list#map
 [[["morphir"], ["s", "d", "k"]], [["list"]], ["map"]]
 ```
 
-## names-0006: The SDK package name {node=Path status=pending}
+## names-0006: The SDK package name {node=Path}
 
-Decision 0001 makes an uppercase segment an initialism, so the legacy array [["morphir"], ["s", "d", "k"]] decodes to morphir/SDK, and names-0004 pins that. Every published v4 example and every spec page writes morphir/sdk, which under the same decision is a different package whose second segment is the word sdk. One of them is wrong. Bead morphir-ir-v4-stabilize.1 owns the answer together with the value vocabulary, because every fixture changes with it.
+Decision 0011: the SDK's canonical package name is `morphir/SDK`, because morphir-elm's `Path.fromString` splits `SDK` into single-letter words that decision 0001 decodes as one initialism. `morphir/sdk` is a different, valid name and is not rejected; distributions-0005 pins the dependency key.
 
-## names-0007: Legacy array item grammar and the FileStem suffix {node=Name status=pending}
+```yaml canonical
+morphir/SDK
+```
 
-The core schema accepts legacy array items matching ^[a-z0-9]+$ while the document-tree schema requires ^[a-z][a-z0-9]*$, so ["item", "2"] is legal in one and not the other. The core schema's FileStem allows a __[0-9a-f]{8} truncation suffix that the naming corpus omits. Bead morphir-ir-v4-stabilize.13 applies decision 0001's consequences to both schemas; this case becomes active when it does.
+```json canonical
+"morphir/SDK"
+```
+
+```json accepted
+[["morphir"], ["s", "d", "k"]]
+```
+
+## names-0007: Legacy array items may be digits {node=Name}
+
+Decision 0012: both schemas use the core legacy word grammar `^[a-z0-9]+$`, so a digits-only word is legal. `["f", "r", "2052", "a"]` decodes as the naming corpus records: the letter run `f r` is one initialism, `2052` breaks the run, and the trailing `a` is a run of one, so a word.
+
+```yaml canonical
+item-2
+```
+
+```json canonical
+"item-2"
+```
+
+```json accepted
+["item", "2"]
+```
+
+## names-0008: A digit word breaks an initialism run {node=Name}
+
+```yaml canonical
+FR-2052-a
+```
+
+```json canonical
+"FR-2052-a"
+```
+
+```json accepted
+["f", "r", "2052", "a"]
+```

--- a/spec/ir/mck/patterns-and-literals.md
+++ b/spec/ir/mck/patterns-and-literals.md
@@ -55,6 +55,10 @@ TuplePattern:
 { "TuplePattern": { "patterns": [{ "WildcardPattern": {} }, { "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "x" } }] } }
 ```
 
+```json accepted
+{ "TuplePattern": { "attributes": {}, "patterns": [{ "WildcardPattern": {} }, { "AsPattern": { "attributes": {}, "pattern": { "WildcardPattern": { "attributes": {} } }, "name": "x" } }] } }
+```
+
 ## patterns-and-literals-0004: Literal pattern shorthand {node=Pattern}
 
 ```yaml canonical
@@ -68,4 +72,130 @@ LiteralPattern:
 
 ```json accepted
 { "LiteralPattern": 42 }
+```
+
+```json accepted
+{ "LiteralPattern": { "attributes": {}, "literal": { "IntegerLiteral": 42 } } }
+```
+
+## patterns-and-literals-0005: Document literal {node=Literal}
+
+Decision 0013: the seventh literal carries a schema-less JSON-like tree verbatim, typed as `morphir/SDK:document#document`. Its payload is the document itself, so there is no `{ "value": .. }` spelling: `{ "DocumentLiteral": { "value": 1 } }` is the one-member document `{"value": 1}`. Number lexemes are preserved; a backend that reads `9007199254740993` through a 64-bit float fails this case visibly.
+
+```yaml canonical
+DocumentLiteral:
+  name: Alice
+  age: 30
+  tags: [admin, user]
+  metadata: null
+```
+
+```json canonical
+{ "DocumentLiteral": { "name": "Alice", "age": 30, "tags": ["admin", "user"], "metadata": null } }
+```
+
+## patterns-and-literals-0006: Document literal keeps large integers {node=Literal}
+
+```yaml canonical
+DocumentLiteral:
+  id: 9007199254740993
+  ratio: 0.10
+```
+
+```json canonical
+{ "DocumentLiteral": { "id": 9007199254740993, "ratio": 0.10 } }
+```
+
+## patterns-and-literals-0007: A document cannot be pattern matched {node=Pattern}
+
+Decision 0013: no `LiteralPattern` on a document.
+
+```json rejected diagnostic=invalid_literal
+{ "LiteralPattern": { "DocumentLiteral": { "name": "Alice" } } }
+```
+
+## patterns-and-literals-0008: Nullary patterns {node=Pattern}
+
+Wildcard, empty-list and unit patterns take an empty payload, or `attributes` alone.
+
+```yaml canonical
+WildcardPattern: {}
+```
+
+```json canonical
+{ "WildcardPattern": {} }
+```
+
+```json accepted
+{ "WildcardPattern": { "attributes": {} } }
+```
+
+## patterns-and-literals-0009: Empty list and unit patterns {node=Pattern}
+
+```yaml canonical
+EmptyListPattern: {}
+```
+
+```json canonical
+{ "EmptyListPattern": {} }
+```
+
+```json accepted
+{ "EmptyListPattern": { "attributes": {} } }
+```
+
+## patterns-and-literals-0010: Constructor pattern {node=Pattern}
+
+```yaml canonical
+ConstructorPattern:
+  fqname: morphir/SDK:maybe#just
+  patterns:
+    - AsPattern:
+        pattern:
+          WildcardPattern: {}
+        name: x
+```
+
+```json canonical
+{ "ConstructorPattern": { "fqname": "morphir/SDK:maybe#just", "patterns": [{ "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "x" } }] } }
+```
+
+```json accepted
+{ "ConstructorPattern": { "attributes": {}, "fqname": "morphir/SDK:maybe#just", "patterns": [{ "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "x" } }] } }
+```
+
+## patterns-and-literals-0011: Head-tail and unit patterns {node=Pattern}
+
+```yaml canonical
+HeadTailPattern:
+  head:
+    AsPattern:
+      pattern:
+        WildcardPattern: {}
+      name: x
+  tail:
+    UnitPattern: {}
+```
+
+```json canonical
+{ "HeadTailPattern": { "head": { "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "x" } }, "tail": { "UnitPattern": {} } } }
+```
+
+```json accepted
+{ "HeadTailPattern": { "attributes": {}, "head": { "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "x" } }, "tail": { "UnitPattern": { "attributes": {} } } } }
+```
+
+## patterns-and-literals-0012: Attributes are kept when compared with them {node=Pattern compare=attributes}
+
+```yaml canonical
+AsPattern:
+  attributes:
+    source: { startLine: 2, startColumn: 1, endLine: 2, endColumn: 2 }
+  pattern:
+    WildcardPattern: {}
+  name: x
+```
+
+```json canonical
+{ "AsPattern": { "attributes": { "source": { "startLine": 2, "startColumn": 1, "endLine": 2, "endColumn": 2 } }, "pattern": { "WildcardPattern": {} }, "name": "x" } }
 ```

--- a/spec/ir/mck/types.md
+++ b/spec/ir/mck/types.md
@@ -1,6 +1,6 @@
 # Types
 
-Type expressions. The bare-array rule closed bead morphir-j442: a bare array is a Tuple, and a parameterized reference always carries the `Reference` wrapper.
+Type expressions. The bare-array rule closed bead morphir-j442: a bare array is a Tuple, and a parameterized reference always carries the `Reference` wrapper. Every node has a compact spelling and an expanded spelling whose payload starts with `attributes` (decision 0005); the expanded spelling with empty attributes is accepted and never written.
 
 ## types-0001: Type variable {node=Type}
 
@@ -10,6 +10,10 @@ a
 
 ```json canonical
 "a"
+```
+
+```json accepted
+{ "Variable": { "attributes": {}, "name": "a" } }
 ```
 
 ## types-0002: Reference without arguments {node=Type}
@@ -34,6 +38,10 @@ morphir/SDK:basics#int
 { "Reference": { "fqname": "morphir/SDK:basics#int", "args": [] } }
 ```
 
+```json accepted
+{ "Reference": { "attributes": {}, "fqname": "morphir/SDK:basics#int" } }
+```
+
 ## types-0003: Reference with one argument {node=Type}
 
 Closes bead morphir-ir-v4-stabilize.2 once the Rust decoder agrees.
@@ -48,6 +56,10 @@ Reference: ["morphir/SDK:list#list", a]
 
 ```json accepted
 { "Reference": { "fqname": "morphir/SDK:list#list", "args": ["a"] } }
+```
+
+```json accepted
+{ "Reference": { "attributes": {}, "fqname": "morphir/SDK:list#list", "args": ["a"] } }
 ```
 
 ```yaml rejected expect=Tuple
@@ -72,18 +84,31 @@ Tuple: ["morphir/SDK:basics#int", "morphir/SDK:string#string"]
 { "Tuple": { "elements": ["morphir/SDK:basics#int", "morphir/SDK:string#string"] } }
 ```
 
-## types-0005: Record type {node=Type status=pending}
-
-The schema's RecordType definition writes fields directly under Record, while the published complete example, the document-tree specification page, and the Rust CLI output write them under a fields member. Both validate today because the schema does not check definition bodies. Bead morphir-ir-v4-stabilize.1 decides the canonical spelling; until then this case is pending and both spellings appear below as illustrations only.
-
-```yaml
-Record:
-  name: morphir/SDK:string#string
-  age: morphir/SDK:basics#int
+```json accepted
+{ "Tuple": { "attributes": {}, "elements": ["morphir/SDK:basics#int", "morphir/SDK:string#string"] } }
 ```
 
-```json
+## types-0005: Record type {node=Type}
+
+Decision 0004: fields live under a `fields` member, so `attributes` can sit beside them. The field map directly under `Record`, which the schema documented until 2026-09-04, is accepted for the one-release window of decision 0006 and reported as `legacy_spelling`.
+
+```yaml canonical
+Record:
+  fields:
+    name: morphir/SDK:string#string
+    age: morphir/SDK:basics#int
+```
+
+```json canonical
 { "Record": { "fields": { "name": "morphir/SDK:string#string", "age": "morphir/SDK:basics#int" } } }
+```
+
+```json accepted
+{ "Record": { "attributes": {}, "fields": { "name": "morphir/SDK:string#string", "age": "morphir/SDK:basics#int" } } }
+```
+
+```json accepted warning=legacy_spelling
+{ "Record": { "name": "morphir/SDK:string#string", "age": "morphir/SDK:basics#int" } }
 ```
 
 ## types-0006: Extensible record type {node=Type}
@@ -99,21 +124,33 @@ ExtensibleRecord:
 { "ExtensibleRecord": { "variable": "r", "fields": { "email": "morphir/SDK:string#string" } } }
 ```
 
+```json accepted
+{ "ExtensibleRecord": { "attributes": {}, "variable": "r", "fields": { "email": "morphir/SDK:string#string" } } }
+```
+
 ## types-0007: Function type {node=Type}
 
-The Rust encoder writes `arg` and `result` today; those are rejected. Bead morphir-ir-v4-stabilize.3.
+Decision 0007: a Function type declares a `parameterType`. `argumentType` (the pre-decision schema) and `arg`/`result` (the Rust encoder) are accepted for the window of decision 0006. Bead morphir-ir-v4-stabilize.3.
 
 ```yaml canonical
 Function:
-  argumentType: morphir/SDK:basics#int
+  parameterType: morphir/SDK:basics#int
   returnType: morphir/SDK:string#string
 ```
 
 ```json canonical
+{ "Function": { "parameterType": "morphir/SDK:basics#int", "returnType": "morphir/SDK:string#string" } }
+```
+
+```json accepted
+{ "Function": { "attributes": {}, "parameterType": "morphir/SDK:basics#int", "returnType": "morphir/SDK:string#string" } }
+```
+
+```json accepted warning=legacy_spelling
 { "Function": { "argumentType": "morphir/SDK:basics#int", "returnType": "morphir/SDK:string#string" } }
 ```
 
-```json rejected diagnostic=unknown_member
+```json accepted warning=legacy_spelling
 { "Function": { "arg": "morphir/SDK:basics#int", "result": "morphir/SDK:string#string" } }
 ```
 
@@ -127,10 +164,41 @@ Unit: {}
 { "Unit": {} }
 ```
 
-## types-0009: Attributes on type expressions {node=Type status=pending}
+```json accepted
+{ "Unit": { "attributes": {} } }
+```
 
-Only `Literal` carries `attributes` in the schema today, while the spec's own examples write `attributes: {}` on every node. Bead morphir-ir-v4-stabilize.1 decides the expanded form for every node.
+## types-0009: Attributes on type expressions {node=Type}
 
-```json rejected diagnostic=unknown_member
+Decision 0005: `attributes` is the optional first member of every expanded payload, and an empty one is never written. `attrs` is the Rust encoder's spelling, accepted for the window of decision 0006.
+
+```yaml canonical
+a
+```
+
+```json canonical
+"a"
+```
+
+```json accepted
 { "Variable": { "attributes": {}, "name": "a" } }
+```
+
+```json accepted warning=legacy_spelling
+{ "Variable": { "attrs": {}, "name": "a" } }
+```
+
+## types-0010: Attributes are kept when compared with them {node=Type compare=attributes}
+
+A source location makes the expanded spelling the canonical one.
+
+```yaml canonical
+Variable:
+  attributes:
+    source: { startLine: 1, startColumn: 1, endLine: 1, endColumn: 2 }
+  name: a
+```
+
+```json canonical
+{ "Variable": { "attributes": { "source": { "startLine": 1, "startColumn": 1, "endLine": 1, "endColumn": 2 } }, "name": "a" } }
 ```

--- a/spec/ir/mck/values.md
+++ b/spec/ir/mck/values.md
@@ -1,6 +1,6 @@
 # Values
 
-Value expressions. Member vocabulary is the schema's; bead morphir-ir-v4-stabilize.1 decides the expanded forms with attributes, so cases that depend on that are pending.
+Value expressions. At value position a bare string is a Variable or a Reference, a bare boolean or number is a literal, and a bare array is a List (decision 0009); a Tuple always carries its wrapper. Every node has an expanded spelling whose payload starts with `attributes` (decision 0005).
 
 ## values-0001: Literal shorthands {node=Value}
 
@@ -15,6 +15,10 @@ Literal:
 
 ```json accepted
 { "Literal": 42 }
+```
+
+```json accepted
+42
 ```
 
 ```json accepted
@@ -43,6 +47,10 @@ Variable: x
 "x"
 ```
 
+```json accepted
+{ "Variable": { "attributes": {}, "name": "x" } }
+```
+
 ## values-0003: Reference shorthand {node=Value}
 
 ```yaml canonical
@@ -55,6 +63,10 @@ Reference: morphir/SDK:basics#add
 
 ```json accepted
 "morphir/SDK:basics#add"
+```
+
+```json accepted
+{ "Reference": { "attributes": {}, "fqname": "morphir/SDK:basics#add" } }
 ```
 
 ## values-0004: Apply {node=Value}
@@ -72,9 +84,13 @@ Apply:
 { "Apply": { "function": { "Reference": "morphir/SDK:basics#negate" }, "argument": { "Literal": { "IntegerLiteral": 1 } } } }
 ```
 
+```json accepted
+{ "Apply": { "attributes": {}, "function": { "Reference": "morphir/SDK:basics#negate" }, "argument": { "Literal": { "IntegerLiteral": 1 } } } }
+```
+
 ## values-0005: If-then-else member names {node=Value}
 
-The Rust encoder writes `thenBranch` and `elseBranch`; those are rejected. Bead morphir-ir-v4-stabilize.3.
+Decision 0006: the schema's `then` and `else` are canonical; the Rust encoder's `thenBranch` and `elseBranch` are accepted for one release. Bead morphir-ir-v4-stabilize.3.
 
 ```yaml canonical
 IfThenElse:
@@ -93,13 +109,17 @@ IfThenElse:
 { "IfThenElse": { "condition": { "Literal": { "BoolLiteral": true } }, "then": { "Literal": { "IntegerLiteral": 1 } }, "else": { "Literal": { "IntegerLiteral": 2 } } } }
 ```
 
-```json rejected diagnostic=unknown_member
-{ "IfThenElse": { "condition": true, "thenBranch": 1, "elseBranch": 2 } }
+```json accepted
+{ "IfThenElse": { "attributes": {}, "condition": { "Literal": { "BoolLiteral": true } }, "then": { "Literal": { "IntegerLiteral": 1 } }, "else": { "Literal": { "IntegerLiteral": 2 } } } }
+```
+
+```json accepted warning=legacy_spelling
+{ "IfThenElse": { "condition": { "Literal": { "BoolLiteral": true } }, "thenBranch": { "Literal": { "IntegerLiteral": 1 } }, "elseBranch": { "Literal": { "IntegerLiteral": 2 } } } }
 ```
 
 ## values-0006: Field access member names {node=Value}
 
-Spec examples wrote `subject` and `fieldName`; the schema says `target` and `name`.
+Decision 0006: `target` and `name`; the older `subject` and `fieldName` are accepted for one release.
 
 ```yaml canonical
 Field:
@@ -112,11 +132,17 @@ Field:
 { "Field": { "target": { "Variable": "record" }, "name": "field-name" } }
 ```
 
-```json rejected diagnostic=unknown_member
+```json accepted
+{ "Field": { "attributes": {}, "target": { "Variable": "record" }, "name": "field-name" } }
+```
+
+```json accepted warning=legacy_spelling
 { "Field": { "subject": { "Variable": "record" }, "fieldName": "field-name" } }
 ```
 
-## values-0007: Tuple and list values {node=Value}
+## values-0007: Tuple value {node=Value}
+
+Decision 0009: a Tuple always carries its wrapper; a bare array at value position is a List.
 
 ```yaml canonical
 Tuple:
@@ -133,20 +159,73 @@ Tuple:
 { "Tuple": { "elements": [{ "Variable": "x" }, { "Literal": { "IntegerLiteral": 1 } }] } }
 ```
 
-## values-0008: Bare array as a value {node=Value status=pending}
+```json accepted
+{ "Tuple": { "attributes": {}, "elements": [{ "Variable": "x" }, { "Literal": { "IntegerLiteral": 1 } }] } }
+```
 
-The schema lists a bare array as a List shorthand and, in the same file, says bare arrays are not allowed for values. Bead morphir-ir-v4-stabilize.4 decides; the design's reasoning favors rejection.
+```json rejected expect=List
+[{ "Variable": "x" }, { "Literal": { "IntegerLiteral": 1 } }]
+```
 
-```json rejected diagnostic=ambiguous_shorthand
+## values-0008: Bare array and bare scalars at value position {node=Value}
+
+Decision 0009 closed bead morphir-ir-v4-stabilize.4: a bare array is a List, a bare number is an IntegerLiteral or FloatLiteral by its lexeme, and a bare boolean is a BoolLiteral. Writers keep the wrapped forms.
+
+```yaml canonical
+List:
+  - Literal:
+      IntegerLiteral: 1
+  - Literal:
+      IntegerLiteral: 2
+  - Literal:
+      IntegerLiteral: 3
+```
+
+```json canonical
+{ "List": [{ "Literal": { "IntegerLiteral": 1 } }, { "Literal": { "IntegerLiteral": 2 } }, { "Literal": { "IntegerLiteral": 3 } }] }
+```
+
+```json accepted
 [1, 2, 3]
 ```
 
-## values-0009: Hole, Native, and External {node=Value status=pending}
+```json accepted
+{ "List": [1, 2, 3] }
+```
 
-These v4 value expressions are absent from the schema's `Value`. Bead morphir-ir-v4-stabilize.1 adds them together with the vocabulary decision.
+```json accepted
+{ "List": { "items": [1, 2, 3] } }
+```
+
+```json accepted
+{ "List": { "attributes": {}, "items": [1, 2, 3] } }
+```
+
+## values-0009: Hole {node=Value}
+
+Decision 0008: Hole stays a value expression with an optional `expectedType`; the Native and External expressions are removed, and a reader refuses them as unknown nodes. Native and external operations are definition bodies (definitions-0007).
+
+```yaml canonical
+Hole:
+  reason:
+    UnresolvedReference:
+      target: my-org/project:module#deleted
+```
+
+```json canonical
+{ "Hole": { "reason": { "UnresolvedReference": { "target": "my-org/project:module#deleted" } } } }
+```
+
+```json accepted
+{ "Hole": { "attributes": {}, "reason": { "UnresolvedReference": { "target": "my-org/project:module#deleted" } } } }
+```
 
 ```json rejected diagnostic=unknown_node
-{ "Hole": { "reason": { "UnresolvedReference": { "target": "my-org/project:module#deleted" } } } }
+{ "Native": { "fqname": "morphir/SDK:basics#add", "nativeInfo": { "hint": { "Arithmetic": {} } } } }
+```
+
+```json rejected diagnostic=unknown_node
+{ "External": { "externalName": "console.log", "targetPlatform": "javascript" } }
 ```
 
 ## values-0010: Unit value {node=Value}
@@ -157,4 +236,254 @@ Unit: {}
 
 ```json canonical
 { "Unit": {} }
+```
+
+```json accepted
+{ "Unit": { "attributes": {} } }
+```
+
+## values-0011: Bare scalars are literals {node=Value}
+
+Decision 0009. A bare `42` is an IntegerLiteral and a bare `true` a BoolLiteral; `4.0` is a FloatLiteral because its lexeme has a point. A bare string is never a StringLiteral (values-0002).
+
+```yaml canonical
+Literal:
+  BoolLiteral: true
+```
+
+```json canonical
+{ "Literal": { "BoolLiteral": true } }
+```
+
+```json accepted
+true
+```
+
+## values-0012: Bare number lexemes {node=Value}
+
+```yaml canonical
+Literal:
+  FloatLiteral: 4.0
+```
+
+```json canonical
+{ "Literal": { "FloatLiteral": 4.0 } }
+```
+
+```json accepted
+4.0
+```
+
+## values-0013: Record value {node=Value}
+
+Decision 0004 applies to record values too; the direct field map is accepted for the window of decision 0006.
+
+```yaml canonical
+Record:
+  fields:
+    name:
+      Variable: x
+    age:
+      Literal:
+        IntegerLiteral: 25
+```
+
+```json canonical
+{ "Record": { "fields": { "name": { "Variable": "x" }, "age": { "Literal": { "IntegerLiteral": 25 } } } } }
+```
+
+```json accepted
+{ "Record": { "attributes": {}, "fields": { "name": { "Variable": "x" }, "age": { "Literal": { "IntegerLiteral": 25 } } } } }
+```
+
+```json accepted warning=legacy_spelling
+{ "Record": { "name": { "Variable": "x" }, "age": { "Literal": { "IntegerLiteral": 25 } } } }
+```
+
+## values-0014: Constructor and field function {node=Value}
+
+```yaml canonical
+Constructor: morphir/SDK:maybe#just
+```
+
+```json canonical
+{ "Constructor": "morphir/SDK:maybe#just" }
+```
+
+```json accepted
+{ "Constructor": { "attributes": {}, "fqname": "morphir/SDK:maybe#just" } }
+```
+
+## values-0015: Field function {node=Value}
+
+```yaml canonical
+FieldFunction: name
+```
+
+```json canonical
+{ "FieldFunction": "name" }
+```
+
+```json accepted
+{ "FieldFunction": { "attributes": {}, "name": "name" } }
+```
+
+## values-0016: Lambda {node=Value}
+
+```yaml canonical
+Lambda:
+  pattern:
+    AsPattern:
+      pattern:
+        WildcardPattern: {}
+      name: x
+  body:
+    Variable: x
+```
+
+```json canonical
+{ "Lambda": { "pattern": { "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "x" } }, "body": { "Variable": "x" } } }
+```
+
+```json accepted
+{ "Lambda": { "attributes": {}, "pattern": { "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "x" } }, "body": { "Variable": "x" } } }
+```
+
+## values-0017: Let definition member names {node=Value}
+
+Decision 0006: `name`, `definition`, and `in`; the spec's older `valueName`, `valueDefinition`, and `inValue` are accepted for one release.
+
+```yaml canonical
+LetDefinition:
+  name: x
+  definition:
+    ExpressionBody:
+      inputTypes: {}
+      outputType: morphir/SDK:basics#int
+      body:
+        Literal:
+          IntegerLiteral: 1
+  in:
+    Variable: x
+```
+
+```json canonical
+{ "LetDefinition": { "name": "x", "definition": { "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Literal": { "IntegerLiteral": 1 } } } }, "in": { "Variable": "x" } } }
+```
+
+```json accepted
+{ "LetDefinition": { "attributes": {}, "name": "x", "definition": { "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Literal": { "IntegerLiteral": 1 } } } }, "in": { "Variable": "x" } } }
+```
+
+```json accepted warning=legacy_spelling
+{ "LetDefinition": { "valueName": "x", "valueDefinition": { "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Literal": { "IntegerLiteral": 1 } } } }, "inValue": { "Variable": "x" } } }
+```
+
+## values-0018: Let recursion {node=Value}
+
+```yaml canonical
+LetRecursion:
+  definitions:
+    f:
+      ExpressionBody:
+        inputTypes: {}
+        outputType: morphir/SDK:basics#int
+        body:
+          Variable: f
+  in:
+    Variable: f
+```
+
+```json canonical
+{ "LetRecursion": { "definitions": { "f": { "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Variable": "f" } } } }, "in": { "Variable": "f" } } }
+```
+
+```json accepted
+{ "LetRecursion": { "attributes": {}, "definitions": { "f": { "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Variable": "f" } } } }, "in": { "Variable": "f" } } }
+```
+
+## values-0019: Destructure {node=Value}
+
+```yaml canonical
+Destructure:
+  pattern:
+    TuplePattern:
+      - AsPattern:
+          pattern:
+            WildcardPattern: {}
+          name: a
+      - WildcardPattern: {}
+  value:
+    Variable: pair
+  in:
+    Variable: a
+```
+
+```json canonical
+{ "Destructure": { "pattern": { "TuplePattern": [{ "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "a" } }, { "WildcardPattern": {} }] }, "value": { "Variable": "pair" }, "in": { "Variable": "a" } } }
+```
+
+```json accepted
+{ "Destructure": { "attributes": {}, "pattern": { "TuplePattern": [{ "AsPattern": { "pattern": { "WildcardPattern": {} }, "name": "a" } }, { "WildcardPattern": {} }] }, "value": { "Variable": "pair" }, "in": { "Variable": "a" } } }
+```
+
+## values-0020: Pattern match {node=Value}
+
+```yaml canonical
+PatternMatch:
+  value:
+    Variable: x
+  cases:
+    - pattern:
+        LiteralPattern:
+          IntegerLiteral: 0
+      body:
+        Literal:
+          BoolLiteral: true
+    - pattern:
+        WildcardPattern: {}
+      body:
+        Literal:
+          BoolLiteral: false
+```
+
+```json canonical
+{ "PatternMatch": { "value": { "Variable": "x" }, "cases": [{ "pattern": { "LiteralPattern": { "IntegerLiteral": 0 } }, "body": { "Literal": { "BoolLiteral": true } } }, { "pattern": { "WildcardPattern": {} }, "body": { "Literal": { "BoolLiteral": false } } }] } }
+```
+
+```json accepted
+{ "PatternMatch": { "attributes": {}, "value": { "Variable": "x" }, "cases": [{ "pattern": { "LiteralPattern": { "IntegerLiteral": 0 } }, "body": { "Literal": { "BoolLiteral": true } } }, { "pattern": { "WildcardPattern": {} }, "body": { "Literal": { "BoolLiteral": false } } }] } }
+```
+
+## values-0021: Update record {node=Value}
+
+```yaml canonical
+UpdateRecord:
+  target:
+    Variable: record
+  fields:
+    name:
+      Literal:
+        StringLiteral: new
+```
+
+```json canonical
+{ "UpdateRecord": { "target": { "Variable": "record" }, "fields": { "name": { "Literal": { "StringLiteral": "new" } } } } }
+```
+
+```json accepted
+{ "UpdateRecord": { "attributes": {}, "target": { "Variable": "record" }, "fields": { "name": { "Literal": { "StringLiteral": "new" } } } } }
+```
+
+## values-0022: Attributes are kept when compared with them {node=Value compare=attributes}
+
+```yaml canonical
+Variable:
+  attributes:
+    source: { startLine: 3, startColumn: 5, endLine: 3, endColumn: 6 }
+  name: x
+```
+
+```json canonical
+{ "Variable": { "attributes": { "source": { "startLine": 3, "startColumn": 5, "endLine": 3, "endColumn": 6 } }, "name": "x" } }
 ```

--- a/tools/gen-naming-corpus.ts
+++ b/tools/gen-naming-corpus.ts
@@ -273,7 +273,8 @@ function truncate(escapedStem: string, available: number): string {
 
 const TRUNCATIONS: readonly (readonly [Name, number])[] = [
 	[[w("customer"), w("relationship"), w("management"), w("record")], 25],
-	[[w("value"), w("in"), i("usd"), w("per"), w("unit")], 16], // cut lands on "-_" and both are dropped
+	[[w("value"), w("in"), i("usd"), w("per"), w("unit")], 16], // cut lands inside "value-": the trailing "-" is dropped
+	[[w("value"), w("in"), i("usd")], 20], // cut lands on "-_" (the initialism's prefix): both are dropped
 ];
 
 // ---------------------------------------------------------------- build

--- a/tools/gen-naming-corpus.ts
+++ b/tools/gen-naming-corpus.ts
@@ -1,5 +1,7 @@
 // Generates docs/spec/ir/fixtures/naming-conformance.json, the shared conformance
-// corpus for Morphir IR v4 name canonicalization.
+// corpus for Morphir IR v4 name canonicalization, including the decision 0012
+// path-length truncation cases (host-verified: they depend on a SHA-256 digest
+// the Morphir SDK cannot express).
 //
 //   bun run gen-naming-corpus.ts            # write the corpus
 //   bun run gen-naming-corpus.ts --check    # verify it and its vendored copy
@@ -74,6 +76,13 @@ interface FqNameCase {
 	readonly documentTreePath: string;
 }
 
+interface TruncationCase {
+	readonly escapedStem: string;
+	readonly available: number; // characters the stem may occupy, suffix included
+	readonly truncatedStem: string;
+	readonly hostVerified: true; // needs SHA-256, which the Morphir SDK cannot express
+}
+
 interface Corpus {
 	readonly contractVersion: number;
 	readonly description: string;
@@ -90,6 +99,7 @@ interface Corpus {
 	readonly rejectCases: readonly RejectCase[];
 	readonly pathCases: readonly PathCase[];
 	readonly fqNameCases: readonly FqNameCase[];
+	readonly truncationCases: readonly TruncationCase[];
 }
 
 /** A Name is a non-empty sequence of segments. */
@@ -114,7 +124,7 @@ const i = (text: string): Segment => ({ kind: "initialism", text });
 
 const P_UP = "^([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*$";
 const P_DB = "^(--)?[a-z0-9]+(--?[a-z0-9]+)*$";
-const P_ST = "^_?[a-z0-9]+(-_?[a-z0-9]+)*_?$";
+const P_ST = "^_?[a-z0-9]+(-_?[a-z0-9]+)*(__[0-9a-f]{8})?_?$";
 
 const encUpper = (segs: Name): string =>
 	segs
@@ -252,6 +262,20 @@ const FQNAMES: readonly FqSpec[] = [
 	{ pkg: [[w("my"), w("org")]], mod: [[w("domain")]], name: [w("value"), w("in"), i("usd")] },
 ];
 
+// Decision 0012: keep `available - 10` characters of the escaped stem, drop
+// trailing "-" and "_" so the stem stays well-formed, append "__" and the first
+// eight hex digits of SHA-256(escaped stem).
+function truncate(escapedStem: string, available: number): string {
+	const digest = new Bun.CryptoHasher("sha256").update(escapedStem).digest("hex").slice(0, 8);
+	const kept = escapedStem.slice(0, Math.max(1, available - 10)).replace(/[-_]+$/, "");
+	return `${kept}__${digest}`;
+}
+
+const TRUNCATIONS: readonly (readonly [Name, number])[] = [
+	[[w("customer"), w("relationship"), w("management"), w("record")], 25],
+	[[w("value"), w("in"), i("usd"), w("per"), w("unit")], 16], // cut lands on "-_" and both are dropped
+];
+
 // ---------------------------------------------------------------- build
 
 function build(): string {
@@ -320,6 +344,16 @@ function build(): string {
 		}
 	}
 
+	const truncationCases: TruncationCase[] = TRUNCATIONS.map(([segs, available]) => {
+		const escapedStem = escapeName(segs);
+		const truncatedStem = truncate(escapedStem, available);
+		if (!reSt.test(truncatedStem)) failures.push(`fileStem pattern: ${truncatedStem}`);
+		if (truncatedStem.length > available) {
+			failures.push(`truncated stem too long: ${truncatedStem} (${truncatedStem.length} > ${available})`);
+		}
+		return { escapedStem, available, truncatedStem, hostVerified: true };
+	});
+
 	const doc: Corpus = {
 		contractVersion: 1,
 		description:
@@ -330,7 +364,7 @@ function build(): string {
 			'legacyDecodeCases apply the rule from decision 0001: a maximal run of two or more single-letter words collapses into one initialism, and a run of one stays a word. That run-of-one rule is what makes a single-letter type variable decode as the word "a" rather than as an initialism.',
 			'The legacy array ["f","r","2052","a"] is inherently ambiguous, because the multi-character token 2052 breaks the letter run. The deterministic result recorded here renders identically to FR2052A in both PascalCase conventions but differs in snakeCase. Implementations must match the recorded value rather than guess.',
 			"rejectCases record validity per style. An input legal under one style and not the other is the disjointness property that decision 0002 relies on for its union decoder.",
-			"Path-length truncation from decision 0001 is not covered here, because it depends on a SHA-256 digest that the Morphir SDK cannot express. Those cases are host-verified.",
+			"truncationCases are host-verified: they depend on SHA-256, which the Morphir SDK cannot express, so a host binding computes the digest and compares. The rule is decision 0012's: keep available-10 characters of the escaped stem, drop trailing '-' and '_', append '__' and eight hex digits.",
 		],
 		patterns: { name: { uppercase: P_UP, doubledHyphen: P_DB }, fileStem: P_ST },
 		reservedDeviceStems: RESERVED,
@@ -354,6 +388,7 @@ function build(): string {
 			},
 			documentTreePath: `pkg/${pathStr(f.pkg, escapeName)}/${pathStr(f.mod, escapeName)}/${escapeName(f.name)}.value.json`,
 		})),
+		truncationCases,
 	};
 
 	if (failures.length > 0) {

--- a/tools/validate-mck-fences.ts
+++ b/tools/validate-mck-fences.ts
@@ -132,7 +132,9 @@ interface Result {
 	message: string;
 }
 
-const CASE_HEADING = /^##\s+([a-z][a-z-]*-\d{4}):\s*(.*)$/;
+// The same shape the kit parser accepts, so a heading this tool cannot read is a
+// heading the kit reads, and the difference is silent coverage loss.
+const CASE_HEADING = /^##\s+([a-z][a-z0-9-]*-\d{4}):\s*(.*)$/;
 const FENCE_OPEN = /^```(\S+)((?:\s+\S+)*)\s*$/;
 
 /** Reads `key=value` pairs out of a `{ .. }` suffix on a case heading. */
@@ -178,8 +180,16 @@ interface OpenFence {
 	readonly line: number;
 }
 
-function collectFences(file: string, text: string): Fence[] {
+/** What one kit file yielded: its data fences, and any heading this tool could not read. */
+interface FileScan {
+	readonly fences: Fence[];
+	/** `## ` headings the case grammar rejects, as `file:line: heading`. */
+	readonly badHeadings: string[];
+}
+
+function collectFences(file: string, text: string): FileScan {
 	const fences: Fence[] = [];
+	const badHeadings: string[] = [];
 	const lines = text.split(/\r?\n/);
 	let current: ActiveCase | null = null;
 	let open: OpenFence | null = null;
@@ -230,7 +240,10 @@ function collectFences(file: string, text: string): Fence[] {
 			current = null;
 			const heading = line.match(CASE_HEADING);
 			const id = heading?.[1];
-			if (heading === null || id === undefined) continue;
+			if (heading === null || id === undefined) {
+				badHeadings.push(`${file}:${offset + 1}: ${line.trim()}`);
+				continue;
+			}
 			const keys = headingKeys(heading[2] ?? "");
 			if (keys.status === "pending") continue;
 			if (keys.version !== undefined && keys.version !== SUPPORTED_VERSION) {
@@ -240,7 +253,7 @@ function collectFences(file: string, text: string): Fence[] {
 		}
 	}
 
-	return fences;
+	return { fences, badHeadings };
 }
 
 // ---------------------------------------------------------------- validation
@@ -299,17 +312,23 @@ function failureMessage(instance: string, target: Target): string {
 
 // ---------------------------------------------------------------- entry point
 
+// README.md is prose, not a case file; the kit loader skips it the same way.
 const glob = new Glob("*.md");
-const kitFiles = (await Array.fromAsync(glob.scan({ cwd: kitDir }))).sort();
+const kitFiles = (await Array.fromAsync(glob.scan({ cwd: kitDir })))
+	.filter((name) => name !== "README.md")
+	.sort();
 if (kitFiles.length === 0) {
 	console.error(`error: no kit case files found in ${kitDir}`);
 	process.exit(1);
 }
 
 const fences: Fence[] = [];
+const badHeadings: string[] = [];
 for (const name of kitFiles) {
 	const file = path.join(kitDir, name);
-	fences.push(...collectFences(name, await Bun.file(file).text()));
+	const scan = collectFences(name, await Bun.file(file).text());
+	fences.push(...scan.fences);
+	badHeadings.push(...scan.badHeadings);
 }
 
 const results: Result[] = fences.map((fence) => ({
@@ -390,4 +409,28 @@ for (const { fence, outcome, message } of results) {
 console.log(
 	`\n${ok} ok, ${rejected} rejected as expected, ${failed} failed, ${skipped} skipped`,
 );
-if (failed > 0) process.exit(1);
+
+// A heading the kit reads and this tool does not, and a node kind with no schema
+// target, both drop fences silently. Coverage loss is a failure, not a pass.
+let coverageLoss = false;
+if (badHeadings.length > 0) {
+	coverageLoss = true;
+	console.log(
+		`\nFAIL ${badHeadings.length} "## " heading(s) the case grammar rejects:`,
+	);
+	for (const heading of badHeadings) console.log(`  ${heading}`);
+}
+if (skipped > 0) {
+	coverageLoss = true;
+	const kinds = [
+		...new Set(
+			results
+				.filter((result) => result.outcome === "skip")
+				.map((result) => result.fence.node || "unset"),
+		),
+	].sort();
+	console.log(
+		`\nFAIL ${skipped} fence(s) skipped; add a NODE_TARGETS entry for: ${kinds.join(", ")}`,
+	);
+}
+if (failed > 0 || coverageLoss) process.exit(1);

--- a/tools/validate-mck-fences.ts
+++ b/tools/validate-mck-fences.ts
@@ -1,0 +1,326 @@
+// Validates every canonical and accepted JSON fence of the Morphir Compatibility
+// Kit against the v4 JSON Schema, so the kit and the schema cannot drift.
+//
+//   bun run tools/validate-mck-fences.ts
+//
+// A case heading names the model type its fences decode to (`{node=Type}`); the
+// node maps to a definition of website/static/schemas/morphir-ir-v4.json, and the
+// fence body must validate against it. Fences carrying `warning=` are the legacy
+// spellings of decision 0006: a reader normalizes them and reports the warning,
+// but the schema deliberately does not describe them, so they are skipped here.
+import { Glob } from "bun";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.dirname(
+	path.dirname(fileURLToPath(import.meta.url)),
+);
+const kitDir = path.join(repositoryRoot, "spec", "ir", "mck");
+const schemaPath = path.join(
+	repositoryRoot,
+	"website",
+	"static",
+	"schemas",
+	"morphir-ir-v4.json",
+);
+
+/** The IR version this checker knows how to validate. */
+const SUPPORTED_VERSION = "4";
+
+/**
+ * Model type named by a case heading, mapped to the schema location its fences
+ * must validate against. `""` is the root schema rather than a definition.
+ */
+const NODE_ENTRYPOINTS: Readonly<Record<string, string>> = {
+	Distribution: "",
+	FormatVersion: "#/definitions/FormatVersion",
+	Name: "#/definitions/Name",
+	Path: "#/definitions/Path",
+	FQName: "#/definitions/FQName",
+	Type: "#/definitions/Type",
+	Value: "#/definitions/Value",
+	Pattern: "#/definitions/Pattern",
+	Literal: "#/definitions/Literal",
+	TypeSpecification: "#/definitions/TypeSpecification",
+	TypeDefinition: "#/definitions/TypeDefinition",
+	ValueSpecification: "#/definitions/ValueSpecification",
+	ValueDefinition: "#/definitions/ValueDefinition",
+	ModuleSpecification: "#/definitions/ModuleSpecification",
+	ModuleDefinition: "#/definitions/ModuleDefinition",
+	AccessControlledTypeDefinition:
+		"#/definitions/AccessControlledTypeDefinition",
+	AccessControlledValueDefinition:
+		"#/definitions/AccessControlledValueDefinition",
+};
+
+// ---------------------------------------------------------------- the kit
+
+interface Fence {
+	readonly caseId: string;
+	readonly node: string;
+	readonly index: number;
+	readonly role: string;
+	readonly body: string;
+	readonly sourceFile: string;
+	readonly line: number;
+}
+
+type Outcome = "ok" | "fail" | "skip";
+
+interface Result {
+	readonly fence: Fence;
+	outcome: Outcome;
+	message: string;
+}
+
+const CASE_HEADING = /^##\s+([a-z][a-z-]*-\d{4}):\s*(.*)$/;
+const FENCE_OPEN = /^```(\S+)((?:\s+\S+)*)\s*$/;
+
+/** Reads `key=value` pairs out of a `{ .. }` suffix on a case heading. */
+function headingKeys(title: string): Record<string, string> {
+	const braces = title.match(/\{([^}]*)\}\s*$/);
+	const keys: Record<string, string> = {};
+	if (!braces) return keys;
+	for (const pair of braces[1].split(/\s+/)) {
+		const [name, value] = pair.split("=");
+		if (name && value !== undefined) keys[name] = value;
+	}
+	return keys;
+}
+
+/**
+ * Splits a fence info string tail into its role and its `key=value` pairs. The
+ * info string is `<language> <role> [key=value ...]`.
+ */
+function fenceInfo(tail: string): {
+	role: string;
+	keys: Record<string, string>;
+} {
+	const tokens = tail.trim().split(/\s+/).filter(Boolean);
+	const keys: Record<string, string> = {};
+	for (const pair of tokens.slice(1)) {
+		const [name, value] = pair.split("=");
+		if (name && value !== undefined) keys[name] = value;
+	}
+	return { role: tokens[0] ?? "", keys };
+}
+
+interface ActiveCase {
+	readonly id: string;
+	readonly node: string;
+	count: number;
+}
+
+function collectFences(file: string, text: string): Fence[] {
+	const fences: Fence[] = [];
+	const lines = text.split(/\r?\n/);
+	let current: ActiveCase | null = null;
+	let open: {
+		language: string;
+		role: string;
+		keys: Record<string, string>;
+	} | null = null;
+	let body: string[] = [];
+	let openLine = 0;
+
+	for (const [offset, line] of lines.entries()) {
+		if (open) {
+			if (line.trimEnd() === "```") {
+				if (
+					current &&
+					open.language === "json" &&
+					(open.role === "canonical" || open.role === "accepted")
+				) {
+					current.count += 1;
+					if (open.keys.warning === undefined) {
+						fences.push({
+							caseId: current.id,
+							node: current.node,
+							index: current.count,
+							role: open.role,
+							body: body.join("\n"),
+							sourceFile: file,
+							line: openLine,
+						});
+					} else {
+						fences.push({
+							caseId: current.id,
+							node: "",
+							index: current.count,
+							role: "window",
+							body: "",
+							sourceFile: file,
+							line: openLine,
+						});
+					}
+				}
+				open = null;
+				body = [];
+			} else {
+				body.push(line);
+			}
+			continue;
+		}
+
+		const fenceOpen = line.match(FENCE_OPEN);
+		if (fenceOpen) {
+			const info = fenceInfo(fenceOpen[2] ?? "");
+			open = { language: fenceOpen[1], role: info.role, keys: info.keys };
+			body = [];
+			openLine = offset + 1;
+			continue;
+		}
+
+		if (line.startsWith("## ")) {
+			const heading = line.match(CASE_HEADING);
+			current = null;
+			if (!heading) continue;
+			const keys = headingKeys(heading[2]);
+			if (keys.status === "pending") continue;
+			if (keys.version !== undefined && keys.version !== SUPPORTED_VERSION) {
+				continue;
+			}
+			current = { id: heading[1], node: keys.node ?? "", count: 0 };
+		}
+	}
+
+	return fences;
+}
+
+// ---------------------------------------------------------------- validation
+
+/** Runs the jsonschema CLI over a directory of instances at one entry point. */
+function validateDirectory(
+	directory: string,
+	entrypoint: string,
+): Map<string, boolean> {
+	const args = ["validate", schemaPath, directory, "--verbose", "--continue"];
+	if (entrypoint !== "") args.push("--entrypoint", entrypoint);
+	const run = Bun.spawnSync(["jsonschema", ...args], { cwd: repositoryRoot });
+	const output = `${run.stdout.toString()}\n${run.stderr.toString()}`;
+	const verdicts = new Map<string, boolean>();
+	for (const line of output.split(/\r?\n/)) {
+		const match = line.match(/^(ok|fail):\s+(.*)$/);
+		if (!match) continue;
+		verdicts.set(path.basename(match[2].trim()), match[1] === "ok");
+	}
+	return verdicts;
+}
+
+/**
+ * Re-runs one instance to get a short reason for its failure. The CLI reports
+ * every branch of every union it tried, so the most informative single line is
+ * the one about the deepest place in the instance it got to.
+ */
+function failureMessage(instance: string, entrypoint: string): string {
+	const args = ["validate", schemaPath, instance];
+	if (entrypoint !== "") args.push("--entrypoint", entrypoint);
+	const run = Bun.spawnSync(["jsonschema", ...args], { cwd: repositoryRoot });
+	const output = `${run.stdout.toString()}\n${run.stderr.toString()}`;
+	const lines = output.split(/\r?\n/).map((line) => line.trim());
+	let best = "";
+	let bestDepth = -1;
+	for (const [offset, line] of lines.entries()) {
+		if (!line.startsWith("The ")) continue;
+		const at = lines[offset + 1]?.match(/^at instance location "([^"]*)"/);
+		if (!at) continue;
+		const depth = at[1].length;
+		if (depth > bestDepth) {
+			bestDepth = depth;
+			best = at[1] === "" ? line : `${line} at ${at[1]}`;
+		}
+	}
+	return best === "" ? "schema validation failed" : best;
+}
+
+// ---------------------------------------------------------------- entry point
+
+const glob = new Glob("*.md");
+const kitFiles = (await Array.fromAsync(glob.scan({ cwd: kitDir }))).sort();
+if (kitFiles.length === 0) {
+	console.error(`error: no kit case files found in ${kitDir}`);
+	process.exit(1);
+}
+
+const fences: Fence[] = [];
+for (const name of kitFiles) {
+	const file = path.join(kitDir, name);
+	fences.push(...collectFences(name, await Bun.file(file).text()));
+}
+
+const results: Result[] = fences.map((fence) => ({
+	fence,
+	outcome: "skip",
+	message: "",
+}));
+
+const workspace = mkdtempSync(path.join(os.tmpdir(), "mck-fences-"));
+try {
+	const byNode = new Map<string, Result[]>();
+	for (const result of results) {
+		const { fence } = result;
+		if (fence.role === "window") {
+			result.message = "skipped (window)";
+			continue;
+		}
+		const entrypoint = NODE_ENTRYPOINTS[fence.node];
+		if (entrypoint === undefined) {
+			result.message = `skipped (node=${fence.node || "unset"})`;
+			continue;
+		}
+		const group = byNode.get(fence.node) ?? [];
+		group.push(result);
+		byNode.set(fence.node, group);
+	}
+
+	for (const [node, group] of byNode) {
+		const entrypoint = NODE_ENTRYPOINTS[node];
+		const directory = path.join(workspace, node);
+		mkdirSync(directory, { recursive: true });
+		const instances = new Map<string, Result>();
+		for (const result of group) {
+			const name = `${result.fence.caseId}__${result.fence.index}.json`;
+			writeFileSync(path.join(directory, name), result.fence.body);
+			instances.set(name, result);
+		}
+		const verdicts = validateDirectory(directory, entrypoint);
+		for (const [name, result] of instances) {
+			const passed = verdicts.get(name);
+			if (passed === true) {
+				result.outcome = "ok";
+			} else {
+				result.outcome = "fail";
+				result.message =
+					passed === undefined
+						? "the validator reported no verdict for this instance"
+						: failureMessage(path.join(directory, name), entrypoint);
+			}
+		}
+	}
+} finally {
+	rmSync(workspace, { recursive: true, force: true });
+}
+
+let ok = 0;
+let failed = 0;
+let skipped = 0;
+for (const { fence, outcome, message } of results) {
+	const label = `${fence.caseId} fence-${fence.index}`;
+	if (outcome === "ok") {
+		ok += 1;
+		console.log(`${label}: ok`);
+	} else if (outcome === "skip") {
+		skipped += 1;
+		console.log(`${label}: ${message}`);
+	} else {
+		failed += 1;
+		console.log(
+			`${label}: FAIL ${message} (${fence.sourceFile}:${fence.line})`,
+		);
+	}
+}
+
+console.log(`\n${ok} ok, ${failed} failed, ${skipped} skipped`);
+if (failed > 0) process.exit(1);

--- a/tools/validate-mck-fences.ts
+++ b/tools/validate-mck-fences.ts
@@ -1,13 +1,16 @@
 // Validates every canonical and accepted JSON fence of the Morphir Compatibility
-// Kit against the v4 JSON Schema, so the kit and the schema cannot drift.
+// Kit against the v4 JSON Schemas, so the kit and the schemas cannot drift.
 //
 //   bun run tools/validate-mck-fences.ts
 //
 // A case heading names the model type its fences decode to (`{node=Type}`); the
-// node maps to a definition of website/static/schemas/morphir-ir-v4.json, and the
-// fence body must validate against it. Fences carrying `warning=` are the legacy
-// spellings of decision 0006: a reader normalizes them and reports the warning,
-// but the schema deliberately does not describe them, so they are skipped here.
+// node maps to a definition of morphir-ir-v4.json or, for document-tree files, of
+// morphir-ir-v4-document-tree-files.json, and the fence body must validate against
+// it. A fence carrying `warning=` is a legacy spelling of decision 0006: a reader
+// normalizes it and reports the warning, but the schema describes only the
+// canonical and expanded forms, so such a fence must be REJECTED here. The
+// exception is the nested { "doc", "value" } wrapper of decision 0010, which the
+// schema still describes for one release.
 import { Glob } from "bun";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
@@ -18,42 +21,92 @@ const repositoryRoot = path.dirname(
 	path.dirname(fileURLToPath(import.meta.url)),
 );
 const kitDir = path.join(repositoryRoot, "spec", "ir", "mck");
-const schemaPath = path.join(
-	repositoryRoot,
-	"website",
-	"static",
-	"schemas",
-	"morphir-ir-v4.json",
-);
+const schemaDir = path.join(repositoryRoot, "website", "static", "schemas");
+const irSchema = path.join(schemaDir, "morphir-ir-v4.json");
+const treeSchema = path.join(schemaDir, "morphir-ir-v4-document-tree-files.json");
 
 /** The IR version this checker knows how to validate. */
 const SUPPORTED_VERSION = "4";
 
+/** A schema file and the location inside it a node's fences must validate against. */
+interface Target {
+	/** Absolute path of the schema file. */
+	readonly schema: string;
+	/** JSON pointer into that schema; "" is the root schema. */
+	readonly pointer: string;
+}
+
+/** Model type named by a case heading, mapped to where its fences are checked. */
+const NODE_TARGETS: ReadonlyMap<string, Target> = new Map<string, Target>([
+	["Distribution", { schema: irSchema, pointer: "" }],
+	["FormatVersion", { schema: irSchema, pointer: "#/definitions/FormatVersion" }],
+	["Name", { schema: irSchema, pointer: "#/definitions/Name" }],
+	["Path", { schema: irSchema, pointer: "#/definitions/Path" }],
+	["FQName", { schema: irSchema, pointer: "#/definitions/FQName" }],
+	["Type", { schema: irSchema, pointer: "#/definitions/Type" }],
+	["Value", { schema: irSchema, pointer: "#/definitions/Value" }],
+	["Pattern", { schema: irSchema, pointer: "#/definitions/Pattern" }],
+	["Literal", { schema: irSchema, pointer: "#/definitions/Literal" }],
+	[
+		"TypeSpecification",
+		{ schema: irSchema, pointer: "#/definitions/TypeSpecification" },
+	],
+	[
+		"TypeDefinition",
+		{ schema: irSchema, pointer: "#/definitions/TypeDefinition" },
+	],
+	[
+		"ValueSpecification",
+		{ schema: irSchema, pointer: "#/definitions/ValueSpecification" },
+	],
+	[
+		"ValueDefinition",
+		{ schema: irSchema, pointer: "#/definitions/ValueDefinition" },
+	],
+	[
+		"ModuleSpecification",
+		{ schema: irSchema, pointer: "#/definitions/ModuleSpecification" },
+	],
+	[
+		"ModuleDefinition",
+		{ schema: irSchema, pointer: "#/definitions/ModuleDefinition" },
+	],
+	[
+		"AccessControlledTypeDefinition",
+		{ schema: irSchema, pointer: "#/definitions/AccessControlledTypeDefinition" },
+	],
+	[
+		"AccessControlledValueDefinition",
+		{ schema: irSchema, pointer: "#/definitions/AccessControlledValueDefinition" },
+	],
+	[
+		"DistributionManifestFile",
+		{ schema: treeSchema, pointer: "#/definitions/DistributionManifestFile" },
+	],
+	[
+		"ModuleManifestFile",
+		{ schema: treeSchema, pointer: "#/definitions/ModuleManifestFile" },
+	],
+	[
+		"TypeDefinitionFile",
+		{ schema: treeSchema, pointer: "#/definitions/TypeDefinitionFile" },
+	],
+	[
+		"ValueDefinitionFile",
+		{ schema: treeSchema, pointer: "#/definitions/ValueDefinitionFile" },
+	],
+]);
+
 /**
- * Model type named by a case heading, mapped to the schema location its fences
- * must validate against. `""` is the root schema rather than a definition.
+ * Cases whose `warning=` fence is the nested { "doc", "value" } wrapper. Decision
+ * 0010 keeps that shape valid in the schema for one release even though a reader
+ * reports legacy_spelling for it, so these fences must validate rather than fail.
+ * An explicit list, because nothing in the fence itself distinguishes them.
  */
-const NODE_ENTRYPOINTS: Readonly<Record<string, string>> = {
-	Distribution: "",
-	FormatVersion: "#/definitions/FormatVersion",
-	Name: "#/definitions/Name",
-	Path: "#/definitions/Path",
-	FQName: "#/definitions/FQName",
-	Type: "#/definitions/Type",
-	Value: "#/definitions/Value",
-	Pattern: "#/definitions/Pattern",
-	Literal: "#/definitions/Literal",
-	TypeSpecification: "#/definitions/TypeSpecification",
-	TypeDefinition: "#/definitions/TypeDefinition",
-	ValueSpecification: "#/definitions/ValueSpecification",
-	ValueDefinition: "#/definitions/ValueDefinition",
-	ModuleSpecification: "#/definitions/ModuleSpecification",
-	ModuleDefinition: "#/definitions/ModuleDefinition",
-	AccessControlledTypeDefinition:
-		"#/definitions/AccessControlledTypeDefinition",
-	AccessControlledValueDefinition:
-		"#/definitions/AccessControlledValueDefinition",
-};
+const DOC_WRAPPER_CASES: ReadonlySet<string> = new Set([
+	"definitions-0006",
+	"definitions-0010",
+]);
 
 // ---------------------------------------------------------------- the kit
 
@@ -62,15 +115,19 @@ interface Fence {
 	readonly node: string;
 	readonly index: number;
 	readonly role: string;
+	/** The legacy-spelling code this fence carries, if any. */
+	readonly warning: string | null;
 	readonly body: string;
 	readonly sourceFile: string;
 	readonly line: number;
 }
 
-type Outcome = "ok" | "fail" | "skip";
+type Outcome = "ok" | "rejected" | "fail" | "skip";
 
 interface Result {
 	readonly fence: Fence;
+	/** Whether the schema is expected to accept this fence. */
+	readonly expectValid: boolean;
 	outcome: Outcome;
 	message: string;
 }
@@ -80,10 +137,11 @@ const FENCE_OPEN = /^```(\S+)((?:\s+\S+)*)\s*$/;
 
 /** Reads `key=value` pairs out of a `{ .. }` suffix on a case heading. */
 function headingKeys(title: string): Record<string, string> {
-	const braces = title.match(/\{([^}]*)\}\s*$/);
 	const keys: Record<string, string> = {};
-	if (!braces) return keys;
-	for (const pair of braces[1].split(/\s+/)) {
+	const braces = title.match(/\{([^}]*)\}\s*$/);
+	const inner = braces?.[1];
+	if (inner === undefined) return keys;
+	for (const pair of inner.split(/\s+/)) {
 		const [name, value] = pair.split("=");
 		if (name && value !== undefined) keys[name] = value;
 	}
@@ -113,48 +171,38 @@ interface ActiveCase {
 	count: number;
 }
 
+interface OpenFence {
+	readonly language: string;
+	readonly role: string;
+	readonly keys: Record<string, string>;
+	readonly line: number;
+}
+
 function collectFences(file: string, text: string): Fence[] {
 	const fences: Fence[] = [];
 	const lines = text.split(/\r?\n/);
 	let current: ActiveCase | null = null;
-	let open: {
-		language: string;
-		role: string;
-		keys: Record<string, string>;
-	} | null = null;
+	let open: OpenFence | null = null;
 	let body: string[] = [];
-	let openLine = 0;
 
 	for (const [offset, line] of lines.entries()) {
-		if (open) {
+		if (open !== null) {
 			if (line.trimEnd() === "```") {
-				if (
-					current &&
+				const isData =
 					open.language === "json" &&
-					(open.role === "canonical" || open.role === "accepted")
-				) {
+					(open.role === "canonical" || open.role === "accepted");
+				if (current !== null && isData) {
 					current.count += 1;
-					if (open.keys.warning === undefined) {
-						fences.push({
-							caseId: current.id,
-							node: current.node,
-							index: current.count,
-							role: open.role,
-							body: body.join("\n"),
-							sourceFile: file,
-							line: openLine,
-						});
-					} else {
-						fences.push({
-							caseId: current.id,
-							node: "",
-							index: current.count,
-							role: "window",
-							body: "",
-							sourceFile: file,
-							line: openLine,
-						});
-					}
+					fences.push({
+						caseId: current.id,
+						node: current.node,
+						index: current.count,
+						role: open.role,
+						warning: open.keys.warning ?? null,
+						body: body.join("\n"),
+						sourceFile: file,
+						line: open.line,
+					});
 				}
 				open = null;
 				body = [];
@@ -165,24 +213,30 @@ function collectFences(file: string, text: string): Fence[] {
 		}
 
 		const fenceOpen = line.match(FENCE_OPEN);
-		if (fenceOpen) {
+		const language = fenceOpen?.[1];
+		if (fenceOpen !== null && language !== undefined) {
 			const info = fenceInfo(fenceOpen[2] ?? "");
-			open = { language: fenceOpen[1], role: info.role, keys: info.keys };
+			open = {
+				language,
+				role: info.role,
+				keys: info.keys,
+				line: offset + 1,
+			};
 			body = [];
-			openLine = offset + 1;
 			continue;
 		}
 
 		if (line.startsWith("## ")) {
-			const heading = line.match(CASE_HEADING);
 			current = null;
-			if (!heading) continue;
-			const keys = headingKeys(heading[2]);
+			const heading = line.match(CASE_HEADING);
+			const id = heading?.[1];
+			if (heading === null || id === undefined) continue;
+			const keys = headingKeys(heading[2] ?? "");
 			if (keys.status === "pending") continue;
 			if (keys.version !== undefined && keys.version !== SUPPORTED_VERSION) {
 				continue;
 			}
-			current = { id: heading[1], node: keys.node ?? "", count: 0 };
+			current = { id, node: keys.node ?? "", count: 0 };
 		}
 	}
 
@@ -194,17 +248,25 @@ function collectFences(file: string, text: string): Fence[] {
 /** Runs the jsonschema CLI over a directory of instances at one entry point. */
 function validateDirectory(
 	directory: string,
-	entrypoint: string,
+	target: Target,
 ): Map<string, boolean> {
-	const args = ["validate", schemaPath, directory, "--verbose", "--continue"];
-	if (entrypoint !== "") args.push("--entrypoint", entrypoint);
+	const args = [
+		"validate",
+		target.schema,
+		directory,
+		"--verbose",
+		"--continue",
+	];
+	if (target.pointer !== "") args.push("--entrypoint", target.pointer);
 	const run = Bun.spawnSync(["jsonschema", ...args], { cwd: repositoryRoot });
 	const output = `${run.stdout.toString()}\n${run.stderr.toString()}`;
 	const verdicts = new Map<string, boolean>();
 	for (const line of output.split(/\r?\n/)) {
 		const match = line.match(/^(ok|fail):\s+(.*)$/);
-		if (!match) continue;
-		verdicts.set(path.basename(match[2].trim()), match[1] === "ok");
+		const verdict = match?.[1];
+		const file = match?.[2];
+		if (verdict === undefined || file === undefined) continue;
+		verdicts.set(path.basename(file.trim()), verdict === "ok");
 	}
 	return verdicts;
 }
@@ -214,9 +276,9 @@ function validateDirectory(
  * every branch of every union it tried, so the most informative single line is
  * the one about the deepest place in the instance it got to.
  */
-function failureMessage(instance: string, entrypoint: string): string {
-	const args = ["validate", schemaPath, instance];
-	if (entrypoint !== "") args.push("--entrypoint", entrypoint);
+function failureMessage(instance: string, target: Target): string {
+	const args = ["validate", target.schema, instance];
+	if (target.pointer !== "") args.push("--entrypoint", target.pointer);
 	const run = Bun.spawnSync(["jsonschema", ...args], { cwd: repositoryRoot });
 	const output = `${run.stdout.toString()}\n${run.stderr.toString()}`;
 	const lines = output.split(/\r?\n/).map((line) => line.trim());
@@ -225,11 +287,11 @@ function failureMessage(instance: string, entrypoint: string): string {
 	for (const [offset, line] of lines.entries()) {
 		if (!line.startsWith("The ")) continue;
 		const at = lines[offset + 1]?.match(/^at instance location "([^"]*)"/);
-		if (!at) continue;
-		const depth = at[1].length;
-		if (depth > bestDepth) {
-			bestDepth = depth;
-			best = at[1] === "" ? line : `${line} at ${at[1]}`;
+		const location = at?.[1];
+		if (location === undefined) continue;
+		if (location.length > bestDepth) {
+			bestDepth = location.length;
+			best = location === "" ? line : `${line} at ${location}`;
 		}
 	}
 	return best === "" ? "schema validation failed" : best;
@@ -252,31 +314,26 @@ for (const name of kitFiles) {
 
 const results: Result[] = fences.map((fence) => ({
 	fence,
+	expectValid: fence.warning === null || DOC_WRAPPER_CASES.has(fence.caseId),
 	outcome: "skip",
 	message: "",
 }));
 
 const workspace = mkdtempSync(path.join(os.tmpdir(), "mck-fences-"));
 try {
-	const byNode = new Map<string, Result[]>();
+	const byNode = new Map<string, { target: Target; group: Result[] }>();
 	for (const result of results) {
-		const { fence } = result;
-		if (fence.role === "window") {
-			result.message = "skipped (window)";
+		const target = NODE_TARGETS.get(result.fence.node);
+		if (target === undefined) {
+			result.message = `skipped (node=${result.fence.node || "unset"})`;
 			continue;
 		}
-		const entrypoint = NODE_ENTRYPOINTS[fence.node];
-		if (entrypoint === undefined) {
-			result.message = `skipped (node=${fence.node || "unset"})`;
-			continue;
-		}
-		const group = byNode.get(fence.node) ?? [];
-		group.push(result);
-		byNode.set(fence.node, group);
+		const entry = byNode.get(result.fence.node) ?? { target, group: [] };
+		entry.group.push(result);
+		byNode.set(result.fence.node, entry);
 	}
 
-	for (const [node, group] of byNode) {
-		const entrypoint = NODE_ENTRYPOINTS[node];
+	for (const [node, { target, group }] of byNode) {
 		const directory = path.join(workspace, node);
 		mkdirSync(directory, { recursive: true });
 		const instances = new Map<string, Result>();
@@ -285,17 +342,21 @@ try {
 			writeFileSync(path.join(directory, name), result.fence.body);
 			instances.set(name, result);
 		}
-		const verdicts = validateDirectory(directory, entrypoint);
+		const verdicts = validateDirectory(directory, target);
 		for (const [name, result] of instances) {
-			const passed = verdicts.get(name);
-			if (passed === true) {
-				result.outcome = "ok";
-			} else {
+			const accepted = verdicts.get(name);
+			if (accepted === undefined) {
+				result.outcome = "fail";
+				result.message = "the validator reported no verdict for this instance";
+			} else if (accepted === result.expectValid) {
+				result.outcome = accepted ? "ok" : "rejected";
+			} else if (accepted) {
 				result.outcome = "fail";
 				result.message =
-					passed === undefined
-						? "the validator reported no verdict for this instance"
-						: failureMessage(path.join(directory, name), entrypoint);
+					"the schema accepted a window spelling it must reject (decision 0006)";
+			} else {
+				result.outcome = "fail";
+				result.message = failureMessage(path.join(directory, name), target);
 			}
 		}
 	}
@@ -304,6 +365,7 @@ try {
 }
 
 let ok = 0;
+let rejected = 0;
 let failed = 0;
 let skipped = 0;
 for (const { fence, outcome, message } of results) {
@@ -311,6 +373,9 @@ for (const { fence, outcome, message } of results) {
 	if (outcome === "ok") {
 		ok += 1;
 		console.log(`${label}: ok`);
+	} else if (outcome === "rejected") {
+		rejected += 1;
+		console.log(`${label}: ok (rejected as expected)`);
 	} else if (outcome === "skip") {
 		skipped += 1;
 		console.log(`${label}: ${message}`);
@@ -322,5 +387,7 @@ for (const { fence, outcome, message } of results) {
 	}
 }
 
-console.log(`\n${ok} ok, ${failed} failed, ${skipped} skipped`);
+console.log(
+	`\n${ok} ok, ${rejected} rejected as expected, ${failed} failed, ${skipped} skipped`,
+);
 if (failed > 0) process.exit(1);

--- a/website/static/ir/examples/v4/books-and-records-example.json
+++ b/website/static/ir/examples/v4/books-and-records-example.json
@@ -4,7 +4,7 @@
     "Library": {
       "packageName": "morphir/reference/model",
       "dependencies": {
-        "morphir/sdk": {
+        "morphir/SDK": {
           "modules": {
             "basics": {
               "types": {
@@ -38,7 +38,7 @@
                     ],
                     "typeExp": {
                       "Reference": [
-                        "morphir/sdk:dict#dict",
+                        "morphir/SDK:dict#dict",
                         "k",
                         "v"
                       ]
@@ -56,11 +56,11 @@
           "books-and-records": {
             "Public": {
               "types": {
-                "product-(i-d)": {
+                "product-ID": {
                   "Public": {
                     "TypeAliasDefinition": {
                       "typeParams": [],
-                      "typeExp": "morphir/sdk:string#string"
+                      "typeExp": "morphir/SDK:string#string"
                     }
                   }
                 },
@@ -68,7 +68,7 @@
                   "Public": {
                     "TypeAliasDefinition": {
                       "typeParams": [],
-                      "typeExp": "morphir/sdk:basics#float"
+                      "typeExp": "morphir/SDK:basics#float"
                     }
                   }
                 },
@@ -76,7 +76,7 @@
                   "Public": {
                     "TypeAliasDefinition": {
                       "typeParams": [],
-                      "typeExp": "morphir/sdk:basics#int"
+                      "typeExp": "morphir/SDK:basics#int"
                     }
                   }
                 },
@@ -86,9 +86,11 @@
                       "typeParams": [],
                       "typeExp": {
                         "Record": {
-                          "product": "morphir/reference/model:books-and-records#product-(i-d)",
-                          "price": "morphir/reference/model:books-and-records#price",
-                          "quantity": "morphir/reference/model:books-and-records#quantity"
+                          "fields": {
+                            "product": "morphir/reference/model:books-and-records#product-ID",
+                            "price": "morphir/reference/model:books-and-records#price",
+                            "quantity": "morphir/reference/model:books-and-records#quantity"
+                          }
                         }
                       }
                     }
@@ -98,17 +100,16 @@
                   "Public": {
                     "CustomTypeDefinition": {
                       "typeParams": [],
-                      "accessControlledConstructors": {
-                        "Public": {
-                          "open-deal": {
-                            "product": "morphir/reference/model:books-and-records#product-(i-d)",
-                            "price": "morphir/reference/model:books-and-records#price",
-                            "quantity": "morphir/reference/model:books-and-records#quantity"
-                          },
-                          "close-deal": {
-                            "product": "morphir/reference/model:books-and-records#product-(i-d)"
-                          }
-                        }
+                      "access": "Public",
+                      "constructors": {
+                        "open-deal": [
+                          ["product", "morphir/reference/model:books-and-records#product-ID"],
+                          ["price", "morphir/reference/model:books-and-records#price"],
+                          ["quantity", "morphir/reference/model:books-and-records#quantity"]
+                        ],
+                        "close-deal": [
+                          ["product", "morphir/reference/model:books-and-records#product-ID"]
+                        ]
                       }
                     }
                   }
@@ -117,29 +118,28 @@
                   "Public": {
                     "CustomTypeDefinition": {
                       "typeParams": [],
-                      "accessControlledConstructors": {
-                        "Public": {
-                          "deal-opened": {
-                            "product": "morphir/reference/model:books-and-records#product-(i-d)",
-                            "price": "morphir/reference/model:books-and-records#price",
-                            "quantity": "morphir/reference/model:books-and-records#quantity"
-                          },
-                          "deal-closed": {
-                            "product": "morphir/reference/model:books-and-records#product-(i-d)"
-                          },
-                          "deal-not-found": {
-                            "product": "morphir/reference/model:books-and-records#product-(i-d)"
-                          },
-                          "duplicate-deal": {
-                            "product": "morphir/reference/model:books-and-records#product-(i-d)"
-                          },
-                          "invalid-price": {
-                            "price": "morphir/reference/model:books-and-records#price"
-                          },
-                          "invalid-quantity": {
-                            "quantity": "morphir/reference/model:books-and-records#quantity"
-                          }
-                        }
+                      "access": "Public",
+                      "constructors": {
+                        "deal-opened": [
+                          ["product", "morphir/reference/model:books-and-records#product-ID"],
+                          ["price", "morphir/reference/model:books-and-records#price"],
+                          ["quantity", "morphir/reference/model:books-and-records#quantity"]
+                        ],
+                        "deal-closed": [
+                          ["product", "morphir/reference/model:books-and-records#product-ID"]
+                        ],
+                        "deal-not-found": [
+                          ["product", "morphir/reference/model:books-and-records#product-ID"]
+                        ],
+                        "duplicate-deal": [
+                          ["product", "morphir/reference/model:books-and-records#product-ID"]
+                        ],
+                        "invalid-price": [
+                          ["price", "morphir/reference/model:books-and-records#price"]
+                        ],
+                        "invalid-quantity": [
+                          ["quantity", "morphir/reference/model:books-and-records#quantity"]
+                        ]
                       }
                     }
                   }
@@ -150,8 +150,8 @@
                       "typeParams": [],
                       "typeExp": {
                         "Reference": [
-                          "morphir/sdk:dict#dict",
-                          "morphir/reference/model:books-and-records#product-(i-d)",
+                          "morphir/SDK:dict#dict",
+                          "morphir/reference/model:books-and-records#product-ID",
                           "morphir/reference/model:books-and-records#deal"
                         ]
                       }
@@ -162,9 +162,9 @@
               "values": {
                 "open-deal": {
                   "Public": {
-                    "ExpressionBody": {
+                    "IncompleteBody": {
                       "inputTypes": {
-                        "product": "morphir/reference/model:books-and-records#product-(i-d)",
+                        "product": "morphir/reference/model:books-and-records#product-ID",
                         "price": "morphir/reference/model:books-and-records#price",
                         "quantity": "morphir/reference/model:books-and-records#quantity",
                         "book": "morphir/reference/model:books-and-records#book"
@@ -175,20 +175,17 @@
                           "morphir/reference/model:books-and-records#deal-event"
                         ]
                       },
-                      "body": {
-                        "Hole": {
-                          "attributes": {},
-                          "message": "Implementation pending"
-                        }
+                      "incompleteness": {
+                        "Draft": {}
                       }
                     }
                   }
                 },
                 "close-deal": {
                   "Public": {
-                    "ExpressionBody": {
+                    "IncompleteBody": {
                       "inputTypes": {
-                        "product": "morphir/reference/model:books-and-records#product-(i-d)",
+                        "product": "morphir/reference/model:books-and-records#product-ID",
                         "book": "morphir/reference/model:books-and-records#book"
                       },
                       "outputType": {
@@ -197,11 +194,8 @@
                           "morphir/reference/model:books-and-records#deal-event"
                         ]
                       },
-                      "body": {
-                        "Hole": {
-                          "attributes": {},
-                          "message": "Implementation pending"
-                        }
+                      "incompleteness": {
+                        "Draft": {}
                       }
                     }
                   }

--- a/website/static/ir/examples/v4/complete-example.json
+++ b/website/static/ir/examples/v4/complete-example.json
@@ -4,7 +4,7 @@
     "Library": {
       "packageName": "regulation",
       "dependencies": {
-        "morphir/sdk": {
+        "morphir/SDK": {
           "modules": {
             "basics": {
               "types": {
@@ -21,10 +21,10 @@
               "values": {
                 "add": {
                   "inputs": {
-                    "a": "morphir/sdk:basics#int",
-                    "b": "morphir/sdk:basics#int"
+                    "a": "morphir/SDK:basics#int",
+                    "b": "morphir/SDK:basics#int"
                   },
-                  "output": "morphir/sdk:basics#int"
+                  "output": "morphir/SDK:basics#int"
                 }
               }
             },
@@ -37,7 +37,7 @@
                     ],
                     "typeExp": {
                       "Reference": [
-                        "morphir/sdk:list#list",
+                        "morphir/SDK:list#list",
                         "a"
                       ]
                     }
@@ -49,20 +49,20 @@
                   "inputs": {
                     "f": {
                       "Function": {
-                        "argumentType": "a",
+                        "parameterType": "a",
                         "returnType": "b"
                       }
                     },
                     "list": {
                       "Reference": [
-                        "morphir/sdk:list#list",
+                        "morphir/SDK:list#list",
                         "a"
                       ]
                     }
                   },
                   "output": {
                     "Reference": [
-                      "morphir/sdk:list#list",
+                      "morphir/SDK:list#list",
                       "b"
                     ]
                   }
@@ -102,7 +102,7 @@
                         "fields": {
                           "assets": {
                             "Reference": [
-                              "morphir/sdk:list#list",
+                              "morphir/SDK:list#list",
                               "regulation:u-s/f-r-2052-a/data-tables/inflows#assets"
                             ]
                           }
@@ -119,7 +119,7 @@
                     "inputTypes": {
                       "tables": "regulation:u-s/f-r-2052-a/data-tables#data-tables"
                     },
-                    "outputType": "morphir/sdk:basics#float",
+                    "outputType": "morphir/SDK:basics#float",
                     "body": {
                       "Literal": {
                         "attributes": {},

--- a/website/static/ir/examples/v4/complete-example.json
+++ b/website/static/ir/examples/v4/complete-example.json
@@ -122,10 +122,7 @@
                     "outputType": "morphir/SDK:basics#float",
                     "body": {
                       "Literal": {
-                        "attributes": {},
-                        "literal": {
-                          "FloatLiteral": 0
-                        }
+                        "FloatLiteral": 0.0
                       }
                     }
                   }

--- a/website/static/schemas/morphir-ir-v4-document-tree-files.json
+++ b/website/static/schemas/morphir-ir-v4-document-tree-files.json
@@ -622,7 +622,7 @@
           "enum": [ "Classic", "VfsMode" ]
         },
         "pathBudget": {
-          "description": "Maximum path length, in characters from the distribution root, that this\ntree was written against. A stem that would exceed it is truncated and\nsuffixed with \"__\" plus eight hex digits, and the module then records the\nmapping in its \"fileNames\".\n\n4000 is the default and suits Linux, macOS, and Windows with long paths\nenabled. 200 is the portable profile, for Windows without\nLongPathsEnabled and for stock Git for Windows, which ships\ncore.longpaths=false.\n\nRequired (decision 0012): writers always state the budget so a reader can\nrefuse a tree it cannot open before opening files one at a time.\n",
+          "description": "Maximum path length, in characters from the distribution root, that this\ntree was written against. A stem that would exceed it is truncated and\nsuffixed with \"__\" plus eight hex digits, and the module then records the\nmapping in its \"fileNames\".\n\n4000 suits Linux, macOS, and Windows with long paths\nenabled. 200 is the portable profile, for Windows without\nLongPathsEnabled and for stock Git for Windows, which ships\ncore.longpaths=false.\n\nRequired (decision 0012): writers always state the budget so a reader can\nrefuse a tree it cannot open before opening files one at a time.\n",
           "examples": [ 4000, 200 ],
           "type": "integer",
           "minimum": 64

--- a/website/static/schemas/morphir-ir-v4-document-tree-files.json
+++ b/website/static/schemas/morphir-ir-v4-document-tree-files.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://morphir.finos.org/schemas/morphir-ir-v4-document-tree-files.json",
   "title": "Morphir IR V4 Document Tree File Formats",
-  "description": "JSON schemas for document tree file formats used in VFS (Virtual File System) mode.\n\nIn VFS mode, Morphir IR distributions are stored as a directory tree with individual\nfiles for each type and value definition. This enables incremental updates, better\ntooling support, and easier navigation of large codebases.\n\nFile types:\n- manifest.json: Distribution-level metadata\n- module.json: Module manifest (with optional inline definitions)\n- *.type.json: Individual type definition/specification files\n- *.value.json: Individual value definition/specification files\n\nNote: This schema references definitions from morphir-ir-v4.yaml for core types\n(Name, ModuleName, PackageName, TypeDefinition, ValueDefinition, etc.).\n",
+  "description": "JSON schemas for document tree file formats used in VFS (Virtual File System) mode.\n\nIn VFS mode, Morphir IR distributions are stored as a directory tree with individual\nfiles for each type and value definition. This enables incremental updates, better\ntooling support, and easier navigation of large codebases.\n\nFile types:\n- manifest.json: Distribution-level metadata\n- module.json: Module manifest (with optional inline definitions)\n- *.type.json: Individual type definition/specification files\n- *.value.json: Individual value definition/specification files\n\nNote: This schema references definitions from morphir-ir-v4.yaml for core types\n(Name, ModuleName, PackageName, TypeDefinition, ValueDefinition, etc.).\n\nA top-level \"$meta\" member in any document-tree file is reserved (decision 0014):\nreaders ignore it and never report it as unknown; writers never emit it.\nsession.jsonl is daemon workspace state and not part of a distribution.\n",
   "definitions": {
     "FormatVersion": {
       "description": "The IR format version, governed by the v3-and-later formatVersion contract. Integer 4 is the canonical v4.0.0 baseline; exact release strings identify later revisions in the v4 family. Prerelease and build metadata are not allowed",
@@ -28,15 +28,27 @@
           "pattern": "^([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*$"
         },
         {
-          "description": "Legacy array representation",
+          "description": "Legacy array representation. One legacy word grammar is shared with\nmorphir-ir-v4.yaml (decision 0012), so a digits-only word is legal:\n[\"item\", \"2\"] decodes to \"item-2\".\n",
           "type": "array",
           "minItems": 1,
           "items": {
             "type": "string",
-            "pattern": "^[a-z][a-z0-9]*$"
+            "pattern": "^[a-z0-9]+$"
           }
         }
       ]
+    },
+    "FileStem": {
+      "description": "Escaped projection of a Name onto the document tree (decision 0001). All lowercase; an\ninitialism segment carries a \"_\" prefix; a Windows reserved device name carries a \"_\"\nsuffix. A stem truncated for the path budget keeps a prefix of the escaped stem with\ntrailing \"-\" and \"_\" removed, then \"__\" and the first eight hex digits of the SHA-256 of\nthe untruncated escaped stem; the module manifest then records the mapping in fileNames.\n",
+      "examples": [
+        "user",
+        "user-_id",
+        "value-in-_usd",
+        "aux_",
+        "customer-relati__3f9a1c04"
+      ],
+      "type": "string",
+      "pattern": "^_?[a-z0-9]+(-_?[a-z0-9]+)*(__[0-9a-f]{8})?_?$"
     },
     "ModuleName": {
       "oneOf": [
@@ -164,14 +176,14 @@
       }
     },
     "TypeDefinitionFile": {
-      "description": "Type definition or specification file (*.type.json).\n\nStructure:\n- formatVersion: Required, shared v4 format version\n- name: Required, canonical name matching filename\n- doc: Optional, documentation (can be at top level or nested in def/spec)\n- def: Required if this is a definition (implementation), contains TypeDefinition variant\n- spec: Required if this is a specification (interface), contains TypeSpecification variant\n\nExactly one of 'def' or 'spec' must be present.\n",
+      "description": "Type definition or specification file (*.type.json).\n\nStructure:\n- formatVersion: Required, shared v4 format version\n- name: Required, canonical name matching filename\n- doc: inside def or spec, first beside the variant (decision 0010); never at the top level\n- def: Required if this is a definition (implementation), contains TypeDefinition variant\n- spec: Required if this is a specification (interface), contains TypeSpecification variant\n\nExactly one of 'def' or 'spec' must be present.\n",
       "examples": [
         {
           "formatVersion": 4,
           "name": "user",
-          "doc": "Represents a user",
           "def": {
             "access": "Public",
+            "doc": "Represents a user",
             "TypeAliasDefinition": {
               "typeParams": [],
               "typeExp": {
@@ -201,21 +213,8 @@
           "type": "object",
           "required": [],
           "properties": {
-            "doc": {
-              "description": "Optional documentation for this type",
-              "oneOf": [
-                {
-                  "description": "Single-line documentation (will be split on newlines)",
-                  "type": "string"
-                },
-                {
-                  "description": "Multi-line documentation (one string per line)",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
+            "$meta": {
+              "description": "Reserved (decision 0014): readers ignore it and never report it as unknown;\nwriters never emit it.\n"
             },
             "def": {
               "description": "Type definition (implementation). Used in PackageDefinition.\nMust contain one of: TypeAliasDefinition, CustomTypeDefinition, IncompleteTypeDefinition.\nThe access field is required when this file is part of a PackageDefinition.\n",
@@ -227,7 +226,7 @@
                   "enum": [ "Public", "Private" ]
                 },
                 "doc": {
-                  "description": "Optional documentation (can be at def level or top level)",
+                  "description": "Documentation, first beside the variant (decision 0010)",
                   "oneOf": [
                     {
                       "type": "string"
@@ -270,7 +269,7 @@
       ]
     },
     "ValueDefinitionFile": {
-      "description": "Value definition or specification file (*.value.json).\n\nStructure:\n- formatVersion: Required, shared v4 format version\n- name: Required, canonical name matching filename\n- doc: Optional, documentation (can be at top level or nested in def/spec)\n- def: Required if this is a definition (implementation), contains ValueDefinition variant\n- spec: Required if this is a specification (interface), contains ValueSpecification\n\nExactly one of 'def' or 'spec' must be present.\n",
+      "description": "Value definition or specification file (*.value.json).\n\nStructure:\n- formatVersion: Required, shared v4 format version\n- name: Required, canonical name matching filename\n- doc: inside def or spec, first beside the variant (decision 0010); never at the top level\n- def: Required if this is a definition (implementation), contains ValueDefinition variant\n- spec: Required if this is a specification (interface), contains ValueSpecification\n\nExactly one of 'def' or 'spec' must be present.\n",
       "examples": [
         {
           "formatVersion": 4,
@@ -312,21 +311,8 @@
           "type": "object",
           "required": [],
           "properties": {
-            "doc": {
-              "description": "Optional documentation for this value",
-              "oneOf": [
-                {
-                  "description": "Single-line documentation",
-                  "type": "string"
-                },
-                {
-                  "description": "Multi-line documentation",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              ]
+            "$meta": {
+              "description": "Reserved (decision 0014): readers ignore it and never report it as unknown;\nwriters never emit it.\n"
             },
             "def": {
               "description": "Value definition (implementation). Used in PackageDefinition.\nMust contain one of: ExpressionBody, NativeBody, ExternalBody, IncompleteBody\nwrapped in their wrapper object format (e.g., { \"ExpressionBody\": { ... } }).\nThe access field is required when this file is part of a PackageDefinition.\n",
@@ -381,13 +367,22 @@
       ]
     },
     "ModuleManifestFile": {
-      "description": "Module manifest file (module.json).\n\nSupports two encoding styles:\n\n1. **Manifest Style (Granular)**: Lists type/value names, definitions in separate files\n   - formatVersion: Required\n   - path or module: Required, module path\n   - doc: Optional, module documentation\n   - types: Optional, array of type names\n   - values: Optional, array of value names\n\n2. **Inline Style (Hybrid)**: Contains definitions directly\n   - formatVersion: Required\n   - path or module: Required, module path\n   - doc: Optional, module documentation\n   - types: Optional, object mapping type names to definitions\n   - values: Optional, object mapping value names to definitions\n\nEither 'path' or 'module' field must be present (they are equivalent).\nThe 'path' field is preferred; 'module' is accepted for backwards compatibility.\nTypes and values can be arrays (manifest) or objects (inline), but not mixed.\n",
+      "description": "Module manifest file (module.json).\n\nSupports two encoding styles:\n\n1. **Manifest Style (Granular)**: Lists type/value names, definitions in separate files\n   - formatVersion: Required\n   - path or module: Required, module path\n   - doc: Optional, module documentation\n   - types: Optional, array of type names\n   - values: Optional, array of value names\n   - fileNames: Optional, canonical name to truncated stem\n\n2. **Inline Style (Hybrid)**: Contains definitions directly\n   - formatVersion: Required\n   - path or module: Required, module path\n   - doc: Optional, module documentation\n   - types: Optional, object mapping type names to definitions\n   - values: Optional, object mapping value names to definitions\n\nEither 'path' or 'module' field must be present (they are equivalent).\nThe 'path' field is preferred; 'module' is accepted for backwards compatibility.\nTypes and values can be arrays (manifest) or objects (inline), but not mixed.\n",
       "examples": [
         {
           "formatVersion": 4,
           "path": "my-org/domain",
           "types": [ "user", "order" ],
           "values": [ "create-order" ]
+        },
+        {
+          "formatVersion": 4,
+          "path": "domain",
+          "types": [ "customer-relationship-management-record" ],
+          "values": [],
+          "fileNames": {
+            "customer-relationship-management-record": "customer-relati__44a101f8"
+          }
         },
         {
           "formatVersion": 4,
@@ -538,16 +533,35 @@
               }
             }
           ]
+        },
+        "fileNames": {
+          "description": "Canonical name to file stem, for every type or value whose stem was truncated for the\npath budget (decision 0012). A name listed here must also appear in types or values.\n",
+          "examples": [
+            {
+              "customer-relationship-management-record": "customer-relati__44a101f8"
+            }
+          ],
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/definitions/FileStem"
+          }
+        },
+        "$meta": {
+          "description": "Reserved (decision 0014): readers ignore it and never report it as unknown;\nwriters never emit it.\n"
         }
       }
     },
     "DistributionManifestFile": {
-      "description": "Distribution manifest/metadata file (manifest.json).\n\nLocated at: `.morphir-dist/manifest.json`\n\nContains distribution-level metadata:\n- formatVersion: Required, IR format version\n- distribution: Required, distribution type (Library, Specs, Application)\n- package: Required, package name\n- version: Optional, package version\n- created: Optional, creation timestamp (ISO 8601)\n- layout: Optional, distribution layout (defaults to VfsMode for document tree)\n- entryPoints: Optional, entry points (required for Application distributions)\n",
+      "description": "Distribution manifest/metadata file (manifest.json).\n\nLocated at: `.morphir-dist/manifest.json`\n\nContains distribution-level metadata:\n- formatVersion: Required, IR format version\n- distribution: Required, distribution type (Library, Specs, Application)\n- package: Required, package name\n- pathBudget: Required, path length this tree was written against (decision 0012)\n- version: Optional, package version\n- created: Optional, creation timestamp (ISO 8601)\n- layout: Optional, distribution layout (defaults to VfsMode for document tree)\n- entryPoints: Optional, entry points (required for Application distributions)\n",
       "examples": [
         {
           "formatVersion": 4,
           "distribution": "Library",
           "package": "my-org/my-project",
+          "pathBudget": 4000,
           "version": "1.2.0",
           "created": "2026-01-15T12:00:00Z",
           "layout": "VfsMode"
@@ -556,6 +570,7 @@
           "formatVersion": 4,
           "distribution": "Specs",
           "package": "morphir/SDK",
+          "pathBudget": 4000,
           "version": "3.0.0",
           "created": "2026-01-15T12:00:00Z",
           "layout": "VfsMode"
@@ -564,6 +579,7 @@
           "formatVersion": 4,
           "distribution": "Application",
           "package": "my-org/my-cli",
+          "pathBudget": 4000,
           "version": "2.0.0",
           "created": "2026-01-15T12:00:00Z",
           "entryPoints": {
@@ -575,7 +591,7 @@
         }
       ],
       "type": "object",
-      "required": [ "formatVersion", "distribution", "package" ],
+      "required": [ "formatVersion", "distribution", "package", "pathBudget" ],
       "properties": {
         "formatVersion": {
           "$ref": "#/definitions/FormatVersion"
@@ -606,9 +622,8 @@
           "enum": [ "Classic", "VfsMode" ]
         },
         "pathBudget": {
-          "description": "Maximum path length, in characters from the distribution root, that this\ntree was written against. A stem that would exceed it is truncated and\nsuffixed with \"__\" plus eight hex digits, and the module then records the\nmapping in its \"fileNames\".\n\n4000 is the default and suits Linux, macOS, and Windows with long paths\nenabled. 200 is the portable profile, for Windows without\nLongPathsEnabled and for stock Git for Windows, which ships\ncore.longpaths=false.\n\nWriters set this unconditionally rather than leaving it inferred, so a\nreader that cannot satisfy the budget can say so up front instead of\nfailing to open files one at a time. A missing value is read as 4000,\nfor trees written before this field existed.\n",
+          "description": "Maximum path length, in characters from the distribution root, that this\ntree was written against. A stem that would exceed it is truncated and\nsuffixed with \"__\" plus eight hex digits, and the module then records the\nmapping in its \"fileNames\".\n\n4000 is the default and suits Linux, macOS, and Windows with long paths\nenabled. 200 is the portable profile, for Windows without\nLongPathsEnabled and for stock Git for Windows, which ships\ncore.longpaths=false.\n\nRequired (decision 0012): writers always state the budget so a reader can\nrefuse a tree it cannot open before opening files one at a time.\n",
           "examples": [ 4000, 200 ],
-          "default": 4000,
           "type": "integer",
           "minimum": 64
         },
@@ -618,6 +633,9 @@
           "additionalProperties": {
             "$ref": "#/definitions/EntryPoint"
           }
+        },
+        "$meta": {
+          "description": "Reserved (decision 0014): readers ignore it and never report it as unknown;\nwriters never emit it.\n"
         }
       }
     }

--- a/website/static/schemas/morphir-ir-v4-document-tree-files.yaml
+++ b/website/static/schemas/morphir-ir-v4-document-tree-files.yaml
@@ -17,6 +17,10 @@ description: |
   Note: This schema references definitions from morphir-ir-v4.yaml for core types
   (Name, ModuleName, PackageName, TypeDefinition, ValueDefinition, etc.).
 
+  A top-level "$meta" member in any document-tree file is reserved (decision 0014):
+  readers ignore it and never report it as unknown; writers never emit it.
+  session.jsonl is daemon workspace state and not part of a distribution.
+
 definitions:
   # Import core types from main schema (these would be $ref in practice)
   FormatVersion:
@@ -38,10 +42,24 @@ definitions:
       - type: array
         items:
           type: string
-          pattern: "^[a-z][a-z0-9]*$"
+          pattern: "^[a-z0-9]+$"
         minItems: 1
-        description: "Legacy array representation"
-  
+        description: |
+          Legacy array representation. One legacy word grammar is shared with
+          morphir-ir-v4.yaml (decision 0012), so a digits-only word is legal:
+          ["item", "2"] decodes to "item-2".
+
+  FileStem:
+    type: string
+    pattern: "^_?[a-z0-9]+(-_?[a-z0-9]+)*(__[0-9a-f]{8})?_?$"
+    description: |
+      Escaped projection of a Name onto the document tree (decision 0001). All lowercase; an
+      initialism segment carries a "_" prefix; a Windows reserved device name carries a "_"
+      suffix. A stem truncated for the path budget keeps a prefix of the escaped stem with
+      trailing "-" and "_" removed, then "__" and the first eight hex digits of the SHA-256 of
+      the untruncated escaped stem; the module manifest then records the mapping in fileNames.
+    examples: ["user", "user-_id", "value-in-_usd", "aux_", "customer-relati__3f9a1c04"]
+
   ModuleName:
     oneOf:
       - type: string
@@ -139,14 +157,10 @@ definitions:
       - type: object
         required: []
         properties:
-          doc:
-            oneOf:
-              - type: string
-                description: "Single-line documentation (will be split on newlines)"
-              - type: array
-                items: { type: string }
-                description: "Multi-line documentation (one string per line)"
-            description: "Optional documentation for this type"
+          "$meta":
+            description: |
+              Reserved (decision 0014): readers ignore it and never report it as unknown;
+              writers never emit it.
           def:
             type: object
             required: []
@@ -159,7 +173,7 @@ definitions:
                   - type: string
                   - type: array
                     items: { type: string }
-                description: "Optional documentation (can be at def level or top level)"
+                description: "Documentation, first beside the variant (decision 0010)"
             additionalProperties: true
             description: |
               Type definition (implementation). Used in PackageDefinition.
@@ -186,13 +200,13 @@ definitions:
       Structure:
       - formatVersion: Required, shared v4 format version
       - name: Required, canonical name matching filename
-      - doc: Optional, documentation (can be at top level or nested in def/spec)
+      - doc: inside def or spec, first beside the variant (decision 0010); never at the top level
       - def: Required if this is a definition (implementation), contains TypeDefinition variant
       - spec: Required if this is a specification (interface), contains TypeSpecification variant
       
       Exactly one of 'def' or 'spec' must be present.
     examples:
-      - { "formatVersion": 4, "name": "user", "doc": "Represents a user", "def": { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": { "Record": { "fields": { "email": "morphir/SDK:string#string" } } } } } }
+      - { "formatVersion": 4, "name": "user", "def": { "access": "Public", "doc": "Represents a user", "TypeAliasDefinition": { "typeParams": [], "typeExp": { "Record": { "fields": { "email": "morphir/SDK:string#string" } } } } } }
       - { "formatVersion": 4, "name": "int", "spec": { "doc": "Arbitrary precision integer", "OpaqueTypeSpecification": {} } }
 
   # Value Definition File (*.value.json)
@@ -202,14 +216,10 @@ definitions:
       - type: object
         required: []
         properties:
-          doc:
-            oneOf:
-              - type: string
-                description: "Single-line documentation"
-              - type: array
-                items: { type: string }
-                description: "Multi-line documentation"
-            description: "Optional documentation for this value"
+          "$meta":
+            description: |
+              Reserved (decision 0014): readers ignore it and never report it as unknown;
+              writers never emit it.
           def:
             type: object
             required: []
@@ -249,7 +259,7 @@ definitions:
       Structure:
       - formatVersion: Required, shared v4 format version
       - name: Required, canonical name matching filename
-      - doc: Optional, documentation (can be at top level or nested in def/spec)
+      - doc: inside def or spec, first beside the variant (decision 0010); never at the top level
       - def: Required if this is a definition (implementation), contains ValueDefinition variant
       - spec: Required if this is a specification (interface), contains ValueSpecification
       
@@ -317,6 +327,19 @@ definitions:
                             value: { $ref: "#/definitions/ValueDefinition" }
                         - $ref: "#/definitions/ValueDefinition"
             description: "Inline value definitions (inline style)"
+      fileNames:
+        type: object
+        propertyNames: { pattern: "^([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*$" }
+        additionalProperties: { $ref: "#/definitions/FileStem" }
+        description: |
+          Canonical name to file stem, for every type or value whose stem was truncated for the
+          path budget (decision 0012). A name listed here must also appear in types or values.
+        examples:
+          - { "customer-relationship-management-record": "customer-relati__44a101f8" }
+      "$meta":
+        description: |
+          Reserved (decision 0014): readers ignore it and never report it as unknown;
+          writers never emit it.
     description: |
       Module manifest file (module.json).
       
@@ -328,6 +351,7 @@ definitions:
          - doc: Optional, module documentation
          - types: Optional, array of type names
          - values: Optional, array of value names
+         - fileNames: Optional, canonical name to truncated stem
       
       2. **Inline Style (Hybrid)**: Contains definitions directly
          - formatVersion: Required
@@ -335,12 +359,13 @@ definitions:
          - doc: Optional, module documentation
          - types: Optional, object mapping type names to definitions
          - values: Optional, object mapping value names to definitions
-      
+
       Either 'path' or 'module' field must be present (they are equivalent).
       The 'path' field is preferred; 'module' is accepted for backwards compatibility.
       Types and values can be arrays (manifest) or objects (inline), but not mixed.
     examples:
       - { "formatVersion": 4, "path": "my-org/domain", "types": ["user", "order"], "values": ["create-order"] }
+      - { "formatVersion": 4, "path": "domain", "types": ["customer-relationship-management-record"], "values": [], "fileNames": { "customer-relationship-management-record": "customer-relati__44a101f8" } }
       - { "formatVersion": 4, "module": "main/domain", "doc": "Domain model", "types": { "user": { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } } }, "values": {} }
       - { "formatVersion": 4, "path": "my-org/domain", "doc": "Domain model", "types": ["user", "order"], "values": ["create-order"] }
       - { "formatVersion": 4, "module": "my-org/domain", "doc": "Domain model (legacy field)", "types": ["user"], "values": [] }
@@ -348,7 +373,7 @@ definitions:
   # Distribution Manifest File (manifest.json)
   DistributionManifestFile:
     type: object
-    required: ["formatVersion", "distribution", "package"]
+    required: ["formatVersion", "distribution", "package", "pathBudget"]
     properties:
       formatVersion:
         $ref: "#/definitions/FormatVersion"
@@ -375,7 +400,6 @@ definitions:
       pathBudget:
         type: integer
         minimum: 64
-        default: 4000
         description: |
           Maximum path length, in characters from the distribution root, that this
           tree was written against. A stem that would exceed it is truncated and
@@ -387,10 +411,8 @@ definitions:
           LongPathsEnabled and for stock Git for Windows, which ships
           core.longpaths=false.
 
-          Writers set this unconditionally rather than leaving it inferred, so a
-          reader that cannot satisfy the budget can say so up front instead of
-          failing to open files one at a time. A missing value is read as 4000,
-          for trees written before this field existed.
+          Required (decision 0012): writers always state the budget so a reader can
+          refuse a tree it cannot open before opening files one at a time.
         examples: [4000, 200]
       entryPoints:
         type: object
@@ -398,6 +420,10 @@ definitions:
         description: |
           Entry points (required for Application distributions, optional otherwise).
           Map of entry point names to EntryPoint definitions.
+      "$meta":
+        description: |
+          Reserved (decision 0014): readers ignore it and never report it as unknown;
+          writers never emit it.
     description: |
       Distribution manifest/metadata file (manifest.json).
       
@@ -407,13 +433,14 @@ definitions:
       - formatVersion: Required, IR format version
       - distribution: Required, distribution type (Library, Specs, Application)
       - package: Required, package name
+      - pathBudget: Required, path length this tree was written against (decision 0012)
       - version: Optional, package version
       - created: Optional, creation timestamp (ISO 8601)
       - layout: Optional, distribution layout (defaults to VfsMode for document tree)
       - entryPoints: Optional, entry points (required for Application distributions)
     examples:
-      - { "formatVersion": 4, "distribution": "Library", "package": "my-org/my-project", "version": "1.2.0", "created": "2026-01-15T12:00:00Z", "layout": "VfsMode" }
-      - { "formatVersion": 4, "distribution": "Specs", "package": "morphir/SDK", "version": "3.0.0", "created": "2026-01-15T12:00:00Z", "layout": "VfsMode" }
-      - { "formatVersion": 4, "distribution": "Application", "package": "my-org/my-cli", "version": "2.0.0", "created": "2026-01-15T12:00:00Z", "entryPoints": { "startup": { "target": "my-org/my-cli:main#run", "kind": "main" } } }
+      - { "formatVersion": 4, "distribution": "Library", "package": "my-org/my-project", "pathBudget": 4000, "version": "1.2.0", "created": "2026-01-15T12:00:00Z", "layout": "VfsMode" }
+      - { "formatVersion": 4, "distribution": "Specs", "package": "morphir/SDK", "pathBudget": 4000, "version": "3.0.0", "created": "2026-01-15T12:00:00Z", "layout": "VfsMode" }
+      - { "formatVersion": 4, "distribution": "Application", "package": "my-org/my-cli", "pathBudget": 4000, "version": "2.0.0", "created": "2026-01-15T12:00:00Z", "entryPoints": { "startup": { "target": "my-org/my-cli:main#run", "kind": "main" } } }
 
 

--- a/website/static/schemas/morphir-ir-v4-document-tree-files.yaml
+++ b/website/static/schemas/morphir-ir-v4-document-tree-files.yaml
@@ -406,7 +406,7 @@ definitions:
           suffixed with "__" plus eight hex digits, and the module then records the
           mapping in its "fileNames".
 
-          4000 is the default and suits Linux, macOS, and Windows with long paths
+          4000 suits Linux, macOS, and Windows with long paths
           enabled. 200 is the portable profile, for Windows without
           LongPathsEnabled and for stock Git for Windows, which ships
           core.longpaths=false.

--- a/website/static/schemas/morphir-ir-v4.json
+++ b/website/static/schemas/morphir-ir-v4.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://morphir.finos.org/schemas/morphir-ir-v4.json",
   "title": "Morphir IR Distribution",
-  "description": "Morphir IR format version 4.\n\nV4 introduces key improvements:\n- Wrapper object format for distributions (replaces tagged arrays)\n- Object/dict format for modules, types, values, and dependencies\n- Explicit TypeAttributes and ValueAttributes\n- Canonical string formats for names, paths, and FQNames\n- Embedded documentation support\n- New value expressions (Hole, Native, External)\n\nSee the complete example at: docs/spec/ir/schemas/v4/complete-example.json\n",
+  "description": "Morphir IR format version 4.\n\nV4 introduces key improvements:\n- Wrapper object format for distributions (replaces tagged arrays)\n- Object/dict format for modules, types, values, and dependencies\n- Explicit TypeAttributes and ValueAttributes\n- Canonical string formats for names, paths, and FQNames\n- Embedded documentation support\n- New value expression (Hole) and definition bodies (NativeBody, ExternalBody, IncompleteBody)\n- DocumentLiteral, a schema-less JSON-like literal (decision 0013)\n\nSee the complete example at: docs/spec/ir/schemas/v4/complete-example.json\n",
   "type": "object",
   "required": [ "formatVersion", "distribution" ],
   "properties": {
@@ -117,18 +117,6 @@
       "description": "Module path within a package. Examples: \"basics\", \"list\", \"domain/users\"\n",
       "examples": [ "basics", "list", "domain/users", "US/FR2052A/data-tables" ],
       "$ref": "#/definitions/Path"
-    },
-    "FileStem": {
-      "description": "Escaped projection of a Name onto the document tree. All lowercase, so it is\nstable on case-insensitive filesystems. An initialism segment carries a \"_\"\nprefix; a stem colliding with a Windows reserved device name carries a \"_\"\nsuffix.\n\nA stem truncated for path length carries \"__\" followed by eight hex digits\nof the SHA-256 of the untruncated stem. A truncated stem is not reversible,\nso the module manifest records the mapping from canonical name to stem.\n",
-      "examples": [
-        "user",
-        "user-_id",
-        "value-in-_usd",
-        "aux_",
-        "some-extremely-long-canonical__3f9a1c04"
-      ],
-      "type": "string",
-      "pattern": "^_?[a-z0-9]+(-_?[a-z0-9]+)*(__[0-9a-f]{8})?_?$"
     },
     "FQNameString": {
       "description": "Fully-qualified name in canonical string format: \"package:module#name\"\nThis uniquely identifies a type or value across the entire IR.\n",
@@ -354,6 +342,11 @@
       "type": "string",
       "enum": [ "Public", "Private", "public", "private", "pub" ]
     },
+    "Doc": {
+      "description": "Documentation text. Decision 0010 places \"doc\" first, flattened beside the\nvariant it documents, rather than in a nested { \"doc\", \"value\" } wrapper.\n",
+      "examples": [ "The user's display name", "Adds two integers" ],
+      "type": "string"
+    },
     "AccessControlled": {
       "description": "Wrapper for access control.\n\nCanonical: Access level as the key: { \"Public\": {...} } or { \"Private\": {...} }\nAccepted: lowercase and abbreviations: { \"pub\": {...} }, { \"public\": {...} }, { \"private\": {...} }\nLegacy: { \"access\": \"Public\", \"value\": {...} }\nFlattened: { \"access\": \"Public\", \"TypeAliasDefinition\": {...} }\n\nEncoders should output the canonical form.\n",
       "examples": [
@@ -444,6 +437,211 @@
           "properties": {
             "access": {
               "$ref": "#/definitions/Access"
+            }
+          }
+        }
+      ]
+    },
+    "DocumentedTypeDefinition": {
+      "description": "A type definition, documented or not.\nCanonical: { \"doc\": \"...\", \"TypeAliasDefinition\": {...} }\nAccepted for one release: { \"doc\": \"...\", \"value\": { \"TypeAliasDefinition\": {...} } }\n",
+      "examples": [
+        {
+          "TypeAliasDefinition": {
+            "typeParams": [],
+            "typeExp": "morphir/SDK:string#string"
+          }
+        },
+        {
+          "doc": "The user's display name",
+          "TypeAliasDefinition": {
+            "typeParams": [],
+            "typeExp": "morphir/SDK:string#string"
+          }
+        }
+      ],
+      "oneOf": [
+        {
+          "$ref": "#/definitions/TypeDefinition"
+        },
+        {
+          "description": "Nested wrapper, accepted for one release (decision 0010)",
+          "type": "object",
+          "required": [ "doc", "value" ],
+          "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
+            "value": {
+              "$ref": "#/definitions/TypeDefinition"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DocumentedValueDefinition": {
+      "description": "A value definition, documented or not.\nCanonical: { \"doc\": \"...\", \"ExpressionBody\": {...} }\nAccepted for one release: { \"doc\": \"...\", \"value\": { \"ExpressionBody\": {...} } }\n",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ValueDefinition"
+        },
+        {
+          "description": "Nested wrapper, accepted for one release (decision 0010)",
+          "type": "object",
+          "required": [ "doc", "value" ],
+          "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
+            "value": {
+              "$ref": "#/definitions/ValueDefinition"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DocumentedTypeSpecification": {
+      "description": "A type specification, documented or not.\nCanonical: { \"doc\": \"...\", \"OpaqueTypeSpecification\": {} }\n",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/TypeSpecification"
+        },
+        {
+          "description": "Nested wrapper, accepted for one release (decision 0010)",
+          "type": "object",
+          "required": [ "doc", "value" ],
+          "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
+            "value": {
+              "$ref": "#/definitions/TypeSpecification"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DocumentedValueSpecification": {
+      "description": "A value specification, documented or not. Its \"doc\" is first beside its own\nmembers (decision 0010).\nCanonical: { \"doc\": \"...\", \"inputs\": {...}, \"output\": ... }\n",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/ValueSpecification"
+        },
+        {
+          "description": "Nested wrapper, accepted for one release (decision 0010)",
+          "type": "object",
+          "required": [ "doc", "value" ],
+          "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
+            "value": {
+              "$ref": "#/definitions/ValueSpecification"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "AccessControlledTypeDefinition": {
+      "description": "An access-controlled type definition, the entry shape of ModuleDefinition.types.\nCanonical: { \"Public\": { \"doc\": \"...\", \"TypeAliasDefinition\": {...} } }\nAccepted: { \"access\": \"Public\", \"TypeAliasDefinition\": {...} } and the lowercase\nand \"pub\" spellings of the access level.\n",
+      "examples": [
+        {
+          "Public": {
+            "TypeAliasDefinition": {
+              "typeParams": [],
+              "typeExp": "morphir/SDK:string#string"
+            }
+          }
+        },
+        {
+          "Public": {
+            "doc": "The user's display name",
+            "TypeAliasDefinition": {
+              "typeParams": [],
+              "typeExp": "morphir/SDK:string#string"
+            }
+          }
+        },
+        {
+          "access": "Public",
+          "TypeAliasDefinition": {
+            "typeParams": [],
+            "typeExp": "morphir/SDK:string#string"
+          }
+        }
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/AccessControlled"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Public": {
+              "$ref": "#/definitions/DocumentedTypeDefinition"
+            },
+            "Private": {
+              "$ref": "#/definitions/DocumentedTypeDefinition"
+            },
+            "public": {
+              "$ref": "#/definitions/DocumentedTypeDefinition"
+            },
+            "private": {
+              "$ref": "#/definitions/DocumentedTypeDefinition"
+            },
+            "pub": {
+              "$ref": "#/definitions/DocumentedTypeDefinition"
+            },
+            "value": {
+              "$ref": "#/definitions/DocumentedTypeDefinition"
+            }
+          }
+        }
+      ]
+    },
+    "AccessControlledValueDefinition": {
+      "description": "An access-controlled value definition, the entry shape of ModuleDefinition.values.\nCanonical: { \"Public\": { \"doc\": \"...\", \"ExpressionBody\": {...} } }\n",
+      "examples": [
+        {
+          "access": "Public",
+          "ExpressionBody": {
+            "inputTypes": {},
+            "outputType": "morphir/SDK:basics#int",
+            "body": {
+              "Literal": {
+                "IntegerLiteral": 42
+              }
+            }
+          }
+        }
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/AccessControlled"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "Public": {
+              "$ref": "#/definitions/DocumentedValueDefinition"
+            },
+            "Private": {
+              "$ref": "#/definitions/DocumentedValueDefinition"
+            },
+            "public": {
+              "$ref": "#/definitions/DocumentedValueDefinition"
+            },
+            "private": {
+              "$ref": "#/definitions/DocumentedValueDefinition"
+            },
+            "pub": {
+              "$ref": "#/definitions/DocumentedValueDefinition"
+            },
+            "value": {
+              "$ref": "#/definitions/DocumentedValueDefinition"
             }
           }
         }
@@ -767,15 +965,17 @@
       "enum": [ "main", "command", "handler", "job", "policy" ]
     },
     "ModuleDefinition": {
-      "description": "Full module definition containing all types and values with their implementations.\nIncludes both public and private items. Used in PackageDefinition.\nThe \"types\" and \"values\" fields can be omitted if empty.\n",
+      "description": "Full module definition containing all types and values with their implementations.\nIncludes both public and private items. Used in PackageDefinition.\nThe \"types\" and \"values\" fields can be omitted if empty.\n\nCanonical: \"doc\" flattened first beside the variant (decision 0010); the nested\n{ \"doc\", \"value\" } form is accepted for one release.\n",
       "examples": [
         {
           "types": {
             "user": {
-              "access": "Public",
-              "TypeAliasDefinition": {
-                "typeParams": [],
-                "typeExp": "morphir/SDK:string#string"
+              "Public": {
+                "doc": "The user's display name",
+                "TypeAliasDefinition": {
+                  "typeParams": [],
+                  "typeExp": "morphir/SDK:string#string"
+                }
               }
             }
           },
@@ -822,90 +1022,38 @@
       "type": "object",
       "properties": {
         "types": {
-          "description": "Dictionary mapping type names to access-controlled type definitions.\nV4 uses object format: { \"type-name\": { \"access\": \"Public\", \"TypeAliasDefinition\": {...} } }\nDocumentation can be included inline or omitted if None.\nOptional - defaults to empty object if omitted.\n",
+          "description": "Dictionary mapping type names to access-controlled type definitions.\nV4 uses object format: { \"type-name\": { \"access\": \"Public\", \"TypeAliasDefinition\": {...} } }\nOptional - defaults to empty object if omitted.\n",
           "type": "object",
           "additionalProperties": {
-            "allOf": [
-              {
-                "$ref": "#/definitions/AccessControlled"
-              },
-              {
-                "properties": {
-                  "value": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": [ "doc", "value" ],
-                        "properties": {
-                          "doc": {
-                            "type": "string"
-                          },
-                          "value": {
-                            "$ref": "#/definitions/TypeDefinition"
-                          }
-                        }
-                      },
-                      {
-                        "$ref": "#/definitions/TypeDefinition"
-                      }
-                    ]
-                  }
-                }
-              }
-            ]
+            "$ref": "#/definitions/AccessControlledTypeDefinition"
           }
         },
         "values": {
-          "description": "Dictionary mapping value names to access-controlled value definitions.\nV4 uses object format: { \"value-name\": { \"access\": \"Public\", \"ExpressionBody\": {...} } }\nDocumentation can be included inline or omitted if None.\nOptional - defaults to empty object if omitted.\n",
+          "description": "Dictionary mapping value names to access-controlled value definitions.\nV4 uses object format: { \"value-name\": { \"access\": \"Public\", \"ExpressionBody\": {...} } }\nOptional - defaults to empty object if omitted.\n",
           "type": "object",
           "additionalProperties": {
-            "allOf": [
-              {
-                "$ref": "#/definitions/AccessControlled"
-              },
-              {
-                "properties": {
-                  "value": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": [ "doc", "value" ],
-                        "properties": {
-                          "doc": {
-                            "type": "string"
-                          },
-                          "value": {
-                            "$ref": "#/definitions/ValueDefinition"
-                          }
-                        }
-                      },
-                      {
-                        "$ref": "#/definitions/ValueDefinition"
-                      }
-                    ]
-                  }
-                }
-              }
-            ]
+            "$ref": "#/definitions/AccessControlledValueDefinition"
           }
         },
         "doc": {
           "description": "Optional module-level documentation",
-          "type": "string"
+          "$ref": "#/definitions/Doc"
         }
       }
     },
     "ModuleSpecification": {
-      "description": "Module specification containing only public interfaces (no implementations).\nUsed in PackageSpecification and dependencies.\nThe \"types\" and \"values\" fields can be omitted if empty.\n",
+      "description": "Module specification containing only public interfaces (no implementations).\nUsed in PackageSpecification and dependencies.\nThe \"types\" and \"values\" fields can be omitted if empty.\n\nCanonical: \"doc\" flattened first beside the variant (decision 0010); the nested\n{ \"doc\", \"value\" } form is accepted for one release.\n",
       "examples": [
         {
           "types": {
             "int": {
+              "doc": "Arbitrary precision integer",
               "OpaqueTypeSpecification": {}
             }
           },
           "values": {
             "add": {
+              "doc": "Adds two integers",
               "inputs": {
                 "a": "morphir/SDK:basics#int",
                 "b": "morphir/SDK:basics#int"
@@ -932,54 +1080,22 @@
           }
         },
         "types": {
-          "description": "Dictionary mapping type names to documented type specifications.\nV4 uses object format: { \"type-name\": { \"TypeAliasSpecification\": {...} } }\nDocumentation can be included inline or omitted if None.\nOptional - defaults to empty object if omitted.\n",
+          "description": "Dictionary mapping type names to documented type specifications.\nV4 uses object format: { \"type-name\": { \"TypeAliasSpecification\": {...} } }\nOptional - defaults to empty object if omitted.\n",
           "type": "object",
           "additionalProperties": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [ "doc", "value" ],
-                "properties": {
-                  "doc": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "$ref": "#/definitions/TypeSpecification"
-                  }
-                }
-              },
-              {
-                "$ref": "#/definitions/TypeSpecification"
-              }
-            ]
+            "$ref": "#/definitions/DocumentedTypeSpecification"
           }
         },
         "values": {
-          "description": "Dictionary mapping value names to documented value specifications.\nV4 uses object format: { \"value-name\": { \"inputs\": {...}, \"output\": \"...\" } }\nDocumentation can be included inline or omitted if None.\nOptional - defaults to empty object if omitted.\n",
+          "description": "Dictionary mapping value names to documented value specifications.\nV4 uses object format: { \"value-name\": { \"inputs\": {...}, \"output\": \"...\" } }\nOptional - defaults to empty object if omitted.\n",
           "type": "object",
           "additionalProperties": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [ "doc", "value" ],
-                "properties": {
-                  "doc": {
-                    "type": "string"
-                  },
-                  "value": {
-                    "$ref": "#/definitions/ValueSpecification"
-                  }
-                }
-              },
-              {
-                "$ref": "#/definitions/ValueSpecification"
-              }
-            ]
+            "$ref": "#/definitions/DocumentedValueSpecification"
           }
         },
         "doc": {
           "description": "Optional module-level documentation",
-          "type": "string"
+          "$ref": "#/definitions/Doc"
         }
       }
     },
@@ -1009,10 +1125,51 @@
       ]
     },
     "VariableType": {
-      "description": "Type variable (generic type parameter).\nV4 compact format: bare name string (no ':' or '#').\nDistinguished from Reference by absence of FQName separators.\n",
-      "examples": [ "a", "comparable", "number" ],
-      "type": "string",
-      "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+      "description": "Type variable (generic type parameter).\nCompact: \"a\"; expanded: {\"Variable\": {\"attributes\": {...}, \"name\": \"a\"}}\n",
+      "examples": [
+        "a",
+        "comparable",
+        {
+          "Variable": {
+            "attributes": {},
+            "name": "a"
+          }
+        }
+      ],
+      "oneOf": [
+        {
+          "description": "Compact format: bare name string (no ':' or '#').\nDistinguished from Reference by absence of FQName separators.\n",
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+        },
+        {
+          "type": "object",
+          "required": [ "Variable" ],
+          "properties": {
+            "Variable": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/Name"
+                },
+                {
+                  "type": "object",
+                  "required": [ "name" ],
+                  "properties": {
+                    "attributes": {
+                      "$ref": "#/definitions/TypeAttributes"
+                    },
+                    "name": {
+                      "$ref": "#/definitions/Name"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "ReferenceType": {
       "description": "Reference to a named type, optionally with type arguments.\n\nCanonical (no args): \"morphir/SDK:basics#int\"\nCanonical (with args): {\"Reference\": [\"morphir/SDK:list#list\", \"a\"]}\n\nAccepted formats:\n- Bare FQName string: \"morphir/SDK:basics#int\"\n- Wrapper with FQName: {\"Reference\": \"morphir/SDK:basics#int\"}\n- Wrapper with array: {\"Reference\": [\"morphir/SDK:list#list\", \"a\"]}\n- Wrapper with object: {\"Reference\": {\"fqname\": \"morphir/SDK:list#list\", \"args\": [\"a\"]}}\n\nEncoders should output canonical form.\n",
@@ -1084,10 +1241,13 @@
           "required": [ "Reference" ],
           "properties": {
             "Reference": {
-              "description": "Object with fqname and optional args fields.\n",
+              "description": "Object with optional attributes, fqname, and optional args fields.\n",
               "type": "object",
               "required": [ "fqname" ],
               "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/TypeAttributes"
+                },
                 "fqname": {
                   "$ref": "#/definitions/FQName"
                 },
@@ -1097,7 +1257,8 @@
                     "$ref": "#/definitions/Type"
                   }
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -1141,7 +1302,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Expanded wrapper format with explicit elements field.\n",
+          "description": "Expanded wrapper format with optional attributes and an explicit elements field.\n",
           "type": "object",
           "required": [ "Tuple" ],
           "properties": {
@@ -1149,13 +1310,17 @@
               "type": "object",
               "required": [ "elements" ],
               "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/TypeAttributes"
+                },
                 "elements": {
                   "type": "array",
                   "items": {
                     "$ref": "#/definitions/Type"
                   }
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -1163,18 +1328,22 @@
       ]
     },
     "RecordType": {
-      "description": "Record type with named fields.\nFormat: {\"Record\": {\"field-name\": type, ...}}\n",
+      "description": "Record type with named fields (decision 0004).\nCanonical: {\"Record\": {\"fields\": {\"field-name\": type, ...}}}\nExpanded: {\"Record\": {\"attributes\": {...}, \"fields\": {...}}}\nThe field map directly under \"Record\" is a legacy spelling readers accept for\none release (decision 0006) and report as legacy_spelling; it is not valid here.\n",
       "examples": [
         {
           "Record": {
-            "name": "morphir/SDK:string#string",
-            "age": "morphir/SDK:int#int"
+            "fields": {
+              "name": "morphir/SDK:string#string",
+              "age": "morphir/SDK:basics#int"
+            }
           }
         },
         {
           "Record": {
-            "inflows": "regulation:data-tables#inflows",
-            "outflows": "regulation:data-tables#outflows"
+            "fields": {
+              "inflows": "regulation:data-tables#inflows",
+              "outflows": "regulation:data-tables#outflows"
+            }
           }
         }
       ],
@@ -1182,16 +1351,27 @@
       "required": [ "Record" ],
       "properties": {
         "Record": {
-          "description": "Dictionary mapping field names to their types.\nField names use kebab-case.\n",
           "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Type"
-          }
+          "required": [ "fields" ],
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/TypeAttributes"
+            },
+            "fields": {
+              "description": "Dictionary mapping field names (kebab-case) to their types.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Type"
+              }
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ExtensibleRecordType": {
-      "description": "Extensible record type (row polymorphism).\nFormat: {\"ExtensibleRecord\": {\"variable\": \"a\", \"fields\": {...}}}\n",
+      "description": "Extensible record type (row polymorphism).\nFormat: {\"ExtensibleRecord\": {\"variable\": \"a\", \"fields\": {...}}}\nExpanded: {\"ExtensibleRecord\": {\"attributes\": {...}, \"variable\": \"a\", \"fields\": {...}}}\n",
       "examples": [
         {
           "ExtensibleRecord": {
@@ -1217,6 +1397,9 @@
           "type": "object",
           "required": [ "variable", "fields" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/TypeAttributes"
+            },
             "variable": {
               "$ref": "#/definitions/Name"
             },
@@ -1226,16 +1409,18 @@
                 "$ref": "#/definitions/Type"
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "FunctionType": {
-      "description": "Function type.\nFormat: {\"Function\": {\"argumentType\": ..., \"returnType\": ...}}\n",
+      "description": "Function type. A function declares a parameter and applies an argument (decision 0007).\nCanonical: {\"Function\": {\"parameterType\": ..., \"returnType\": ...}}\nExpanded: {\"Function\": {\"attributes\": {...}, \"parameterType\": ..., \"returnType\": ...}}\nThe older \"argumentType\" and the \"arg\"/\"result\" pair are legacy spellings readers\naccept for one release (decision 0006); they are not valid here.\n",
       "examples": [
         {
           "Function": {
-            "argumentType": "morphir/SDK:int#int",
+            "parameterType": "morphir/SDK:basics#int",
             "returnType": "morphir/SDK:string#string"
           }
         }
@@ -1245,32 +1430,49 @@
       "properties": {
         "Function": {
           "type": "object",
-          "required": [ "argumentType", "returnType" ],
+          "required": [ "parameterType", "returnType" ],
           "properties": {
-            "argumentType": {
+            "attributes": {
+              "$ref": "#/definitions/TypeAttributes"
+            },
+            "parameterType": {
               "$ref": "#/definitions/Type"
             },
             "returnType": {
               "$ref": "#/definitions/Type"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "UnitType": {
-      "description": "Unit type (the type with exactly one value).\nFormat: {\"Unit\": {}}\n",
+      "description": "Unit type (the type with exactly one value).\nCompact: {\"Unit\": {}}; expanded: {\"Unit\": {\"attributes\": {...}}}\n",
       "examples": [
         {
           "Unit": {}
+        },
+        {
+          "Unit": {
+            "attributes": {}
+          }
         }
       ],
       "type": "object",
       "required": [ "Unit" ],
       "properties": {
         "Unit": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/TypeAttributes"
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "Field": {
       "type": "object",
@@ -1323,6 +1525,9 @@
           "type": "object",
           "required": [ "TypeAliasSpecification" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "TypeAliasSpecification": {
               "type": "object",
               "required": [ "typeParams", "typeExp" ],
@@ -1383,6 +1588,9 @@
           "type": "object",
           "required": [ "OpaqueTypeSpecification" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "OpaqueTypeSpecification": {
               "type": "object",
               "properties": {
@@ -1439,6 +1647,9 @@
           "type": "object",
           "required": [ "CustomTypeSpecification" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "CustomTypeSpecification": {
               "type": "object",
               "required": [ "typeParams", "constructors" ],
@@ -1499,6 +1710,9 @@
           "type": "object",
           "required": [ "DerivedTypeSpecification" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "DerivedTypeSpecification": {
               "type": "object",
               "required": [
@@ -1604,6 +1818,9 @@
           "type": "object",
           "required": [ "TypeAliasDefinition" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "TypeAliasDefinition": {
               "type": "object",
               "required": [ "typeParams", "typeExp" ],
@@ -1662,6 +1879,9 @@
           "type": "object",
           "required": [ "CustomTypeDefinition" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "CustomTypeDefinition": {
               "type": "object",
               "required": [ "typeParams", "constructors" ],
@@ -1735,6 +1955,9 @@
       "type": "object",
       "required": [ "IncompleteTypeDefinition" ],
       "properties": {
+        "doc": {
+          "$ref": "#/definitions/Doc"
+        },
         "IncompleteTypeDefinition": {
           "type": "object",
           "required": [ "typeParams", "incompleteness" ],
@@ -1829,7 +2052,7 @@
           "type": "boolean"
         },
         {
-          "description": "Shorthand for IntegerLiteral or FloatLiteral",
+          "description": "Shorthand for IntegerLiteral or FloatLiteral, by lexeme (decision 0009)",
           "type": "number"
         },
         {
@@ -1843,7 +2066,7 @@
           "pattern": "^([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*$"
         },
         {
-          "description": "Shorthand for List",
+          "description": "Shorthand for List (decision 0009); a Tuple always carries its wrapper",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Value"
@@ -1902,6 +2125,9 @@
         },
         {
           "$ref": "#/definitions/UnitValue"
+        },
+        {
+          "$ref": "#/definitions/HoleValue"
         }
       ]
     },
@@ -1979,32 +2205,55 @@
                     }
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ConstructorValue": {
-      "description": "Reference to a custom type constructor.\nFormat: {\"Constructor\": \"package:module#constructor-name\"}\n",
+      "description": "Reference to a custom type constructor.\nCompact: {\"Constructor\": \"package:module#constructor-name\"}\nExpanded: {\"Constructor\": {\"attributes\": {...}, \"fqname\": \"package:module#constructor-name\"}}\n",
       "examples": [
         {
           "Constructor": "morphir/SDK:maybe#just"
         },
         {
-          "Constructor": "morphir/SDK:maybe#nothing"
+          "Constructor": {
+            "attributes": {},
+            "fqname": "morphir/SDK:maybe#just"
+          }
         }
       ],
       "type": "object",
       "required": [ "Constructor" ],
       "properties": {
         "Constructor": {
-          "$ref": "#/definitions/FQName"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FQName"
+            },
+            {
+              "type": "object",
+              "required": [ "fqname" ],
+              "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/ValueAttributes"
+                },
+                "fqname": {
+                  "$ref": "#/definitions/FQName"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "TupleValue": {
-      "description": "Tuple value with multiple elements.\n\nCanonical: {\"Tuple\": [value1, value2, ...]}\n\nAccepted formats:\n- Wrapper with array: {\"Tuple\": [value1, value2, ...]}\n- Wrapper with object: {\"Tuple\": {\"elements\": [value1, value2, ...]}}\n\nNote: Bare arrays are NOT allowed for values (would be ambiguous with ListValue).\n\nEncoders should output canonical form.\n",
+      "description": "Tuple value with multiple elements.\n\nCanonical: {\"Tuple\": [value1, value2, ...]}\n\nAccepted formats:\n- Wrapper with array: {\"Tuple\": [value1, value2, ...]}\n- Wrapper with object: {\"Tuple\": {\"elements\": [value1, value2, ...]}}\n- Expanded: {\"Tuple\": {\"attributes\": {...}, \"elements\": [...]}}\n\nA bare array at value position is a List (decision 0009).\n\nEncoders should output canonical form.\n",
       "examples": [
         {
           "Tuple": [
@@ -2049,7 +2298,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Expanded wrapper format with explicit elements field.\n",
+          "description": "Expanded wrapper format with optional attributes and an explicit elements field.\n",
           "type": "object",
           "required": [ "Tuple" ],
           "properties": {
@@ -2057,13 +2306,17 @@
               "type": "object",
               "required": [ "elements" ],
               "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/ValueAttributes"
+                },
                 "elements": {
                   "type": "array",
                   "items": {
                     "$ref": "#/definitions/Value"
                   }
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -2071,7 +2324,7 @@
       ]
     },
     "ListValue": {
-      "description": "List of values.\n\nCanonical: {\"List\": [value1, value2, ...]}\n\nAccepted formats:\n- Wrapper with array: {\"List\": [value1, value2, ...]}\n- Wrapper with object: {\"List\": {\"items\": [value1, value2, ...]}}\n\nNote: Bare arrays are NOT allowed for values (would be ambiguous with TupleValue).\n\nEncoders should output canonical form.\n",
+      "description": "List of values.\n\nCanonical: {\"List\": [value1, value2, ...]}\n\nAccepted formats:\n- Wrapper with array: {\"List\": [value1, value2, ...]}\n- Wrapper with object: {\"List\": {\"items\": [value1, value2, ...]}}\n- Expanded: {\"List\": {\"attributes\": {...}, \"items\": [...]}}\n\nA bare array at value position is a List (decision 0009).\n\nEncoders should output canonical form.\n",
       "examples": [
         {
           "List": [
@@ -2120,7 +2373,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Expanded wrapper format with explicit items field.\n",
+          "description": "Expanded wrapper format with optional attributes and an explicit items field.\n",
           "type": "object",
           "required": [ "List" ],
           "properties": {
@@ -2128,13 +2381,17 @@
               "type": "object",
               "required": [ "items" ],
               "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/ValueAttributes"
+                },
                 "items": {
                   "type": "array",
                   "items": {
                     "$ref": "#/definitions/Value"
                   }
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -2142,16 +2399,18 @@
       ]
     },
     "RecordValue": {
-      "description": "Record value with named fields.\nFormat: {\"Record\": {\"field-name\": value, ...}}\nField names use kebab-case.\n",
+      "description": "Record value with named fields (decision 0004).\nCanonical: {\"Record\": {\"fields\": {\"field-name\": value, ...}}}\nExpanded: {\"Record\": {\"attributes\": {...}, \"fields\": {...}}}\nThe field map directly under \"Record\" is a legacy spelling readers accept for\none release (decision 0006) and report as legacy_spelling; it is not valid here.\n",
       "examples": [
         {
           "Record": {
-            "name": {
-              "Variable": "x"
-            },
-            "age": {
-              "Literal": {
-                "IntegerLiteral": 25
+            "fields": {
+              "name": {
+                "Variable": "x"
+              },
+              "age": {
+                "Literal": {
+                  "IntegerLiteral": 25
+                }
               }
             }
           }
@@ -2162,50 +2421,104 @@
       "properties": {
         "Record": {
           "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
+          "required": [ "fields" ],
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
+            "fields": {
+              "description": "Dictionary mapping field names (kebab-case) to their values.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/Value"
+              }
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "VariableValue": {
-      "description": "Reference to a variable in scope.\nFormat: {\"Variable\": \"variable-name\"}\n",
+      "description": "Reference to a variable in scope.\nCompact: {\"Variable\": \"variable-name\"}; expanded: {\"Variable\": {\"attributes\": {...}, \"name\": \"variable-name\"}}\n",
       "examples": [
         {
           "Variable": "x"
         },
         {
-          "Variable": "my-value"
+          "Variable": {
+            "attributes": {},
+            "name": "x"
+          }
         }
       ],
       "type": "object",
       "required": [ "Variable" ],
       "properties": {
         "Variable": {
-          "$ref": "#/definitions/Name"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Name"
+            },
+            {
+              "type": "object",
+              "required": [ "name" ],
+              "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/ValueAttributes"
+                },
+                "name": {
+                  "$ref": "#/definitions/Name"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ReferenceValue": {
-      "description": "Reference to a defined value (function or constant).\nFormat: {\"Reference\": \"package:module#name\"}\n",
+      "description": "Reference to a defined value (function or constant).\nCompact: {\"Reference\": \"package:module#name\"}; expanded: {\"Reference\": {\"attributes\": {...}, \"fqname\": \"package:module#name\"}}\n",
       "examples": [
         {
           "Reference": "morphir/SDK:basics#add"
         },
         {
-          "Reference": "morphir/SDK:list#map"
+          "Reference": {
+            "attributes": {},
+            "fqname": "morphir/SDK:basics#add"
+          }
         }
       ],
       "type": "object",
       "required": [ "Reference" ],
       "properties": {
         "Reference": {
-          "$ref": "#/definitions/FQName"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/FQName"
+            },
+            {
+              "type": "object",
+              "required": [ "fqname" ],
+              "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/ValueAttributes"
+                },
+                "fqname": {
+                  "$ref": "#/definitions/FQName"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "FieldValue": {
-      "description": "Field access on a record.\nFormat: {\"Field\": {\"target\": value, \"name\": \"field-name\"}}\n",
+      "description": "Field access on a record.\nFormat: {\"Field\": {\"target\": value, \"name\": \"field-name\"}}\nThe older \"subject\" and \"fieldName\" are legacy spellings readers accept for one\nrelease (decision 0006); they are not valid here.\n",
       "examples": [
         {
           "Field": {
@@ -2223,36 +2536,62 @@
           "type": "object",
           "required": [ "target", "name" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "target": {
               "$ref": "#/definitions/Value"
             },
             "name": {
               "$ref": "#/definitions/Name"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "FieldFunctionValue": {
-      "description": "A function that extracts a field.\nFormat: {\"FieldFunction\": \"field-name\"}\n",
+      "description": "A function that extracts a field.\nCompact: {\"FieldFunction\": \"field-name\"}; expanded: {\"FieldFunction\": {\"attributes\": {...}, \"name\": \"field-name\"}}\n",
       "examples": [
         {
           "FieldFunction": "name"
         },
         {
-          "FieldFunction": "age"
+          "FieldFunction": {
+            "attributes": {},
+            "name": "name"
+          }
         }
       ],
       "type": "object",
       "required": [ "FieldFunction" ],
       "properties": {
         "FieldFunction": {
-          "$ref": "#/definitions/Name"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Name"
+            },
+            {
+              "type": "object",
+              "required": [ "name" ],
+              "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/ValueAttributes"
+                },
+                "name": {
+                  "$ref": "#/definitions/Name"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ApplyValue": {
-      "description": "Function application.\nFormat: {\"Apply\": {\"function\": value, \"argument\": value}}\n",
+      "description": "Function application: an argument is applied to a function (decision 0007).\nFormat: {\"Apply\": {\"function\": value, \"argument\": value}}\n",
       "examples": [
         {
           "Apply": {
@@ -2274,15 +2613,20 @@
           "type": "object",
           "required": [ "function", "argument" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "function": {
               "$ref": "#/definitions/Value"
             },
             "argument": {
               "$ref": "#/definitions/Value"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "LambdaValue": {
       "description": "Anonymous function (lambda).\nFormat: {\"Lambda\": {\"pattern\": pattern, \"body\": value}}\n",
@@ -2310,23 +2654,38 @@
           "type": "object",
           "required": [ "pattern", "body" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "pattern": {
               "$ref": "#/definitions/Pattern"
             },
             "body": {
               "$ref": "#/definitions/Value"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "LetDefinitionValue": {
-      "description": "Let binding introducing a single value.\nFormat: {\"LetDefinition\": {\"name\": \"x\", \"definition\": {...}, \"in\": value}}\n",
+      "description": "Let binding introducing a single value.\nFormat: {\"LetDefinition\": {\"name\": \"x\", \"definition\": {...}, \"in\": value}}\nThe older \"valueName\", \"valueDefinition\", and \"inValue\" are legacy spellings\nreaders accept for one release (decision 0006); they are not valid here.\n",
       "examples": [
         {
           "LetDefinition": {
             "name": "x",
-            "definition": {},
+            "definition": {
+              "ExpressionBody": {
+                "inputTypes": {},
+                "outputType": "morphir/SDK:basics#int",
+                "body": {
+                  "Literal": {
+                    "IntegerLiteral": 1
+                  }
+                }
+              }
+            },
             "in": {
               "Variable": "x"
             }
@@ -2340,6 +2699,9 @@
           "type": "object",
           "required": [ "name", "definition", "in" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "name": {
               "$ref": "#/definitions/Name"
             },
@@ -2349,9 +2711,11 @@
             "in": {
               "$ref": "#/definitions/Value"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "LetRecursionValue": {
       "description": "Mutually recursive let bindings.\nFormat: {\"LetRecursion\": {\"definitions\": {\"f\": {...}, \"g\": {...}}, \"in\": value}}\n",
@@ -2359,8 +2723,15 @@
         {
           "LetRecursion": {
             "definitions": {
-              "f": {},
-              "g": {}
+              "f": {
+                "ExpressionBody": {
+                  "inputTypes": {},
+                  "outputType": "morphir/SDK:basics#int",
+                  "body": {
+                    "Variable": "f"
+                  }
+                }
+              }
             },
             "in": {
               "Variable": "f"
@@ -2375,6 +2746,9 @@
           "type": "object",
           "required": [ "definitions", "in" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "definitions": {
               "type": "object",
               "additionalProperties": {
@@ -2384,9 +2758,11 @@
             "in": {
               "$ref": "#/definitions/Value"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "DestructureValue": {
       "description": "Pattern-based destructuring.\nFormat: {\"Destructure\": {\"pattern\": pattern, \"value\": value, \"in\": value}}\n",
@@ -2397,6 +2773,9 @@
           "type": "object",
           "required": [ "pattern", "value", "in" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "pattern": {
               "$ref": "#/definitions/Pattern"
             },
@@ -2406,12 +2785,14 @@
             "in": {
               "$ref": "#/definitions/Value"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "IfThenElseValue": {
-      "description": "Conditional expression.\nFormat: {\"IfThenElse\": {\"condition\": value, \"then\": value, \"else\": value}}\n",
+      "description": "Conditional expression.\nFormat: {\"IfThenElse\": {\"condition\": value, \"then\": value, \"else\": value}}\nThe older \"thenBranch\" and \"elseBranch\" are legacy spellings readers accept for\none release (decision 0006); they are not valid here.\n",
       "type": "object",
       "required": [ "IfThenElse" ],
       "properties": {
@@ -2419,6 +2800,9 @@
           "type": "object",
           "required": [ "condition", "then", "else" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "condition": {
               "$ref": "#/definitions/Value"
             },
@@ -2428,9 +2812,11 @@
             "else": {
               "$ref": "#/definitions/Value"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "PatternMatchValue": {
       "description": "Pattern matching with multiple cases.\nFormat: {\"PatternMatch\": {\"value\": value, \"cases\": [{\"pattern\": ..., \"body\": ...}, ...]}}\n",
@@ -2441,6 +2827,9 @@
           "type": "object",
           "required": [ "value", "cases" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "value": {
               "$ref": "#/definitions/Value"
             },
@@ -2456,12 +2845,15 @@
                   "body": {
                     "$ref": "#/definitions/Value"
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "UpdateRecordValue": {
       "description": "Record update expression.\nFormat: {\"UpdateRecord\": {\"target\": value, \"fields\": {\"field-name\": value, ...}}}\n",
@@ -2488,6 +2880,9 @@
           "type": "object",
           "required": [ "target", "fields" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "target": {
               "$ref": "#/definitions/Value"
             },
@@ -2497,24 +2892,84 @@
                 "$ref": "#/definitions/Value"
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "UnitValue": {
-      "description": "The unit value.\nFormat: {\"Unit\": {}}\n",
+      "description": "The unit value.\nCompact: {\"Unit\": {}}; expanded: {\"Unit\": {\"attributes\": {...}}}\n",
       "examples": [
         {
           "Unit": {}
+        },
+        {
+          "Unit": {
+            "attributes": {}
+          }
         }
       ],
       "type": "object",
       "required": [ "Unit" ],
       "properties": {
         "Unit": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "HoleValue": {
+      "description": "A missing expression (decision 0008). Hole is the only V4-specific value\nexpression: native and external operations are definition bodies (NativeBody,\nExternalBody), not expressions, and a reader refuses \"Native\" or \"External\" at\nvalue position as an unknown node.\n",
+      "examples": [
+        {
+          "Hole": {
+            "reason": {
+              "UnresolvedReference": {
+                "target": "my-org/project:module#deleted"
+              }
+            }
+          }
+        },
+        {
+          "Hole": {
+            "attributes": {},
+            "reason": {
+              "UnresolvedReference": {
+                "target": "my-org/project:module#deleted"
+              }
+            }
+          }
+        }
+      ],
+      "type": "object",
+      "required": [ "Hole" ],
+      "properties": {
+        "Hole": {
+          "type": "object",
+          "required": [ "reason" ],
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
+            "reason": {
+              "$ref": "#/definitions/HoleReason"
+            },
+            "expectedType": {
+              "description": "Optional type the missing expression was expected to have",
+              "$ref": "#/definitions/Type"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     },
     "Pattern": {
       "oneOf": [
@@ -2545,19 +3000,31 @@
       ]
     },
     "WildcardPattern": {
-      "description": "Wildcard pattern (matches anything).\nFormat: {\"WildcardPattern\": {}}\n",
+      "description": "Wildcard pattern (matches anything).\nCompact: {\"WildcardPattern\": {}}; expanded: {\"WildcardPattern\": {\"attributes\": {...}}}\n",
       "examples": [
         {
           "WildcardPattern": {}
+        },
+        {
+          "WildcardPattern": {
+            "attributes": {}
+          }
         }
       ],
       "type": "object",
       "required": [ "WildcardPattern" ],
       "properties": {
         "WildcardPattern": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "AsPattern": {
       "description": "As pattern (binds matched value to a name).\nFormat: {\"AsPattern\": {\"pattern\": pattern, \"name\": \"x\"}}\n",
@@ -2578,15 +3045,20 @@
           "type": "object",
           "required": [ "pattern", "name" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "pattern": {
               "$ref": "#/definitions/Pattern"
             },
             "name": {
               "$ref": "#/definitions/Name"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "TuplePattern": {
       "description": "Tuple pattern for destructuring tuples.\n\nCanonical: {\"TuplePattern\": [pattern1, pattern2, ...]}\n\nAccepted formats:\n- Bare array: [pattern1, pattern2, ...]\n- Wrapper with array: {\"TuplePattern\": [pattern1, pattern2, ...]}\n- Wrapper with object: {\"TuplePattern\": {\"patterns\": [pattern1, pattern2, ...]}}\n\nEncoders should output canonical form.\n",
@@ -2660,7 +3132,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Expanded wrapper format with explicit patterns field.\n",
+          "description": "Expanded wrapper format with optional attributes and an explicit patterns field.\n",
           "type": "object",
           "required": [ "TuplePattern" ],
           "properties": {
@@ -2668,13 +3140,17 @@
               "type": "object",
               "required": [ "patterns" ],
               "properties": {
+                "attributes": {
+                  "$ref": "#/definitions/ValueAttributes"
+                },
                 "patterns": {
                   "type": "array",
                   "items": {
                     "$ref": "#/definitions/Pattern"
                   }
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false
@@ -2707,6 +3183,9 @@
           "type": "object",
           "required": [ "fqname", "patterns" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "fqname": {
               "$ref": "#/definitions/FQName"
             },
@@ -2716,24 +3195,38 @@
                 "$ref": "#/definitions/Pattern"
               }
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "EmptyListPattern": {
-      "description": "Pattern matching an empty list.\nFormat: {\"EmptyListPattern\": {}}\n",
+      "description": "Pattern matching an empty list.\nCompact: {\"EmptyListPattern\": {}}; expanded: {\"EmptyListPattern\": {\"attributes\": {...}}}\n",
       "examples": [
         {
           "EmptyListPattern": {}
+        },
+        {
+          "EmptyListPattern": {
+            "attributes": {}
+          }
         }
       ],
       "type": "object",
       "required": [ "EmptyListPattern" ],
       "properties": {
         "EmptyListPattern": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "HeadTailPattern": {
       "description": "Pattern matching head and tail of a list.\nFormat: {\"HeadTailPattern\": {\"head\": pattern, \"tail\": pattern}}\n",
@@ -2766,18 +3259,23 @@
           "type": "object",
           "required": [ "head", "tail" ],
           "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            },
             "head": {
               "$ref": "#/definitions/Pattern"
             },
             "tail": {
               "$ref": "#/definitions/Pattern"
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "LiteralPattern": {
-      "description": "Pattern matching a literal value. Multiple forms accepted:\n\n- Most compact: { \"LiteralPattern\": 42 }\n- Compact with type: { \"LiteralPattern\": { \"IntegerLiteral\": 42 } }\n- Expanded: { \"LiteralPattern\": { \"attributes\": {...}, \"literal\": { \"IntegerLiteral\": 42 } } }\n\nEncoders should prefer the most compact unambiguous form.\n",
+      "description": "Pattern matching a literal value. A DocumentLiteral is not a valid pattern\n(decision 0013). Multiple forms accepted:\n\n- Most compact: { \"LiteralPattern\": 42 }\n- Compact with type: { \"LiteralPattern\": { \"IntegerLiteral\": 42 } }\n- Expanded: { \"LiteralPattern\": { \"attributes\": {...}, \"literal\": { \"IntegerLiteral\": 42 } } }\n\nEncoders should prefer the most compact unambiguous form.\n",
       "examples": [
         {
           "LiteralPattern": 42
@@ -2811,7 +3309,29 @@
               "type": "string"
             },
             {
-              "$ref": "#/definitions/Literal"
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/BoolLiteral"
+                },
+                {
+                  "$ref": "#/definitions/CharLiteral"
+                },
+                {
+                  "$ref": "#/definitions/StringLiteral"
+                },
+                {
+                  "$ref": "#/definitions/IntegerLiteral"
+                },
+                {
+                  "$ref": "#/definitions/WholeNumberLiteral"
+                },
+                {
+                  "$ref": "#/definitions/FloatLiteral"
+                },
+                {
+                  "$ref": "#/definitions/DecimalLiteral"
+                }
+              ]
             },
             {
               "type": "object",
@@ -2832,30 +3352,66 @@
                       "type": "string"
                     },
                     {
-                      "$ref": "#/definitions/Literal"
+                      "oneOf": [
+                        {
+                          "$ref": "#/definitions/BoolLiteral"
+                        },
+                        {
+                          "$ref": "#/definitions/CharLiteral"
+                        },
+                        {
+                          "$ref": "#/definitions/StringLiteral"
+                        },
+                        {
+                          "$ref": "#/definitions/IntegerLiteral"
+                        },
+                        {
+                          "$ref": "#/definitions/WholeNumberLiteral"
+                        },
+                        {
+                          "$ref": "#/definitions/FloatLiteral"
+                        },
+                        {
+                          "$ref": "#/definitions/DecimalLiteral"
+                        }
+                      ]
                     }
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "UnitPattern": {
-      "description": "Pattern matching the unit value.\nFormat: {\"UnitPattern\": {}}\n",
+      "description": "Pattern matching the unit value.\nCompact: {\"UnitPattern\": {}}; expanded: {\"UnitPattern\": {\"attributes\": {...}}}\n",
       "examples": [
         {
           "UnitPattern": {}
+        },
+        {
+          "UnitPattern": {
+            "attributes": {}
+          }
         }
       ],
       "type": "object",
       "required": [ "UnitPattern" ],
       "properties": {
         "UnitPattern": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/definitions/ValueAttributes"
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ValueSpecification": {
       "description": "Value specification (public interface - signature only, no implementation).\n\nCanonical format: { \"inputs\": { \"a\": type, \"b\": type }, \"output\": type }\nThe \"inputs\" field can be omitted if empty.\n\nEncoders should output the canonical object format.\nDecoders should accept both object and legacy array formats.\n",
@@ -2926,6 +3482,9 @@
           "type": "object",
           "required": [ "ExpressionBody" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "ExpressionBody": {
               "$ref": "#/definitions/ExpressionBody"
             }
@@ -2936,6 +3495,9 @@
           "type": "object",
           "required": [ "NativeBody" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "NativeBody": {
               "$ref": "#/definitions/NativeBody"
             }
@@ -2946,6 +3508,9 @@
           "type": "object",
           "required": [ "ExternalBody" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "ExternalBody": {
               "$ref": "#/definitions/ExternalBody"
             }
@@ -2956,6 +3521,9 @@
           "type": "object",
           "required": [ "IncompleteBody" ],
           "properties": {
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
             "IncompleteBody": {
               "$ref": "#/definitions/IncompleteBody"
             }
@@ -3046,25 +3614,46 @@
         }
       }
     },
+    "ExternalBinding": {
+      "description": "One per-target binding of an external definition.",
+      "examples": [
+        {
+          "targetPlatform": "javascript",
+          "externalName": "console.log"
+        }
+      ],
+      "type": "object",
+      "required": [ "targetPlatform", "externalName" ],
+      "properties": {
+        "targetPlatform": {
+          "description": "Target platform identifier (e.g. 'javascript', 'erlang', 'wasm')",
+          "type": "string"
+        },
+        "externalName": {
+          "description": "Name of the external function on that platform",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ExternalBody": {
-      "description": "External FFI call body (no IR expression).\nUsed for foreign function interface calls to platform-specific code.\n",
+      "description": "External definition body (decision 0008): one or more per-target bindings and an\noptional fallback body, so a Gleam-style external with a body encodes faithfully.\nThe single-binding spelling with top-level externalName/targetPlatform is a legacy\nspelling readers accept for one release (decision 0006); it is not valid here.\n",
       "examples": [
         {
           "inputTypes": {
             "msg": "morphir/SDK:string#string"
           },
           "outputType": "morphir/SDK:basics#unit",
-          "externalName": "console.log",
-          "targetPlatform": "javascript"
+          "externals": [
+            {
+              "targetPlatform": "javascript",
+              "externalName": "console.log"
+            }
+          ]
         }
       ],
       "type": "object",
-      "required": [
-        "inputTypes",
-        "outputType",
-        "externalName",
-        "targetPlatform"
-      ],
+      "required": [ "inputTypes", "outputType", "externals" ],
       "properties": {
         "inputTypes": {
           "description": "Dictionary mapping input parameter names to their types.\nV4 uses object format: { \"param-name\": type, ... }\n",
@@ -3076,15 +3665,20 @@
         "outputType": {
           "$ref": "#/definitions/Type"
         },
-        "externalName": {
-          "description": "Name of the external function/operation",
-          "type": "string"
+        "externals": {
+          "description": "Per-target bindings; a backend picks the one for its platform",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ExternalBinding"
+          }
         },
-        "targetPlatform": {
-          "description": "Target platform identifier (e.g., 'wasm', 'native')",
-          "type": "string"
+        "body": {
+          "description": "Optional fallback expression for platforms with no binding",
+          "$ref": "#/definitions/Value"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "IncompleteBody": {
       "description": "Incomplete definition body (V4 feature for best-effort support).\nUsed when a definition cannot be fully resolved (e.g., deleted reference, type mismatch).\n",
@@ -3127,7 +3721,7 @@
       }
     },
     "Literal": {
-      "description": "Literal constant value. V4 uses wrapper object format.\n\nTwo forms are accepted (permissive decoding):\n- Compact (canonical): { \"IntegerLiteral\": 42 }\n- Expanded: { \"IntegerLiteral\": { \"value\": 42 } }\n\nEncoders should output the compact form.\n",
+      "description": "Literal constant value. V4 uses wrapper object format, and has seven literals:\nthe six scalar ones and DocumentLiteral (decision 0013).\n\nTwo forms are accepted (permissive decoding):\n- Compact (canonical): { \"IntegerLiteral\": 42 }\n- Expanded: { \"IntegerLiteral\": { \"value\": 42 } }\n\nEncoders should output the compact form.\n",
       "oneOf": [
         {
           "$ref": "#/definitions/BoolLiteral"
@@ -3142,10 +3736,16 @@
           "$ref": "#/definitions/IntegerLiteral"
         },
         {
+          "$ref": "#/definitions/WholeNumberLiteral"
+        },
+        {
           "$ref": "#/definitions/FloatLiteral"
         },
         {
           "$ref": "#/definitions/DecimalLiteral"
+        },
+        {
+          "$ref": "#/definitions/DocumentLiteral"
         }
       ]
     },
@@ -3284,6 +3884,35 @@
       },
       "additionalProperties": false
     },
+    "WholeNumberLiteral": {
+      "description": "The V3 name of IntegerLiteral, accepted on input and never written.\nCompact: { \"WholeNumberLiteral\": 42 }\nExpanded: { \"WholeNumberLiteral\": { \"value\": 42 } }\n",
+      "examples": [
+        {
+          "WholeNumberLiteral": 42
+        }
+      ],
+      "type": "object",
+      "required": [ "WholeNumberLiteral" ],
+      "properties": {
+        "WholeNumberLiteral": {
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "object",
+              "required": [ "value" ],
+              "properties": {
+                "value": {
+                  "type": "integer"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "FloatLiteral": {
       "description": "Floating-point literal.\nCompact: { \"FloatLiteral\": 3.14 }\nExpanded: { \"FloatLiteral\": { \"value\": 3.14 } }\n",
       "examples": [
@@ -3347,6 +3976,27 @@
               }
             }
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DocumentLiteral": {
+      "description": "Schema-less JSON-like document (decision 0013), typed morphir/SDK:document#document.\nNumber lexemes are preserved; readers must not narrow them to 64-bit floats.\nA DocumentLiteral cannot appear in a LiteralPattern.\n",
+      "examples": [
+        {
+          "DocumentLiteral": {
+            "name": "Alice",
+            "age": 30,
+            "tags": [ "admin", "user" ],
+            "metadata": null
+          }
+        }
+      ],
+      "type": "object",
+      "required": [ "DocumentLiteral" ],
+      "properties": {
+        "DocumentLiteral": {
+          "description": "The document itself: any JSON value, carried verbatim. There is no { value } spelling."
         }
       },
       "additionalProperties": false

--- a/website/static/schemas/morphir-ir-v4.json
+++ b/website/static/schemas/morphir-ir-v4.json
@@ -573,32 +573,99 @@
           }
         }
       ],
-      "allOf": [
+      "anyOf": [
         {
-          "$ref": "#/definitions/AccessControlled"
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [ "Public" ],
+              "properties": {
+                "Public": {
+                  "$ref": "#/definitions/DocumentedTypeDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "Private" ],
+              "properties": {
+                "Private": {
+                  "$ref": "#/definitions/DocumentedTypeDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "public" ],
+              "properties": {
+                "public": {
+                  "$ref": "#/definitions/DocumentedTypeDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "private" ],
+              "properties": {
+                "private": {
+                  "$ref": "#/definitions/DocumentedTypeDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "pub" ],
+              "properties": {
+                "pub": {
+                  "$ref": "#/definitions/DocumentedTypeDefinition"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
         },
         {
           "type": "object",
+          "required": [ "access", "value" ],
           "properties": {
-            "Public": {
-              "$ref": "#/definitions/DocumentedTypeDefinition"
+            "access": {
+              "$ref": "#/definitions/Access"
             },
-            "Private": {
-              "$ref": "#/definitions/DocumentedTypeDefinition"
-            },
-            "public": {
-              "$ref": "#/definitions/DocumentedTypeDefinition"
-            },
-            "private": {
-              "$ref": "#/definitions/DocumentedTypeDefinition"
-            },
-            "pub": {
-              "$ref": "#/definitions/DocumentedTypeDefinition"
+            "doc": {
+              "$ref": "#/definitions/Doc"
             },
             "value": {
               "$ref": "#/definitions/DocumentedTypeDefinition"
             }
-          }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [ "access" ],
+          "minProperties": 2,
+          "properties": {
+            "access": {
+              "$ref": "#/definitions/Access"
+            },
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
+            "TypeAliasDefinition": {
+              "$ref": "#/definitions/TypeAliasDefinitionBody"
+            },
+            "CustomTypeDefinition": {
+              "$ref": "#/definitions/CustomTypeDefinitionBody"
+            },
+            "IncompleteTypeDefinition": {
+              "$ref": "#/definitions/IncompleteTypeDefinitionBody"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -618,32 +685,102 @@
           }
         }
       ],
-      "allOf": [
+      "anyOf": [
         {
-          "$ref": "#/definitions/AccessControlled"
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [ "Public" ],
+              "properties": {
+                "Public": {
+                  "$ref": "#/definitions/DocumentedValueDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "Private" ],
+              "properties": {
+                "Private": {
+                  "$ref": "#/definitions/DocumentedValueDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "public" ],
+              "properties": {
+                "public": {
+                  "$ref": "#/definitions/DocumentedValueDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "private" ],
+              "properties": {
+                "private": {
+                  "$ref": "#/definitions/DocumentedValueDefinition"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [ "pub" ],
+              "properties": {
+                "pub": {
+                  "$ref": "#/definitions/DocumentedValueDefinition"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
         },
         {
           "type": "object",
+          "required": [ "access", "value" ],
           "properties": {
-            "Public": {
-              "$ref": "#/definitions/DocumentedValueDefinition"
+            "access": {
+              "$ref": "#/definitions/Access"
             },
-            "Private": {
-              "$ref": "#/definitions/DocumentedValueDefinition"
-            },
-            "public": {
-              "$ref": "#/definitions/DocumentedValueDefinition"
-            },
-            "private": {
-              "$ref": "#/definitions/DocumentedValueDefinition"
-            },
-            "pub": {
-              "$ref": "#/definitions/DocumentedValueDefinition"
+            "doc": {
+              "$ref": "#/definitions/Doc"
             },
             "value": {
               "$ref": "#/definitions/DocumentedValueDefinition"
             }
-          }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [ "access" ],
+          "minProperties": 2,
+          "properties": {
+            "access": {
+              "$ref": "#/definitions/Access"
+            },
+            "doc": {
+              "$ref": "#/definitions/Doc"
+            },
+            "ExpressionBody": {
+              "$ref": "#/definitions/ExpressionBody"
+            },
+            "NativeBody": {
+              "$ref": "#/definitions/NativeBody"
+            },
+            "ExternalBody": {
+              "$ref": "#/definitions/ExternalBody"
+            },
+            "IncompleteBody": {
+              "$ref": "#/definitions/IncompleteBody"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
@@ -1792,6 +1929,28 @@
         }
       ]
     },
+    "TypeAliasDefinitionBody": {
+      "description": "The payload under a \"TypeAliasDefinition\" key.",
+      "examples": [
+        {
+          "typeParams": [],
+          "typeExp": "morphir/SDK:string#string"
+        }
+      ],
+      "type": "object",
+      "required": [ "typeParams", "typeExp" ],
+      "properties": {
+        "typeParams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Name"
+          }
+        },
+        "typeExp": {
+          "$ref": "#/definitions/Type"
+        }
+      }
+    },
     "TypeAliasDefinition": {
       "description": "Type alias definition (implementation).\nV4 format: { \"TypeAliasDefinition\": { \"typeParams\": [...], \"typeExp\": ... } }\nLegacy format: [\"TypeAliasDefinition\", [...], ...]\n",
       "examples": [
@@ -1806,8 +1965,10 @@
             "typeParams": [],
             "typeExp": {
               "Record": {
-                "name": "morphir/SDK:string#string",
-                "age": "morphir/SDK:basics#int"
+                "fields": {
+                  "name": "morphir/SDK:string#string",
+                  "age": "morphir/SDK:basics#int"
+                }
               }
             }
           }
@@ -1822,19 +1983,7 @@
               "$ref": "#/definitions/Doc"
             },
             "TypeAliasDefinition": {
-              "type": "object",
-              "required": [ "typeParams", "typeExp" ],
-              "properties": {
-                "typeParams": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Name"
-                  }
-                },
-                "typeExp": {
-                  "$ref": "#/definitions/Type"
-                }
-              }
+              "$ref": "#/definitions/TypeAliasDefinitionBody"
             }
           },
           "additionalProperties": false
@@ -1857,6 +2006,38 @@
           ]
         }
       ]
+    },
+    "CustomTypeDefinitionBody": {
+      "description": "The payload under a \"CustomTypeDefinition\" key.",
+      "examples": [
+        {
+          "typeParams": [ "a" ],
+          "access": "Public",
+          "constructors": {
+            "just": [
+              [ "value", "a" ]
+            ],
+            "nothing": []
+          }
+        }
+      ],
+      "type": "object",
+      "required": [ "typeParams", "constructors" ],
+      "properties": {
+        "typeParams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Name"
+          }
+        },
+        "access": {
+          "description": "Visibility of constructors",
+          "enum": [ "Public", "Private" ]
+        },
+        "constructors": {
+          "$ref": "#/definitions/Constructors"
+        }
+      }
     },
     "CustomTypeDefinition": {
       "description": "Custom type definition (sum type implementation).\nV4 format: { \"CustomTypeDefinition\": { \"typeParams\": [...], \"access\": \"Public\", \"constructors\": {...} } }\nLegacy format: [\"CustomTypeDefinition\", [...], { \"access\": ..., \"value\": [...] }]\n",
@@ -1883,23 +2064,7 @@
               "$ref": "#/definitions/Doc"
             },
             "CustomTypeDefinition": {
-              "type": "object",
-              "required": [ "typeParams", "constructors" ],
-              "properties": {
-                "typeParams": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/Name"
-                  }
-                },
-                "access": {
-                  "description": "Visibility of constructors",
-                  "enum": [ "Public", "Private" ]
-                },
-                "constructors": {
-                  "$ref": "#/definitions/Constructors"
-                }
-              }
+              "$ref": "#/definitions/CustomTypeDefinitionBody"
             }
           },
           "additionalProperties": false
@@ -1934,6 +2099,33 @@
         }
       ]
     },
+    "IncompleteTypeDefinitionBody": {
+      "description": "The payload under an \"IncompleteTypeDefinition\" key.",
+      "examples": [
+        {
+          "typeParams": [],
+          "incompleteness": {
+            "Draft": {}
+          }
+        }
+      ],
+      "type": "object",
+      "required": [ "typeParams", "incompleteness" ],
+      "properties": {
+        "typeParams": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Name"
+          }
+        },
+        "incompleteness": {
+          "$ref": "#/definitions/Incompleteness"
+        },
+        "partialTypeExp": {
+          "$ref": "#/definitions/Type"
+        }
+      }
+    },
     "IncompleteTypeDefinition": {
       "description": "Incomplete type definition (V4 feature for best-effort support).\nUsed when a type definition cannot be fully resolved.\n",
       "examples": [
@@ -1959,22 +2151,7 @@
           "$ref": "#/definitions/Doc"
         },
         "IncompleteTypeDefinition": {
-          "type": "object",
-          "required": [ "typeParams", "incompleteness" ],
-          "properties": {
-            "typeParams": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Name"
-              }
-            },
-            "incompleteness": {
-              "$ref": "#/definitions/Incompleteness"
-            },
-            "partialTypeExp": {
-              "$ref": "#/definitions/Type"
-            }
-          }
+          "$ref": "#/definitions/IncompleteTypeDefinitionBody"
         }
       },
       "additionalProperties": false

--- a/website/static/schemas/morphir-ir-v4.json
+++ b/website/static/schemas/morphir-ir-v4.json
@@ -2199,7 +2199,7 @@
       ],
       "oneOf": [
         {
-          "description": "Object mapping constructor names to their argument lists",
+          "description": "Object mapping constructor names to their parameter lists (decision 0007)",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -3837,7 +3837,7 @@
       "additionalProperties": false
     },
     "ExternalBody": {
-      "description": "External definition body (decision 0008): one or more per-target bindings and an\noptional fallback body, so a Gleam-style external with a body encodes faithfully.\nThe single-binding spelling with top-level externalName/targetPlatform is a legacy\nspelling readers accept for one release (decision 0006); it is not valid here.\n",
+      "description": "External definition body (decision 0008): one or more per-target bindings and an\noptional fallback body, so a Gleam-style external with a body encodes faithfully.\nThe single-binding spelling with top-level externalName/targetPlatform is a legacy\nspelling readers accept for one release (decision 0006); it is not valid here.\nA targetPlatform value must be unique within externals; JSON Schema cannot express\nthat constraint, so readers enforce it (decision 0008).\n",
       "examples": [
         {
           "inputTypes": {

--- a/website/static/schemas/morphir-ir-v4.json
+++ b/website/static/schemas/morphir-ir-v4.json
@@ -646,8 +646,18 @@
         },
         {
           "type": "object",
+          "oneOf": [
+            {
+              "required": [ "TypeAliasDefinition" ]
+            },
+            {
+              "required": [ "CustomTypeDefinition" ]
+            },
+            {
+              "required": [ "IncompleteTypeDefinition" ]
+            }
+          ],
           "required": [ "access" ],
-          "minProperties": 2,
           "properties": {
             "access": {
               "$ref": "#/definitions/Access"
@@ -758,8 +768,21 @@
         },
         {
           "type": "object",
+          "oneOf": [
+            {
+              "required": [ "ExpressionBody" ]
+            },
+            {
+              "required": [ "NativeBody" ]
+            },
+            {
+              "required": [ "ExternalBody" ]
+            },
+            {
+              "required": [ "IncompleteBody" ]
+            }
+          ],
           "required": [ "access" ],
-          "minProperties": 2,
           "properties": {
             "access": {
               "$ref": "#/definitions/Access"

--- a/website/static/schemas/morphir-ir-v4.yaml
+++ b/website/static/schemas/morphir-ir-v4.yaml
@@ -10,8 +10,9 @@ description: |
   - Explicit TypeAttributes and ValueAttributes
   - Canonical string formats for names, paths, and FQNames
   - Embedded documentation support
-  - New value expressions (Hole, Native, External)
-  
+  - New value expression (Hole) and definition bodies (NativeBody, ExternalBody, IncompleteBody)
+  - DocumentLiteral, a schema-less JSON-like literal (decision 0013)
+
   See the complete example at: docs/spec/ir/schemas/v4/complete-example.json
 
 type: object
@@ -99,19 +100,10 @@ definitions:
       Module path within a package. Examples: "basics", "list", "domain/users"
     examples: ["basics", "list", "domain/users", "US/FR2052A/data-tables"]
 
-  FileStem:
-    type: string
-    pattern: "^_?[a-z0-9]+(-_?[a-z0-9]+)*(__[0-9a-f]{8})?_?$"
-    description: |
-      Escaped projection of a Name onto the document tree. All lowercase, so it is
-      stable on case-insensitive filesystems. An initialism segment carries a "_"
-      prefix; a stem colliding with a Windows reserved device name carries a "_"
-      suffix.
-
-      A stem truncated for path length carries "__" followed by eight hex digits
-      of the SHA-256 of the untruncated stem. A truncated stem is not reversible,
-      so the module manifest records the mapping from canonical name to stem.
-    examples: ["user", "user-_id", "value-in-_usd", "aux_", "some-extremely-long-canonical__3f9a1c04"]
+  # FileStem is defined authoritatively in morphir-ir-v4-document-tree-files.yaml
+  # (decision 0012). Nothing in this schema references it, so the copy that used to
+  # sit here is gone; a cross-file reference replaces it when the generated schema
+  # of specification step 7.2 lands.
 
   FQNameString:
     type: string
@@ -226,6 +218,14 @@ definitions:
       Encoders should output the canonical form.
     examples: ["Public", "Private", "pub"]
 
+  # Documentation
+  Doc:
+    type: string
+    description: |
+      Documentation text. Decision 0010 places "doc" first, flattened beside the
+      variant it documents, rather than in a nested { "doc", "value" } wrapper.
+    examples: ["The user's display name", "Adds two integers"]
+
   AccessControlled:
     # anyOf rather than oneOf: these are alternative spellings of the same thing,
     # and the flattened form below is deliberately a superset of the legacy
@@ -283,6 +283,115 @@ definitions:
       - { "pub": { "some": "data" } }
       - { "access": "Public", "value": { "some": "data" } }
       - { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } }
+
+  # Documented definitions and specifications
+  #
+  # Decision 0010: "doc" is a flattened member placed first beside the variant it
+  # documents. The nested { "doc", "value" } wrapper is accepted for one release
+  # (decision 0006) and then refused.
+  #
+  DocumentedTypeDefinition:
+    oneOf:
+      - $ref: "#/definitions/TypeDefinition"
+      - type: object
+        required: ["doc", "value"]
+        additionalProperties: false
+        properties:
+          doc: { $ref: "#/definitions/Doc" }
+          value: { $ref: "#/definitions/TypeDefinition" }
+        description: "Nested wrapper, accepted for one release (decision 0010)"
+    description: |
+      A type definition, documented or not.
+      Canonical: { "doc": "...", "TypeAliasDefinition": {...} }
+      Accepted for one release: { "doc": "...", "value": { "TypeAliasDefinition": {...} } }
+    examples:
+      - { "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } }
+      - { "doc": "The user's display name", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } }
+
+  DocumentedValueDefinition:
+    oneOf:
+      - $ref: "#/definitions/ValueDefinition"
+      - type: object
+        required: ["doc", "value"]
+        additionalProperties: false
+        properties:
+          doc: { $ref: "#/definitions/Doc" }
+          value: { $ref: "#/definitions/ValueDefinition" }
+        description: "Nested wrapper, accepted for one release (decision 0010)"
+    description: |
+      A value definition, documented or not.
+      Canonical: { "doc": "...", "ExpressionBody": {...} }
+      Accepted for one release: { "doc": "...", "value": { "ExpressionBody": {...} } }
+
+  DocumentedTypeSpecification:
+    oneOf:
+      - $ref: "#/definitions/TypeSpecification"
+      - type: object
+        required: ["doc", "value"]
+        additionalProperties: false
+        properties:
+          doc: { $ref: "#/definitions/Doc" }
+          value: { $ref: "#/definitions/TypeSpecification" }
+        description: "Nested wrapper, accepted for one release (decision 0010)"
+    description: |
+      A type specification, documented or not.
+      Canonical: { "doc": "...", "OpaqueTypeSpecification": {} }
+
+  DocumentedValueSpecification:
+    oneOf:
+      - $ref: "#/definitions/ValueSpecification"
+      - type: object
+        required: ["doc", "value"]
+        additionalProperties: false
+        properties:
+          doc: { $ref: "#/definitions/Doc" }
+          value: { $ref: "#/definitions/ValueSpecification" }
+        description: "Nested wrapper, accepted for one release (decision 0010)"
+    description: |
+      A value specification, documented or not. Its "doc" is first beside its own
+      members (decision 0010).
+      Canonical: { "doc": "...", "inputs": {...}, "output": ... }
+
+  AccessControlledTypeDefinition:
+    allOf:
+      - $ref: "#/definitions/AccessControlled"
+      # Only the keyed and nested spellings carry the definition as a payload; in
+      # the flattened spelling the variant sits beside "access", so no property
+      # here applies to it.
+      - type: object
+        properties:
+          Public: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          Private: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          public: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          private: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          pub: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          value: { $ref: "#/definitions/DocumentedTypeDefinition" }
+    description: |
+      An access-controlled type definition, the entry shape of ModuleDefinition.types.
+      Canonical: { "Public": { "doc": "...", "TypeAliasDefinition": {...} } }
+      Accepted: { "access": "Public", "TypeAliasDefinition": {...} } and the lowercase
+      and "pub" spellings of the access level.
+    examples:
+      - { "Public": { "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } } }
+      - { "Public": { "doc": "The user's display name", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } } }
+      - { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } }
+
+  AccessControlledValueDefinition:
+    allOf:
+      - $ref: "#/definitions/AccessControlled"
+      - type: object
+        properties:
+          Public: { $ref: "#/definitions/DocumentedValueDefinition" }
+          Private: { $ref: "#/definitions/DocumentedValueDefinition" }
+          public: { $ref: "#/definitions/DocumentedValueDefinition" }
+          private: { $ref: "#/definitions/DocumentedValueDefinition" }
+          pub: { $ref: "#/definitions/DocumentedValueDefinition" }
+          value: { $ref: "#/definitions/DocumentedValueDefinition" }
+    description: |
+      An access-controlled value definition, the entry shape of ModuleDefinition.values.
+      Canonical: { "Public": { "doc": "...", "ExpressionBody": {...} } }
+    examples:
+      - { "access": "Public", "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Literal": { "IntegerLiteral": 42 } } } }
 
   # Packages
   Dependencies:
@@ -461,49 +570,28 @@ definitions:
     properties:
       types:
         type: object
-        additionalProperties:
-          allOf:
-            - $ref: "#/definitions/AccessControlled"
-            - properties:
-                value:
-                  oneOf:
-                    - type: object
-                      required: ["doc", "value"]
-                      properties:
-                        doc: { type: string }
-                        value: { $ref: "#/definitions/TypeDefinition" }
-                    - $ref: "#/definitions/TypeDefinition"
+        additionalProperties: { $ref: "#/definitions/AccessControlledTypeDefinition" }
         description: |
           Dictionary mapping type names to access-controlled type definitions.
           V4 uses object format: { "type-name": { "access": "Public", "TypeAliasDefinition": {...} } }
-          Documentation can be included inline or omitted if None.
           Optional - defaults to empty object if omitted.
       values:
         type: object
-        additionalProperties:
-          allOf:
-            - $ref: "#/definitions/AccessControlled"
-            - properties:
-                value:
-                  oneOf:
-                    - type: object
-                      required: ["doc", "value"]
-                      properties:
-                        doc: { type: string }
-                        value: { $ref: "#/definitions/ValueDefinition" }
-                    - $ref: "#/definitions/ValueDefinition"
+        additionalProperties: { $ref: "#/definitions/AccessControlledValueDefinition" }
         description: |
           Dictionary mapping value names to access-controlled value definitions.
           V4 uses object format: { "value-name": { "access": "Public", "ExpressionBody": {...} } }
-          Documentation can be included inline or omitted if None.
           Optional - defaults to empty object if omitted.
-      doc: { type: string, description: "Optional module-level documentation" }
+      doc: { $ref: "#/definitions/Doc", description: "Optional module-level documentation" }
     description: |
       Full module definition containing all types and values with their implementations.
       Includes both public and private items. Used in PackageDefinition.
       The "types" and "values" fields can be omitted if empty.
+
+      Canonical: "doc" flattened first beside the variant (decision 0010); the nested
+      { "doc", "value" } form is accepted for one release.
     examples:
-      - { "types": { "user": { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } } }, "values": {} }
+      - { "types": { "user": { "Public": { "doc": "The user's display name", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } } } }, "values": {} }
       - { "types": {}, "values": { "calculate": { "access": "Public", "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Literal": { "attributes": {}, "literal": { "IntegerLiteral": 42 } } } } } }, "doc": "Module documentation" }
       - { "values": { "main": { "access": "Public", "ExpressionBody": { "inputTypes": {}, "outputType": { "Unit": {} }, "body": { "Unit": {} } } } } }
 
@@ -516,41 +604,28 @@ definitions:
         description: "Module-level annotations"
       types:
         type: object
-        additionalProperties:
-          oneOf:
-            - type: object
-              required: ["doc", "value"]
-              properties:
-                doc: { type: string }
-                value: { $ref: "#/definitions/TypeSpecification" }
-            - $ref: "#/definitions/TypeSpecification"
+        additionalProperties: { $ref: "#/definitions/DocumentedTypeSpecification" }
         description: |
           Dictionary mapping type names to documented type specifications.
           V4 uses object format: { "type-name": { "TypeAliasSpecification": {...} } }
-          Documentation can be included inline or omitted if None.
           Optional - defaults to empty object if omitted.
       values:
         type: object
-        additionalProperties:
-          oneOf:
-            - type: object
-              required: ["doc", "value"]
-              properties:
-                doc: { type: string }
-                value: { $ref: "#/definitions/ValueSpecification" }
-            - $ref: "#/definitions/ValueSpecification"
+        additionalProperties: { $ref: "#/definitions/DocumentedValueSpecification" }
         description: |
           Dictionary mapping value names to documented value specifications.
           V4 uses object format: { "value-name": { "inputs": {...}, "output": "..." } }
-          Documentation can be included inline or omitted if None.
           Optional - defaults to empty object if omitted.
-      doc: { type: string, description: "Optional module-level documentation" }
+      doc: { $ref: "#/definitions/Doc", description: "Optional module-level documentation" }
     description: |
       Module specification containing only public interfaces (no implementations).
       Used in PackageSpecification and dependencies.
       The "types" and "values" fields can be omitted if empty.
+
+      Canonical: "doc" flattened first beside the variant (decision 0010); the nested
+      { "doc", "value" } form is accepted for one release.
     examples:
-      - { "types": { "int": { "OpaqueTypeSpecification": {} } }, "values": { "add": { "inputs": { "a": "morphir/SDK:basics#int", "b": "morphir/SDK:basics#int" }, "output": "morphir/SDK:basics#int" } } }
+      - { "types": { "int": { "doc": "Arbitrary precision integer", "OpaqueTypeSpecification": {} } }, "values": { "add": { "doc": "Adds two integers", "inputs": { "a": "morphir/SDK:basics#int", "b": "morphir/SDK:basics#int" }, "output": "morphir/SDK:basics#int" } } }
       - { "types": { "int": { "OpaqueTypeSpecification": {} } } }
 
   # Type System
@@ -573,16 +648,34 @@ definitions:
       - $ref: "#/definitions/UnitType"
 
   VariableType:
-    type: string
-    pattern: "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+    oneOf:
+      # Compact: bare name string
+      - type: string
+        pattern: "^[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+        description: |
+          Compact format: bare name string (no ':' or '#').
+          Distinguished from Reference by absence of FQName separators.
+      # Wrapper, with the expanded payload of decision 0005
+      - type: object
+        required: ["Variable"]
+        additionalProperties: false
+        properties:
+          Variable:
+            oneOf:
+              - $ref: "#/definitions/Name"
+              - type: object
+                required: ["name"]
+                additionalProperties: false
+                properties:
+                  attributes: { $ref: "#/definitions/TypeAttributes" }
+                  name: { $ref: "#/definitions/Name" }
     description: |
       Type variable (generic type parameter).
-      V4 compact format: bare name string (no ':' or '#').
-      Distinguished from Reference by absence of FQName separators.
+      Compact: "a"; expanded: {"Variable": {"attributes": {...}, "name": "a"}}
     examples:
       - "a"
       - "comparable"
-      - "number"
+      - { "Variable": { "attributes": {}, "name": "a" } }
 
   ReferenceType:
     oneOf:
@@ -625,13 +718,15 @@ definitions:
           Reference:
             type: object
             required: ["fqname"]
+            additionalProperties: false
             properties:
+              attributes: { $ref: "#/definitions/TypeAttributes" }
               fqname: { $ref: "#/definitions/FQName" }
               args:
                 type: array
                 items: { $ref: "#/definitions/Type" }
             description: |
-              Object with fqname and optional args fields.
+              Object with optional attributes, fqname, and optional args fields.
         description: |
           Expanded wrapper format with explicit fqname and args fields.
     description: |
@@ -680,12 +775,14 @@ definitions:
           Tuple:
             type: object
             required: ["elements"]
+            additionalProperties: false
             properties:
+              attributes: { $ref: "#/definitions/TypeAttributes" }
               elements:
                 type: array
                 items: { $ref: "#/definitions/Type" }
         description: |
-          Expanded wrapper format with explicit elements field.
+          Expanded wrapper format with optional attributes and an explicit elements field.
     description: |
       Tuple type with multiple element types.
 
@@ -706,28 +803,39 @@ definitions:
   RecordType:
     type: object
     required: ["Record"]
+    additionalProperties: false
     properties:
       Record:
         type: object
-        additionalProperties: { $ref: "#/definitions/Type" }
-        description: |
-          Dictionary mapping field names to their types.
-          Field names use kebab-case.
+        required: ["fields"]
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/TypeAttributes" }
+          fields:
+            type: object
+            additionalProperties: { $ref: "#/definitions/Type" }
+            description: "Dictionary mapping field names (kebab-case) to their types."
     description: |
-      Record type with named fields.
-      Format: {"Record": {"field-name": type, ...}}
+      Record type with named fields (decision 0004).
+      Canonical: {"Record": {"fields": {"field-name": type, ...}}}
+      Expanded: {"Record": {"attributes": {...}, "fields": {...}}}
+      The field map directly under "Record" is a legacy spelling readers accept for
+      one release (decision 0006) and report as legacy_spelling; it is not valid here.
     examples:
-      - { "Record": { "name": "morphir/SDK:string#string", "age": "morphir/SDK:int#int" } }
-      - { "Record": { "inflows": "regulation:data-tables#inflows", "outflows": "regulation:data-tables#outflows" } }
+      - { "Record": { "fields": { "name": "morphir/SDK:string#string", "age": "morphir/SDK:basics#int" } } }
+      - { "Record": { "fields": { "inflows": "regulation:data-tables#inflows", "outflows": "regulation:data-tables#outflows" } } }
 
   ExtensibleRecordType:
     type: object
     required: ["ExtensibleRecord"]
+    additionalProperties: false
     properties:
       ExtensibleRecord:
         type: object
         required: ["variable", "fields"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/TypeAttributes" }
           variable: { $ref: "#/definitions/Name" }
           fields:
             type: object
@@ -735,6 +843,7 @@ definitions:
     description: |
       Extensible record type (row polymorphism).
       Format: {"ExtensibleRecord": {"variable": "a", "fields": {...}}}
+      Expanded: {"ExtensibleRecord": {"attributes": {...}, "variable": "a", "fields": {...}}}
     examples:
       - { "ExtensibleRecord": { "variable": "a", "fields": { "name": "morphir/SDK:string#string" } } }
       - { "ExtensibleRecord": { "variable": "r", "fields": { "email": "morphir/SDK:string#string" } } }
@@ -742,30 +851,41 @@ definitions:
   FunctionType:
     type: object
     required: ["Function"]
+    additionalProperties: false
     properties:
       Function:
         type: object
-        required: ["argumentType", "returnType"]
+        required: ["parameterType", "returnType"]
+        additionalProperties: false
         properties:
-          argumentType: { $ref: "#/definitions/Type" }
+          attributes: { $ref: "#/definitions/TypeAttributes" }
+          parameterType: { $ref: "#/definitions/Type" }
           returnType: { $ref: "#/definitions/Type" }
     description: |
-      Function type.
-      Format: {"Function": {"argumentType": ..., "returnType": ...}}
+      Function type. A function declares a parameter and applies an argument (decision 0007).
+      Canonical: {"Function": {"parameterType": ..., "returnType": ...}}
+      Expanded: {"Function": {"attributes": {...}, "parameterType": ..., "returnType": ...}}
+      The older "argumentType" and the "arg"/"result" pair are legacy spellings readers
+      accept for one release (decision 0006); they are not valid here.
     examples:
-      - { "Function": { "argumentType": "morphir/SDK:int#int", "returnType": "morphir/SDK:string#string" } }
+      - { "Function": { "parameterType": "morphir/SDK:basics#int", "returnType": "morphir/SDK:string#string" } }
 
   UnitType:
     type: object
     required: ["Unit"]
+    additionalProperties: false
     properties:
       Unit:
         type: object
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/TypeAttributes" }
     description: |
       Unit type (the type with exactly one value).
-      Format: {"Unit": {}}
+      Compact: {"Unit": {}}; expanded: {"Unit": {"attributes": {...}}}
     examples:
       - { "Unit": {} }
+      - { "Unit": { "attributes": {} } }
 
   Field:
     type: object
@@ -794,6 +914,7 @@ definitions:
         required: ["TypeAliasSpecification"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           TypeAliasSpecification:
             type: object
             required: ["typeParams", "typeExp"]
@@ -827,6 +948,7 @@ definitions:
         required: ["OpaqueTypeSpecification"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           # One schema rather than a oneOf. The previous second branch, an object
           # carrying only "annotations", was a strict subset of this one, so any
           # value matching it matched both and "exactly one" could never hold.
@@ -862,6 +984,7 @@ definitions:
         required: ["CustomTypeSpecification"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           CustomTypeSpecification:
             type: object
             required: ["typeParams", "constructors"]
@@ -894,6 +1017,7 @@ definitions:
         required: ["DerivedTypeSpecification"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           DerivedTypeSpecification:
             type: object
             required: ["typeParams", "baseType", "fromBaseType", "toBaseType"]
@@ -942,6 +1066,7 @@ definitions:
         required: ["TypeAliasDefinition"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           TypeAliasDefinition:
             type: object
             required: ["typeParams", "typeExp"]
@@ -972,6 +1097,7 @@ definitions:
         required: ["CustomTypeDefinition"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           CustomTypeDefinition:
             type: object
             required: ["typeParams", "constructors"]
@@ -1005,6 +1131,7 @@ definitions:
     required: ["IncompleteTypeDefinition"]
     additionalProperties: false
     properties:
+      doc: { $ref: "#/definitions/Doc" }
       IncompleteTypeDefinition:
         type: object
         required: ["typeParams", "incompleteness"]
@@ -1075,7 +1202,7 @@ definitions:
       - type: boolean
         description: "Shorthand for BoolLiteral"
       - type: number
-        description: "Shorthand for IntegerLiteral or FloatLiteral"
+        description: "Shorthand for IntegerLiteral or FloatLiteral, by lexeme (decision 0009)"
       - type: string
         pattern: "^([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*(/([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*)*:([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*(/([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*)*#([a-z0-9]+|[A-Z0-9]+)(-([a-z0-9]+|[A-Z0-9]+))*$"
         description: "Shorthand for Reference (FQName string)"
@@ -1084,7 +1211,7 @@ definitions:
         description: "Shorthand for Variable (Name string)"
       - type: array
         items: { $ref: "#/definitions/Value" }
-        description: "Shorthand for List"
+        description: "Shorthand for List (decision 0009); a Tuple always carries its wrapper"
 
       # Canonical wrapper formats
       - $ref: "#/definitions/LiteralValue"
@@ -1105,10 +1232,12 @@ definitions:
       - $ref: "#/definitions/PatternMatchValue"
       - $ref: "#/definitions/UpdateRecordValue"
       - $ref: "#/definitions/UnitValue"
+      - $ref: "#/definitions/HoleValue"
 
   LiteralValue:
     type: object
     required: ["Literal"]
+    additionalProperties: false
     properties:
       Literal:
         oneOf:
@@ -1121,6 +1250,7 @@ definitions:
           # Expanded with attributes (literal can be typed or direct value)
           - type: object
             required: ["literal"]
+            additionalProperties: false
             properties:
               attributes: { $ref: "#/definitions/ValueAttributes" }
               literal:
@@ -1149,14 +1279,24 @@ definitions:
   ConstructorValue:
     type: object
     required: ["Constructor"]
+    additionalProperties: false
     properties:
-      Constructor: { $ref: "#/definitions/FQName" }
+      Constructor:
+        oneOf:
+          - $ref: "#/definitions/FQName"
+          - type: object
+            required: ["fqname"]
+            additionalProperties: false
+            properties:
+              attributes: { $ref: "#/definitions/ValueAttributes" }
+              fqname: { $ref: "#/definitions/FQName" }
     description: |
       Reference to a custom type constructor.
-      Format: {"Constructor": "package:module#constructor-name"}
+      Compact: {"Constructor": "package:module#constructor-name"}
+      Expanded: {"Constructor": {"attributes": {...}, "fqname": "package:module#constructor-name"}}
     examples:
       - { "Constructor": "morphir/SDK:maybe#just" }
-      - { "Constructor": "morphir/SDK:maybe#nothing" }
+      - { "Constructor": { "attributes": {}, "fqname": "morphir/SDK:maybe#just" } }
 
   TupleValue:
     oneOf:
@@ -1178,12 +1318,14 @@ definitions:
           Tuple:
             type: object
             required: ["elements"]
+            additionalProperties: false
             properties:
+              attributes: { $ref: "#/definitions/ValueAttributes" }
               elements:
                 type: array
                 items: { $ref: "#/definitions/Value" }
         description: |
-          Expanded wrapper format with explicit elements field.
+          Expanded wrapper format with optional attributes and an explicit elements field.
     description: |
       Tuple value with multiple elements.
 
@@ -1192,8 +1334,9 @@ definitions:
       Accepted formats:
       - Wrapper with array: {"Tuple": [value1, value2, ...]}
       - Wrapper with object: {"Tuple": {"elements": [value1, value2, ...]}}
+      - Expanded: {"Tuple": {"attributes": {...}, "elements": [...]}}
 
-      Note: Bare arrays are NOT allowed for values (would be ambiguous with ListValue).
+      A bare array at value position is a List (decision 0009).
 
       Encoders should output canonical form.
     examples:
@@ -1220,12 +1363,14 @@ definitions:
           List:
             type: object
             required: ["items"]
+            additionalProperties: false
             properties:
+              attributes: { $ref: "#/definitions/ValueAttributes" }
               items:
                 type: array
                 items: { $ref: "#/definitions/Value" }
         description: |
-          Expanded wrapper format with explicit items field.
+          Expanded wrapper format with optional attributes and an explicit items field.
     description: |
       List of values.
 
@@ -1234,8 +1379,9 @@ definitions:
       Accepted formats:
       - Wrapper with array: {"List": [value1, value2, ...]}
       - Wrapper with object: {"List": {"items": [value1, value2, ...]}}
+      - Expanded: {"List": {"attributes": {...}, "items": [...]}}
 
-      Note: Bare arrays are NOT allowed for values (would be ambiguous with TupleValue).
+      A bare array at value position is a List (decision 0009).
 
       Encoders should output canonical form.
     examples:
@@ -1245,81 +1391,126 @@ definitions:
   RecordValue:
     type: object
     required: ["Record"]
+    additionalProperties: false
     properties:
       Record:
         type: object
-        additionalProperties: { $ref: "#/definitions/Value" }
+        required: ["fields"]
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
+          fields:
+            type: object
+            additionalProperties: { $ref: "#/definitions/Value" }
+            description: "Dictionary mapping field names (kebab-case) to their values."
     description: |
-      Record value with named fields.
-      Format: {"Record": {"field-name": value, ...}}
-      Field names use kebab-case.
+      Record value with named fields (decision 0004).
+      Canonical: {"Record": {"fields": {"field-name": value, ...}}}
+      Expanded: {"Record": {"attributes": {...}, "fields": {...}}}
+      The field map directly under "Record" is a legacy spelling readers accept for
+      one release (decision 0006) and report as legacy_spelling; it is not valid here.
     examples:
-      - { "Record": { "name": { "Variable": "x" }, "age": { "Literal": { "IntegerLiteral": 25 } } } }
+      - { "Record": { "fields": { "name": { "Variable": "x" }, "age": { "Literal": { "IntegerLiteral": 25 } } } } }
 
   VariableValue:
     type: object
     required: ["Variable"]
+    additionalProperties: false
     properties:
-      Variable: { $ref: "#/definitions/Name" }
+      Variable:
+        oneOf:
+          - $ref: "#/definitions/Name"
+          - type: object
+            required: ["name"]
+            additionalProperties: false
+            properties:
+              attributes: { $ref: "#/definitions/ValueAttributes" }
+              name: { $ref: "#/definitions/Name" }
     description: |
       Reference to a variable in scope.
-      Format: {"Variable": "variable-name"}
+      Compact: {"Variable": "variable-name"}; expanded: {"Variable": {"attributes": {...}, "name": "variable-name"}}
     examples:
       - { "Variable": "x" }
-      - { "Variable": "my-value" }
+      - { "Variable": { "attributes": {}, "name": "x" } }
 
   ReferenceValue:
     type: object
     required: ["Reference"]
+    additionalProperties: false
     properties:
-      Reference: { $ref: "#/definitions/FQName" }
+      Reference:
+        oneOf:
+          - $ref: "#/definitions/FQName"
+          - type: object
+            required: ["fqname"]
+            additionalProperties: false
+            properties:
+              attributes: { $ref: "#/definitions/ValueAttributes" }
+              fqname: { $ref: "#/definitions/FQName" }
     description: |
       Reference to a defined value (function or constant).
-      Format: {"Reference": "package:module#name"}
+      Compact: {"Reference": "package:module#name"}; expanded: {"Reference": {"attributes": {...}, "fqname": "package:module#name"}}
     examples:
       - { "Reference": "morphir/SDK:basics#add" }
-      - { "Reference": "morphir/SDK:list#map" }
+      - { "Reference": { "attributes": {}, "fqname": "morphir/SDK:basics#add" } }
 
   FieldValue:
     type: object
     required: ["Field"]
+    additionalProperties: false
     properties:
       Field:
         type: object
         required: ["target", "name"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           target: { $ref: "#/definitions/Value" }
           name: { $ref: "#/definitions/Name" }
     description: |
       Field access on a record.
       Format: {"Field": {"target": value, "name": "field-name"}}
+      The older "subject" and "fieldName" are legacy spellings readers accept for one
+      release (decision 0006); they are not valid here.
     examples:
       - { "Field": { "target": { "Variable": "record" }, "name": "field-name" } }
 
   FieldFunctionValue:
     type: object
     required: ["FieldFunction"]
+    additionalProperties: false
     properties:
-      FieldFunction: { $ref: "#/definitions/Name" }
+      FieldFunction:
+        oneOf:
+          - $ref: "#/definitions/Name"
+          - type: object
+            required: ["name"]
+            additionalProperties: false
+            properties:
+              attributes: { $ref: "#/definitions/ValueAttributes" }
+              name: { $ref: "#/definitions/Name" }
     description: |
       A function that extracts a field.
-      Format: {"FieldFunction": "field-name"}
+      Compact: {"FieldFunction": "field-name"}; expanded: {"FieldFunction": {"attributes": {...}, "name": "field-name"}}
     examples:
       - { "FieldFunction": "name" }
-      - { "FieldFunction": "age" }
+      - { "FieldFunction": { "attributes": {}, "name": "name" } }
 
   ApplyValue:
     type: object
     required: ["Apply"]
+    additionalProperties: false
     properties:
       Apply:
         type: object
         required: ["function", "argument"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           function: { $ref: "#/definitions/Value" }
           argument: { $ref: "#/definitions/Value" }
     description: |
-      Function application.
+      Function application: an argument is applied to a function (decision 0007).
       Format: {"Apply": {"function": value, "argument": value}}
     examples:
       - { "Apply": { "function": { "Reference": "morphir/SDK:basics#add" }, "argument": { "Literal": { "IntegerLiteral": 1 } } } }
@@ -1327,11 +1518,14 @@ definitions:
   LambdaValue:
     type: object
     required: ["Lambda"]
+    additionalProperties: false
     properties:
       Lambda:
         type: object
         required: ["pattern", "body"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           pattern: { $ref: "#/definitions/Pattern" }
           body: { $ref: "#/definitions/Value" }
     description: |
@@ -1343,28 +1537,36 @@ definitions:
   LetDefinitionValue:
     type: object
     required: ["LetDefinition"]
+    additionalProperties: false
     properties:
       LetDefinition:
         type: object
         required: ["name", "definition", "in"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           name: { $ref: "#/definitions/Name" }
           definition: { $ref: "#/definitions/ValueDefinition" }
           in: { $ref: "#/definitions/Value" }
     description: |
       Let binding introducing a single value.
       Format: {"LetDefinition": {"name": "x", "definition": {...}, "in": value}}
+      The older "valueName", "valueDefinition", and "inValue" are legacy spellings
+      readers accept for one release (decision 0006); they are not valid here.
     examples:
-      - { "LetDefinition": { "name": "x", "definition": { }, "in": { "Variable": "x" } } }
+      - { "LetDefinition": { "name": "x", "definition": { "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Literal": { "IntegerLiteral": 1 } } } }, "in": { "Variable": "x" } } }
 
   LetRecursionValue:
     type: object
     required: ["LetRecursion"]
+    additionalProperties: false
     properties:
       LetRecursion:
         type: object
         required: ["definitions", "in"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           definitions:
             type: object
             additionalProperties: { $ref: "#/definitions/ValueDefinition" }
@@ -1373,16 +1575,19 @@ definitions:
       Mutually recursive let bindings.
       Format: {"LetRecursion": {"definitions": {"f": {...}, "g": {...}}, "in": value}}
     examples:
-      - { "LetRecursion": { "definitions": { "f": { }, "g": { } }, "in": { "Variable": "f" } } }
+      - { "LetRecursion": { "definitions": { "f": { "ExpressionBody": { "inputTypes": {}, "outputType": "morphir/SDK:basics#int", "body": { "Variable": "f" } } } }, "in": { "Variable": "f" } } }
 
   DestructureValue:
     type: object
     required: ["Destructure"]
+    additionalProperties: false
     properties:
       Destructure:
         type: object
         required: ["pattern", "value", "in"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           pattern: { $ref: "#/definitions/Pattern" }
           value: { $ref: "#/definitions/Value" }
           in: { $ref: "#/definitions/Value" }
@@ -1393,32 +1598,41 @@ definitions:
   IfThenElseValue:
     type: object
     required: ["IfThenElse"]
+    additionalProperties: false
     properties:
       IfThenElse:
         type: object
         required: ["condition", "then", "else"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           condition: { $ref: "#/definitions/Value" }
           then: { $ref: "#/definitions/Value" }
           else: { $ref: "#/definitions/Value" }
     description: |
       Conditional expression.
       Format: {"IfThenElse": {"condition": value, "then": value, "else": value}}
+      The older "thenBranch" and "elseBranch" are legacy spellings readers accept for
+      one release (decision 0006); they are not valid here.
 
   PatternMatchValue:
     type: object
     required: ["PatternMatch"]
+    additionalProperties: false
     properties:
       PatternMatch:
         type: object
         required: ["value", "cases"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           value: { $ref: "#/definitions/Value" }
           cases:
             type: array
             items:
               type: object
               required: ["pattern", "body"]
+              additionalProperties: false
               properties:
                 pattern: { $ref: "#/definitions/Pattern" }
                 body: { $ref: "#/definitions/Value" }
@@ -1429,11 +1643,14 @@ definitions:
   UpdateRecordValue:
     type: object
     required: ["UpdateRecord"]
+    additionalProperties: false
     properties:
       UpdateRecord:
         type: object
         required: ["target", "fields"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           target: { $ref: "#/definitions/Value" }
           fields:
             type: object
@@ -1447,14 +1664,43 @@ definitions:
   UnitValue:
     type: object
     required: ["Unit"]
+    additionalProperties: false
     properties:
       Unit:
         type: object
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
     description: |
       The unit value.
-      Format: {"Unit": {}}
+      Compact: {"Unit": {}}; expanded: {"Unit": {"attributes": {...}}}
     examples:
       - { "Unit": {} }
+      - { "Unit": { "attributes": {} } }
+
+  HoleValue:
+    type: object
+    required: ["Hole"]
+    additionalProperties: false
+    properties:
+      Hole:
+        type: object
+        required: ["reason"]
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
+          reason: { $ref: "#/definitions/HoleReason" }
+          expectedType:
+            $ref: "#/definitions/Type"
+            description: "Optional type the missing expression was expected to have"
+    description: |
+      A missing expression (decision 0008). Hole is the only V4-specific value
+      expression: native and external operations are definition bodies (NativeBody,
+      ExternalBody), not expressions, and a reader refuses "Native" or "External" at
+      value position as an unknown node.
+    examples:
+      - { "Hole": { "reason": { "UnresolvedReference": { "target": "my-org/project:module#deleted" } } } }
+      - { "Hole": { "attributes": {}, "reason": { "UnresolvedReference": { "target": "my-org/project:module#deleted" } } } }
 
   # Pattern
   #
@@ -1474,23 +1720,31 @@ definitions:
   WildcardPattern:
     type: object
     required: ["WildcardPattern"]
+    additionalProperties: false
     properties:
       WildcardPattern:
         type: object
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
     description: |
       Wildcard pattern (matches anything).
-      Format: {"WildcardPattern": {}}
+      Compact: {"WildcardPattern": {}}; expanded: {"WildcardPattern": {"attributes": {...}}}
     examples:
       - { "WildcardPattern": {} }
+      - { "WildcardPattern": { "attributes": {} } }
 
   AsPattern:
     type: object
     required: ["AsPattern"]
+    additionalProperties: false
     properties:
       AsPattern:
         type: object
         required: ["pattern", "name"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           pattern: { $ref: "#/definitions/Pattern" }
           name: { $ref: "#/definitions/Name" }
     description: |
@@ -1524,12 +1778,14 @@ definitions:
           TuplePattern:
             type: object
             required: ["patterns"]
+            additionalProperties: false
             properties:
+              attributes: { $ref: "#/definitions/ValueAttributes" }
               patterns:
                 type: array
                 items: { $ref: "#/definitions/Pattern" }
         description: |
-          Expanded wrapper format with explicit patterns field.
+          Expanded wrapper format with optional attributes and an explicit patterns field.
     description: |
       Tuple pattern for destructuring tuples.
 
@@ -1549,11 +1805,14 @@ definitions:
   ConstructorPattern:
     type: object
     required: ["ConstructorPattern"]
+    additionalProperties: false
     properties:
       ConstructorPattern:
         type: object
         required: ["fqname", "patterns"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           fqname: { $ref: "#/definitions/FQName" }
           patterns:
             type: array
@@ -1567,23 +1826,31 @@ definitions:
   EmptyListPattern:
     type: object
     required: ["EmptyListPattern"]
+    additionalProperties: false
     properties:
       EmptyListPattern:
         type: object
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
     description: |
       Pattern matching an empty list.
-      Format: {"EmptyListPattern": {}}
+      Compact: {"EmptyListPattern": {}}; expanded: {"EmptyListPattern": {"attributes": {...}}}
     examples:
       - { "EmptyListPattern": {} }
+      - { "EmptyListPattern": { "attributes": {} } }
 
   HeadTailPattern:
     type: object
     required: ["HeadTailPattern"]
+    additionalProperties: false
     properties:
       HeadTailPattern:
         type: object
         required: ["head", "tail"]
+        additionalProperties: false
         properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
           head: { $ref: "#/definitions/Pattern" }
           tail: { $ref: "#/definitions/Pattern" }
     description: |
@@ -1595,6 +1862,7 @@ definitions:
   LiteralPattern:
     type: object
     required: ["LiteralPattern"]
+    additionalProperties: false
     properties:
       LiteralPattern:
         oneOf:
@@ -1603,10 +1871,18 @@ definitions:
           - type: number
           - type: string
           # Compact with explicit type
-          - $ref: "#/definitions/Literal"
+          - oneOf:
+              - $ref: "#/definitions/BoolLiteral"
+              - $ref: "#/definitions/CharLiteral"
+              - $ref: "#/definitions/StringLiteral"
+              - $ref: "#/definitions/IntegerLiteral"
+              - $ref: "#/definitions/WholeNumberLiteral"
+              - $ref: "#/definitions/FloatLiteral"
+              - $ref: "#/definitions/DecimalLiteral"
           # Expanded with attributes
           - type: object
             required: ["literal"]
+            additionalProperties: false
             properties:
               attributes: { $ref: "#/definitions/ValueAttributes" }
               literal:
@@ -1614,9 +1890,17 @@ definitions:
                   - type: boolean
                   - type: number
                   - type: string
-                  - $ref: "#/definitions/Literal"
+                  - oneOf:
+                      - $ref: "#/definitions/BoolLiteral"
+                      - $ref: "#/definitions/CharLiteral"
+                      - $ref: "#/definitions/StringLiteral"
+                      - $ref: "#/definitions/IntegerLiteral"
+                      - $ref: "#/definitions/WholeNumberLiteral"
+                      - $ref: "#/definitions/FloatLiteral"
+                      - $ref: "#/definitions/DecimalLiteral"
     description: |
-      Pattern matching a literal value. Multiple forms accepted:
+      Pattern matching a literal value. A DocumentLiteral is not a valid pattern
+      (decision 0013). Multiple forms accepted:
 
       - Most compact: { "LiteralPattern": 42 }
       - Compact with type: { "LiteralPattern": { "IntegerLiteral": 42 } }
@@ -1632,14 +1916,19 @@ definitions:
   UnitPattern:
     type: object
     required: ["UnitPattern"]
+    additionalProperties: false
     properties:
       UnitPattern:
         type: object
+        additionalProperties: false
+        properties:
+          attributes: { $ref: "#/definitions/ValueAttributes" }
     description: |
       Pattern matching the unit value.
-      Format: {"UnitPattern": {}}
+      Compact: {"UnitPattern": {}}; expanded: {"UnitPattern": {"attributes": {...}}}
     examples:
       - { "UnitPattern": {} }
+      - { "UnitPattern": { "attributes": {} } }
 
   # Specs & Defs
   ValueSpecification:
@@ -1689,21 +1978,25 @@ definitions:
         required: ["ExpressionBody"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           ExpressionBody: { $ref: "#/definitions/ExpressionBody" }
       - type: object
         required: ["NativeBody"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           NativeBody: { $ref: "#/definitions/NativeBody" }
       - type: object
         required: ["ExternalBody"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           ExternalBody: { $ref: "#/definitions/ExternalBody" }
       - type: object
         required: ["IncompleteBody"]
         additionalProperties: false
         properties:
+          doc: { $ref: "#/definitions/Doc" }
           IncompleteBody: { $ref: "#/definitions/IncompleteBody" }
     description: |
       Value definition body variant. When wrapped in AccessControlled (as in ModuleDefinition.values),
@@ -1747,9 +2040,21 @@ definitions:
     examples:
       - { "inputTypes": { "a": "morphir/SDK:basics#int", "b": "morphir/SDK:basics#int" }, "outputType": "morphir/SDK:basics#int", "nativeInfo": { "hint": { "Arithmetic": {} } } }
 
+  ExternalBinding:
+    type: object
+    required: ["targetPlatform", "externalName"]
+    additionalProperties: false
+    properties:
+      targetPlatform: { type: string, description: "Target platform identifier (e.g. 'javascript', 'erlang', 'wasm')" }
+      externalName: { type: string, description: "Name of the external function on that platform" }
+    description: "One per-target binding of an external definition."
+    examples:
+      - { "targetPlatform": "javascript", "externalName": "console.log" }
+
   ExternalBody:
     type: object
-    required: ["inputTypes", "outputType", "externalName", "targetPlatform"]
+    required: ["inputTypes", "outputType", "externals"]
+    additionalProperties: false
     properties:
       inputTypes:
         type: object
@@ -1758,13 +2063,21 @@ definitions:
           Dictionary mapping input parameter names to their types.
           V4 uses object format: { "param-name": type, ... }
       outputType: { $ref: "#/definitions/Type" }
-      externalName: { type: string, description: "Name of the external function/operation" }
-      targetPlatform: { type: string, description: "Target platform identifier (e.g., 'wasm', 'native')" }
+      externals:
+        type: array
+        minItems: 1
+        items: { $ref: "#/definitions/ExternalBinding" }
+        description: "Per-target bindings; a backend picks the one for its platform"
+      body:
+        $ref: "#/definitions/Value"
+        description: "Optional fallback expression for platforms with no binding"
     description: |
-      External FFI call body (no IR expression).
-      Used for foreign function interface calls to platform-specific code.
+      External definition body (decision 0008): one or more per-target bindings and an
+      optional fallback body, so a Gleam-style external with a body encodes faithfully.
+      The single-binding spelling with top-level externalName/targetPlatform is a legacy
+      spelling readers accept for one release (decision 0006); it is not valid here.
     examples:
-      - { "inputTypes": { "msg": "morphir/SDK:string#string" }, "outputType": "morphir/SDK:basics#unit", "externalName": "console.log", "targetPlatform": "javascript" }
+      - { "inputTypes": { "msg": "morphir/SDK:string#string" }, "outputType": "morphir/SDK:basics#unit", "externals": [{ "targetPlatform": "javascript", "externalName": "console.log" }] }
 
   IncompleteBody:
     type: object
@@ -1800,10 +2113,13 @@ definitions:
       - $ref: "#/definitions/CharLiteral"
       - $ref: "#/definitions/StringLiteral"
       - $ref: "#/definitions/IntegerLiteral"
+      - $ref: "#/definitions/WholeNumberLiteral"
       - $ref: "#/definitions/FloatLiteral"
       - $ref: "#/definitions/DecimalLiteral"
+      - $ref: "#/definitions/DocumentLiteral"
     description: |
-      Literal constant value. V4 uses wrapper object format.
+      Literal constant value. V4 uses wrapper object format, and has seven literals:
+      the six scalar ones and DocumentLiteral (decision 0013).
 
       Two forms are accepted (permissive decoding):
       - Compact (canonical): { "IntegerLiteral": 42 }
@@ -1895,6 +2211,25 @@ definitions:
       - { "IntegerLiteral": -100 }
       - { "IntegerLiteral": 0 }
 
+  WholeNumberLiteral:
+    type: object
+    required: ["WholeNumberLiteral"]
+    additionalProperties: false
+    properties:
+      WholeNumberLiteral:
+        oneOf:
+          - type: integer
+          - type: object
+            required: ["value"]
+            properties:
+              value: { type: integer }
+    description: |
+      The V3 name of IntegerLiteral, accepted on input and never written.
+      Compact: { "WholeNumberLiteral": 42 }
+      Expanded: { "WholeNumberLiteral": { "value": 42 } }
+    examples:
+      - { "WholeNumberLiteral": 42 }
+
   FloatLiteral:
     type: object
     required: ["FloatLiteral"]
@@ -1935,6 +2270,20 @@ definitions:
     examples:
       - { "DecimalLiteral": "123456789.987654321" }
       - { "DecimalLiteral": "0.000000000000000001" }
+
+  DocumentLiteral:
+    type: object
+    required: ["DocumentLiteral"]
+    additionalProperties: false
+    properties:
+      DocumentLiteral:
+        description: "The document itself: any JSON value, carried verbatim. There is no { value } spelling."
+    description: |
+      Schema-less JSON-like document (decision 0013), typed morphir/SDK:document#document.
+      Number lexemes are preserved; readers must not narrow them to 64-bit floats.
+      A DocumentLiteral cannot appear in a LiteralPattern.
+    examples:
+      - { "DocumentLiteral": { "name": "Alice", "age": 30, "tags": ["admin", "user"], "metadata": null } }
 
   # V4-specific: Native and Incomplete Support
   NativeInfo:

--- a/website/static/schemas/morphir-ir-v4.yaml
+++ b/website/static/schemas/morphir-ir-v4.yaml
@@ -1266,7 +1266,7 @@ definitions:
             items:
               - $ref: "#/definitions/Name"
               - $ref: "#/definitions/Type"
-        description: "Object mapping constructor names to their argument lists"
+        description: "Object mapping constructor names to their parameter lists (decision 0007)"
       # Legacy array format
       - type: array
         items:
@@ -2177,6 +2177,8 @@ definitions:
       optional fallback body, so a Gleam-style external with a body encodes faithfully.
       The single-binding spelling with top-level externalName/targetPlatform is a legacy
       spelling readers accept for one release (decision 0006); it is not valid here.
+      A targetPlatform value must be unique within externals; JSON Schema cannot express
+      that constraint, so readers enforce it (decision 0008).
     examples:
       - { "inputTypes": { "msg": "morphir/SDK:string#string" }, "outputType": "morphir/SDK:basics#unit", "externals": [{ "targetPlatform": "javascript", "externalName": "console.log" }] }
 

--- a/website/static/schemas/morphir-ir-v4.yaml
+++ b/website/static/schemas/morphir-ir-v4.yaml
@@ -353,19 +353,55 @@ definitions:
       Canonical: { "doc": "...", "inputs": {...}, "output": ... }
 
   AccessControlledTypeDefinition:
-    allOf:
-      - $ref: "#/definitions/AccessControlled"
-      # Only the keyed and nested spellings carry the definition as a payload; in
-      # the flattened spelling the variant sits beside "access", so no property
-      # here applies to it.
+    # anyOf rather than oneOf: the legacy { access, value } form and the flattened
+    # form share the "access" member, so exactly-one matching cannot hold.
+    anyOf:
+      # Canonical: the access level is the key
+      - oneOf:
+          - type: object
+            required: ["Public"]
+            additionalProperties: false
+            properties:
+              Public: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          - type: object
+            required: ["Private"]
+            additionalProperties: false
+            properties:
+              Private: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          - type: object
+            required: ["public"]
+            additionalProperties: false
+            properties:
+              public: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          - type: object
+            required: ["private"]
+            additionalProperties: false
+            properties:
+              private: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          - type: object
+            required: ["pub"]
+            additionalProperties: false
+            properties:
+              pub: { $ref: "#/definitions/DocumentedTypeDefinition" }
+      # Legacy: access and value members
       - type: object
+        required: ["access", "value"]
+        additionalProperties: false
         properties:
-          Public: { $ref: "#/definitions/DocumentedTypeDefinition" }
-          Private: { $ref: "#/definitions/DocumentedTypeDefinition" }
-          public: { $ref: "#/definitions/DocumentedTypeDefinition" }
-          private: { $ref: "#/definitions/DocumentedTypeDefinition" }
-          pub: { $ref: "#/definitions/DocumentedTypeDefinition" }
+          access: { $ref: "#/definitions/Access" }
+          doc: { $ref: "#/definitions/Doc" }
           value: { $ref: "#/definitions/DocumentedTypeDefinition" }
+      # Flattened: the definition variant sits beside "access"
+      - type: object
+        required: ["access"]
+        minProperties: 2
+        additionalProperties: false
+        properties:
+          access: { $ref: "#/definitions/Access" }
+          doc: { $ref: "#/definitions/Doc" }
+          TypeAliasDefinition: { $ref: "#/definitions/TypeAliasDefinitionBody" }
+          CustomTypeDefinition: { $ref: "#/definitions/CustomTypeDefinitionBody" }
+          IncompleteTypeDefinition: { $ref: "#/definitions/IncompleteTypeDefinitionBody" }
     description: |
       An access-controlled type definition, the entry shape of ModuleDefinition.types.
       Canonical: { "Public": { "doc": "...", "TypeAliasDefinition": {...} } }
@@ -377,16 +413,55 @@ definitions:
       - { "access": "Public", "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } }
 
   AccessControlledValueDefinition:
-    allOf:
-      - $ref: "#/definitions/AccessControlled"
+    # anyOf for the same reason as AccessControlledTypeDefinition.
+    anyOf:
+      # Canonical: the access level is the key
+      - oneOf:
+          - type: object
+            required: ["Public"]
+            additionalProperties: false
+            properties:
+              Public: { $ref: "#/definitions/DocumentedValueDefinition" }
+          - type: object
+            required: ["Private"]
+            additionalProperties: false
+            properties:
+              Private: { $ref: "#/definitions/DocumentedValueDefinition" }
+          - type: object
+            required: ["public"]
+            additionalProperties: false
+            properties:
+              public: { $ref: "#/definitions/DocumentedValueDefinition" }
+          - type: object
+            required: ["private"]
+            additionalProperties: false
+            properties:
+              private: { $ref: "#/definitions/DocumentedValueDefinition" }
+          - type: object
+            required: ["pub"]
+            additionalProperties: false
+            properties:
+              pub: { $ref: "#/definitions/DocumentedValueDefinition" }
+      # Legacy: access and value members
       - type: object
+        required: ["access", "value"]
+        additionalProperties: false
         properties:
-          Public: { $ref: "#/definitions/DocumentedValueDefinition" }
-          Private: { $ref: "#/definitions/DocumentedValueDefinition" }
-          public: { $ref: "#/definitions/DocumentedValueDefinition" }
-          private: { $ref: "#/definitions/DocumentedValueDefinition" }
-          pub: { $ref: "#/definitions/DocumentedValueDefinition" }
+          access: { $ref: "#/definitions/Access" }
+          doc: { $ref: "#/definitions/Doc" }
           value: { $ref: "#/definitions/DocumentedValueDefinition" }
+      # Flattened: the body variant sits beside "access"
+      - type: object
+        required: ["access"]
+        minProperties: 2
+        additionalProperties: false
+        properties:
+          access: { $ref: "#/definitions/Access" }
+          doc: { $ref: "#/definitions/Doc" }
+          ExpressionBody: { $ref: "#/definitions/ExpressionBody" }
+          NativeBody: { $ref: "#/definitions/NativeBody" }
+          ExternalBody: { $ref: "#/definitions/ExternalBody" }
+          IncompleteBody: { $ref: "#/definitions/IncompleteBody" }
     description: |
       An access-controlled value definition, the entry shape of ModuleDefinition.values.
       Canonical: { "Public": { "doc": "...", "ExpressionBody": {...} } }
@@ -634,7 +709,7 @@ definitions:
   # - Variables: bare name string (e.g., "a")
   # - References without args: bare FQName string (e.g., "morphir/SDK:int#int")
   # - References with args: {"Reference": {"fqname": "...", "args": [...]}}
-  # - Records: {"Record": {field-map}}
+  # - Records: {"Record": {"fields": {field-map}}}
   # - Other types: {"TypeName": {...}}
   #
   Type:
@@ -1059,6 +1134,18 @@ definitions:
       - $ref: "#/definitions/CustomTypeDefinition"
       - $ref: "#/definitions/IncompleteTypeDefinition"
 
+  TypeAliasDefinitionBody:
+    type: object
+    required: ["typeParams", "typeExp"]
+    properties:
+      typeParams:
+        type: array
+        items: { $ref: "#/definitions/Name" }
+      typeExp: { $ref: "#/definitions/Type" }
+    description: "The payload under a \"TypeAliasDefinition\" key."
+    examples:
+      - { "typeParams": [], "typeExp": "morphir/SDK:string#string" }
+
   TypeAliasDefinition:
     oneOf:
       # V4 wrapper object format (canonical)
@@ -1067,14 +1154,7 @@ definitions:
         additionalProperties: false
         properties:
           doc: { $ref: "#/definitions/Doc" }
-          TypeAliasDefinition:
-            type: object
-            required: ["typeParams", "typeExp"]
-            properties:
-              typeParams:
-                type: array
-                items: { $ref: "#/definitions/Name" }
-              typeExp: { $ref: "#/definitions/Type" }
+          TypeAliasDefinition: { $ref: "#/definitions/TypeAliasDefinitionBody" }
       # Legacy tagged array format
       - type: array
         items:
@@ -1088,7 +1168,22 @@ definitions:
       Legacy format: ["TypeAliasDefinition", [...], ...]
     examples:
       - { "TypeAliasDefinition": { "typeParams": [], "typeExp": "morphir/SDK:string#string" } }
-      - { "TypeAliasDefinition": { "typeParams": [], "typeExp": { "Record": { "name": "morphir/SDK:string#string", "age": "morphir/SDK:basics#int" } } } }
+      - { "TypeAliasDefinition": { "typeParams": [], "typeExp": { "Record": { "fields": { "name": "morphir/SDK:string#string", "age": "morphir/SDK:basics#int" } } } } }
+
+  CustomTypeDefinitionBody:
+    type: object
+    required: ["typeParams", "constructors"]
+    properties:
+      typeParams:
+        type: array
+        items: { $ref: "#/definitions/Name" }
+      access:
+        enum: ["Public", "Private"]
+        description: "Visibility of constructors"
+      constructors: { $ref: "#/definitions/Constructors" }
+    description: "The payload under a \"CustomTypeDefinition\" key."
+    examples:
+      - { "typeParams": ["a"], "access": "Public", "constructors": { "just": [["value", "a"]], "nothing": [] } }
 
   CustomTypeDefinition:
     oneOf:
@@ -1098,17 +1193,7 @@ definitions:
         additionalProperties: false
         properties:
           doc: { $ref: "#/definitions/Doc" }
-          CustomTypeDefinition:
-            type: object
-            required: ["typeParams", "constructors"]
-            properties:
-              typeParams:
-                type: array
-                items: { $ref: "#/definitions/Name" }
-              access:
-                enum: ["Public", "Private"]
-                description: "Visibility of constructors"
-              constructors: { $ref: "#/definitions/Constructors" }
+          CustomTypeDefinition: { $ref: "#/definitions/CustomTypeDefinitionBody" }
       # Legacy tagged array format
       - type: array
         items:
@@ -1126,21 +1211,26 @@ definitions:
     examples:
       - { "CustomTypeDefinition": { "typeParams": ["a"], "access": "Public", "constructors": { "just": [["value", "a"]], "nothing": [] } } }
 
+  IncompleteTypeDefinitionBody:
+    type: object
+    required: ["typeParams", "incompleteness"]
+    properties:
+      typeParams:
+        type: array
+        items: { $ref: "#/definitions/Name" }
+      incompleteness: { $ref: "#/definitions/Incompleteness" }
+      partialTypeExp: { $ref: "#/definitions/Type" }
+    description: "The payload under an \"IncompleteTypeDefinition\" key."
+    examples:
+      - { "typeParams": [], "incompleteness": { "Draft": {} } }
+
   IncompleteTypeDefinition:
     type: object
     required: ["IncompleteTypeDefinition"]
     additionalProperties: false
     properties:
       doc: { $ref: "#/definitions/Doc" }
-      IncompleteTypeDefinition:
-        type: object
-        required: ["typeParams", "incompleteness"]
-        properties:
-          typeParams:
-            type: array
-            items: { $ref: "#/definitions/Name" }
-          incompleteness: { $ref: "#/definitions/Incompleteness" }
-          partialTypeExp: { $ref: "#/definitions/Type" }
+      IncompleteTypeDefinition: { $ref: "#/definitions/IncompleteTypeDefinitionBody" }
     description: |
       Incomplete type definition (V4 feature for best-effort support).
       Used when a type definition cannot be fully resolved.
@@ -1192,7 +1282,7 @@ definitions:
   # - {"Variable": "name"}
   # - {"Reference": "fqname"}
   # - {"Literal": {...}}
-  # - {"Record": {field-map}}
+  # - {"Record": {"fields": {field-map}}}
   # - {"Apply": {"function": ..., "argument": ...}}
   # etc.
   #

--- a/website/static/schemas/morphir-ir-v4.yaml
+++ b/website/static/schemas/morphir-ir-v4.yaml
@@ -391,10 +391,11 @@ definitions:
           access: { $ref: "#/definitions/Access" }
           doc: { $ref: "#/definitions/Doc" }
           value: { $ref: "#/definitions/DocumentedTypeDefinition" }
-      # Flattened: the definition variant sits beside "access"
+      # Flattened: the definition variant sits beside "access". The oneOf pins
+      # exactly one variant key, so neither a bodiless entry nor two variants at
+      # once validates.
       - type: object
         required: ["access"]
-        minProperties: 2
         additionalProperties: false
         properties:
           access: { $ref: "#/definitions/Access" }
@@ -402,6 +403,10 @@ definitions:
           TypeAliasDefinition: { $ref: "#/definitions/TypeAliasDefinitionBody" }
           CustomTypeDefinition: { $ref: "#/definitions/CustomTypeDefinitionBody" }
           IncompleteTypeDefinition: { $ref: "#/definitions/IncompleteTypeDefinitionBody" }
+        oneOf:
+          - required: ["TypeAliasDefinition"]
+          - required: ["CustomTypeDefinition"]
+          - required: ["IncompleteTypeDefinition"]
     description: |
       An access-controlled type definition, the entry shape of ModuleDefinition.types.
       Canonical: { "Public": { "doc": "...", "TypeAliasDefinition": {...} } }
@@ -450,10 +455,11 @@ definitions:
           access: { $ref: "#/definitions/Access" }
           doc: { $ref: "#/definitions/Doc" }
           value: { $ref: "#/definitions/DocumentedValueDefinition" }
-      # Flattened: the body variant sits beside "access"
+      # Flattened: the body variant sits beside "access". The oneOf pins exactly
+      # one variant key, so neither a bodiless entry nor two variants at once
+      # validates.
       - type: object
         required: ["access"]
-        minProperties: 2
         additionalProperties: false
         properties:
           access: { $ref: "#/definitions/Access" }
@@ -462,6 +468,11 @@ definitions:
           NativeBody: { $ref: "#/definitions/NativeBody" }
           ExternalBody: { $ref: "#/definitions/ExternalBody" }
           IncompleteBody: { $ref: "#/definitions/IncompleteBody" }
+        oneOf:
+          - required: ["ExpressionBody"]
+          - required: ["NativeBody"]
+          - required: ["ExternalBody"]
+          - required: ["IncompleteBody"]
     description: |
       An access-controlled value definition, the entry shape of ModuleDefinition.values.
       Canonical: { "Public": { "doc": "...", "ExpressionBody": {...} } }


### PR DESCRIPTION
## Summary

Implements IR v4 Decision Records 0004 through 0014 across the parent repository, with the matching reference-codec change in finos/morphir-typescript#3, squash-merged as fd92022 on `main` and pinned here. Stacked on `ir-v4-decisions` (#799).

**Decisions implemented**

- 0004 Record `fields`; 0005 attributes-first expanded payloads; 0006 one-release compatibility window with `warning=<code>` fences
- 0007 `parameterType` / constructor `parameters`; 0008 Hole stays, Native/External removed as expressions, `ExternalBody` with unique `targetPlatform`
- 0009 bare arrays are Lists, bare scalars are literals by lexeme, Tuple is wrapped
- 0010 flattened `doc` first, nested `{doc,value}` in the window; 0011 `morphir/SDK` (`deps/morphir/_sdk`)
- 0012 legacy grammar, `FileStem` suffix, required `pathBudget`, `fileNames`; 0013 `DocumentLiteral` verbatim payload; 0014 `$meta` reserved, `session.jsonl` out, books `product-ID`

**What changed**

- `spec/ir/mck/*.md`: kit cases flipped to the decided spellings; legacy spellings moved to `accepted` fences carrying `warning=` (74 cases)
- `website/static/schemas/morphir-ir-v4.yaml` and the document-tree schema: all decisions; generated JSON regenerated
- `tools/validate-mck-fences.ts` + mise task `mck:schema-check`: every accepted kit fence validates against the schema node it names, window fences must fail. Wired into the CI Docs job. Current tally: 140 ok / 9 rejected as expected / 0 failed / 0 skipped
- v4 examples (`website/static/ir/examples/v4`, `spec/ir/mck/documents`), spec pages under `docs/spec`, design pages under `docs/design/draft/ir`, naming fixtures
- kb decision log updated; beads `morphir-ir-v4-stabilize.16` to `.26` created for the follow-ups surfaced in review
- `ecosystem/morphir-typescript` pinned to `main` at fd92022 (the #3 squash commit)

Closes #793.

## Test plan

- [x] `mise run mck:schema-check` (140/9/0/0)
- [x] Kit runner in morphir-typescript: 71 pass / 0 fail; `bun test` 220/0
- [x] `mise run tools:typecheck`, examples validate, Docusaurus build exit 0
- [ ] CI Docs job green on this PR (first run of the new gate in CI)

## Notes for review

finos/morphir-typescript#3 is merged; the submodule pointer resolves to `main`.

